### PR TITLE
feat: add additional supported interfaces

### DIFF
--- a/src/authentication/Credentials.ts
+++ b/src/authentication/Credentials.ts
@@ -1,0 +1,6 @@
+/**
+ * Credentials identifying an entity accessing or owning data.
+ */
+export interface Credentials {
+  webID: string;
+}

--- a/src/authentication/CredentialsExtractor.ts
+++ b/src/authentication/CredentialsExtractor.ts
@@ -1,0 +1,15 @@
+import { Credentials } from './Credentials';
+import { HttpRequest } from '../server/HttpRequest';
+
+/**
+ * Responsible for extracting credentials.
+ */
+export interface CredentialsExtractor {
+  /**
+   * Extracts the credentials found in an HttpRequest.
+   *
+   * @param request - The incoming request.
+   * @returns A promise resolving to the credentials.
+   */
+  extractCredentials: (request: HttpRequest) => Promise<Credentials>;
+}

--- a/src/authorization/Authorizer.ts
+++ b/src/authorization/Authorizer.ts
@@ -1,0 +1,23 @@
+import { Credentials } from '../authentication/Credentials';
+import { PermissionSet } from '../ldp/permissions/PermissionSet';
+import { ResourceIdentifier } from '../ldp/http/ResourceIdentifier';
+
+/**
+ * Responsible for the permission verification.
+ */
+export interface Authorizer {
+  /**
+   * Verifies if the given credentials have access to the given permissions on the given resource.
+   * @param credentials - Credentials of the entity that wants to use the resource.
+   * @param identifier - Identifier of the resource that will be read/modified.
+   * @param permissions - Permissions that are requested on the resource.
+   *
+   * @returns A promise resolving when the Authorizer is finished.
+   * An {@link Error} with the necessary explanation will be thrown when permissions are not granted.
+   */
+  ensurePermissions: (
+    credentials: Credentials,
+    identifier: ResourceIdentifier,
+    permissions: PermissionSet,
+  ) => Promise<void>;
+}

--- a/src/ldp/http/Patch.ts
+++ b/src/ldp/http/Patch.ts
@@ -1,4 +1,6 @@
+import { Representation } from './Representation';
+
 /**
  * Represents the changes needed for a PATCH request.
  */
-export interface Patch {}
+export interface Patch extends Representation {}

--- a/src/ldp/http/RequestParser.ts
+++ b/src/ldp/http/RequestParser.ts
@@ -1,0 +1,8 @@
+import { AsyncHandler } from '../../util/AsyncHandler';
+import { HttpRequest } from '../../server/HttpRequest';
+import { Operation } from '../operations/Operation';
+
+/**
+ * Converts an incoming HttpRequest to an Operation.
+ */
+export type RequestParser = AsyncHandler<HttpRequest, Operation>;

--- a/src/ldp/operations/OperationHandler.ts
+++ b/src/ldp/operations/OperationHandler.ts
@@ -1,21 +1,7 @@
+import { AsyncHandler } from '../../util/AsyncHandler';
 import { Operation } from './Operation';
 
 /**
  * Handler for a specific operation type.
  */
-export interface OperationHandler {
-  /**
-   * Checks if the handler supports the given operation.
-   * @param operation - The input operation.
-   *
-   * @returns A promise resolving to a boolean indicating if this handler supports the operation.
-   */
-  canHandle: (operation: Operation) => Promise<boolean>;
-  /**
-   * Handles the given operation.
-   * @param operation - The input operation.
-   *
-   * @returns A promise resolving when the operation is handled.
-   */
-  handle: (operation: Operation) => Promise<void>;
-}
+export type OperationHandler = AsyncHandler<Operation>;

--- a/src/ldp/permissions/PermissionSet.ts
+++ b/src/ldp/permissions/PermissionSet.ts
@@ -1,0 +1,9 @@
+/**
+ * A data interface indicating which permissions are allowed (based on the context).
+ */
+export interface PermissionSet {
+  read: boolean;
+  append: boolean;
+  write: boolean;
+  delete: boolean;
+}

--- a/src/ldp/permissions/PermissionsExtractor.ts
+++ b/src/ldp/permissions/PermissionsExtractor.ts
@@ -1,0 +1,8 @@
+import { AsyncHandler } from '../../util/AsyncHandler';
+import { Operation } from '../operations/Operation';
+import { PermissionSet } from './PermissionSet';
+
+/**
+ * Verifies which permissions are requested on a given {@link Operation}.
+ */
+export type PermissionsExtractor = AsyncHandler<Operation, PermissionSet>;

--- a/src/server/HttpHandler.ts
+++ b/src/server/HttpHandler.ts
@@ -1,22 +1,8 @@
-import { IncomingMessage, ServerResponse } from 'http';
+import { AsyncHandler } from '../util/AsyncHandler';
+import { HttpRequest } from './HttpRequest';
+import { HttpResponse } from './HttpResponse';
 
 /**
  * An HTTP request handler.
  */
-export interface HttpHandler {
-  /**
-   * Checks whether this handler supports the given request.
-   * @param req - The input request.
-   *
-   * @returns A promise that indicates if this request is supported after resolving.
-   */
-  canHandle: (req: Request) => Promise<boolean>;
-  /**
-   * Handles the given request.
-   * @param req - The input request.
-   * @param res - The response needed for responding to the request.
-   *
-   * @returns A promise resolving when the handling is finished.
-   */
-  handle: (req: IncomingMessage, res: ServerResponse) => Promise<void>;
-}
+export type HttpHandler = AsyncHandler<{ request: HttpRequest; response: HttpResponse }>;

--- a/src/server/HttpRequest.ts
+++ b/src/server/HttpRequest.ts
@@ -1,0 +1,6 @@
+import { IncomingMessage } from 'http';
+
+/**
+ * An incoming HTTP request;
+ */
+export type HttpRequest = IncomingMessage;

--- a/src/server/HttpResponse.ts
+++ b/src/server/HttpResponse.ts
@@ -1,0 +1,6 @@
+import { OutgoingMessage } from 'http';
+
+/**
+ * An outgoing HTTP response;
+ */
+export type HttpResponse = OutgoingMessage;

--- a/src/util/AsyncHandler.ts
+++ b/src/util/AsyncHandler.ts
@@ -1,0 +1,17 @@
+/**
+ * Simple interface for classes that can potentially handle a specific kind of data asynchronously.
+ */
+export interface AsyncHandler<TInput, TOutput = void> {
+  /**
+   * Checks if the input data can be handled by this class.
+   * @param input - Input data that would be handled potentially.
+   * @returns A promise resolving to if this input can be handled.
+   */
+  canHandle: (input: TInput) => Promise<boolean>;
+  /**
+   * Handles the given input. This should only be done if the {@link canHandle} function returned `true`.
+   * @param input - Input data that needs to be handled.
+   * @returns A promise resolving when the handling is finished. Return value depends on the given type.
+   */
+  handle: (input: TInput) => Promise<TOutput>;
+}


### PR DESCRIPTION
This includes the relevant auth headers and a simplification of several others.

The PermissionsExtractor was added after we discovered nothing in the architecture yet covered getting the required permissions from an incoming HttpRequest.

There is no interface yet for the ResponseWriter because I'm not 100% sure yet what the input would be for that yet.