### PR TITLE
fix: Release lock only when stream ends or is abandoned

### DIFF
--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -63,6 +63,8 @@ export class LockingResourceStore implements AtomicResourceStore {
   /**
    * Acquires a lock for the identifier that should return a representation with Readable data and releases it when the
    * Readable is read, closed or results in an error.
+   * When using this function, it is required to close the Readable stream when you are ready.
+   *
    * @param identifier - Identifier that should be locked.
    * @param preferences - Representation preferences.
    * @param conditions - Optional conditions.

--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -32,8 +32,7 @@ export class LockingResourceStore implements AtomicResourceStore {
 
   public async getRepresentation(identifier: ResourceIdentifier, preferences: RepresentationPreferences,
     conditions?: Conditions): Promise<Representation> {
-    return this.lockedRunGet(identifier,
-      async(): Promise<Representation> => this.source.getRepresentation(identifier, preferences, conditions));
+    return this.lockedRunGet(identifier, preferences, conditions);
   }
 
   public async modifyResource(identifier: ResourceIdentifier, patch: Patch, conditions?: Conditions): Promise<void> {
@@ -56,14 +55,14 @@ export class LockingResourceStore implements AtomicResourceStore {
     }
   }
 
-  private async lockedRunGet(identifier: ResourceIdentifier, func: () => Promise<Representation>):
-  Promise<Representation> {
+  private async lockedRunGet(identifier: ResourceIdentifier, preferences: RepresentationPreferences,
+    conditions?: Conditions): Promise<Representation> {
     const lock = await this.locks.acquire(identifier);
 
-    // Execute the function and returns the resulting Representation.
+    // Execute the getRepresentation function and return the resulting Representation.
     let result;
     try {
-      result = await func();
+      result = await this.source.getRepresentation(identifier, preferences, conditions);
       return result;
     } finally {
       // Wait for the end or error event to be called to release the lock if the result contains a valid Readable.

--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -87,10 +87,13 @@ export class LockingResourceStore implements AtomicResourceStore {
       if (!data) {
         await lock.release();
       } else {
+        // When an error occurs, destroy the readable so the lock is released safely.
+        data.on('error', (): void => data.destroy());
+
+        // An `end` and/or `close` event signals that the readable has been consumed.
         new Promise((resolve): void => {
           data.on('end', resolve);
           data.on('close', resolve);
-          data.on('error', resolve);
         }).then((): any => lock.release(), null);
       }
     }

--- a/test/unit/storage/LockingResourceStore.test.ts
+++ b/test/unit/storage/LockingResourceStore.test.ts
@@ -4,7 +4,6 @@ import { Patch } from '../../../src/ldp/http/Patch';
 import { Representation } from '../../../src/ldp/representation/Representation';
 import { ResourceLocker } from '../../../src/storage/ResourceLocker';
 import { ResourceStore } from '../../../src/storage/ResourceStore';
-import { SingleThreadedResourceLocker } from '../../../src/storage/SingleThreadedResourceLocker';
 import streamifyArray from 'streamify-array';
 
 describe('A LockingResourceStore', (): void => {
@@ -162,11 +161,5 @@ describe('A LockingResourceStore', (): void => {
     expect(source.getRepresentation).toHaveBeenCalledTimes(1);
     expect(lock.release).toHaveBeenCalledTimes(1);
     expect(order).toEqual([ 'acquire', 'getRepresentation', 'close', 'release' ]);
-  });
-
-  it('releases the lock without error when called twice.', async(): Promise<void> => {
-    const dummyLock = await new SingleThreadedResourceLocker().acquire({ path: 'dummyIdentifier' });
-    await dummyLock.release();
-    await dummyLock.release();
   });
 });

--- a/test/unit/storage/LockingResourceStore.test.ts
+++ b/test/unit/storage/LockingResourceStore.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events';
 import { Lock } from '../../../src/storage/Lock';
 import { LockingResourceStore } from '../../../src/storage/LockingResourceStore';
 import { Patch } from '../../../src/ldp/http/Patch';
@@ -49,6 +50,15 @@ describe('A LockingResourceStore', (): void => {
     store = new LockingResourceStore(source, locker);
   });
 
+  const registerEventOrder = async(eventSource: EventEmitter, event: string): Promise<void> => {
+    await new Promise((resolve): any => {
+      eventSource.prependListener(event, (): any => {
+        order.push(event);
+        resolve();
+      });
+    });
+  };
+
   it('acquires a lock on the container when adding a representation.', async(): Promise<void> => {
     await store.addResource({ path: 'path' }, {} as Representation);
     expect(locker.acquire).toHaveBeenCalledTimes(1);
@@ -97,69 +107,62 @@ describe('A LockingResourceStore', (): void => {
   });
 
   it('releases the lock on the resource when data has been read.', async(): Promise<void> => {
+    // Read all data from the representation
     const representation = await store.getRepresentation({ path: 'path' }, {});
-    const drainData = new Promise((resolve): any => {
-      representation.data.on('data', (): any => true);
-      representation.data.prependListener('end', (): any => {
-        order.push('end');
+    representation.data.on('data', (): any => true);
+    await registerEventOrder(representation.data, 'end');
 
-        // Close the stream when all the data has been read.
-        representation.data.destroy();
-      });
-      representation.data.prependListener('close', (): any => {
-        order.push('close');
-        resolve();
-      });
-    });
-
-    await drainData;
-
+    // Verify the lock was acquired and released at the right time
     expect(locker.acquire).toHaveBeenCalledTimes(1);
     expect(locker.acquire).toHaveBeenLastCalledWith({ path: 'path' });
     expect(source.getRepresentation).toHaveBeenCalledTimes(1);
-
-    // Both the end and the close event will be invoked.
-    expect(lock.release).toHaveBeenCalledTimes(2);
-    expect(order).toEqual([ 'acquire', 'getRepresentation', 'end', 'release', 'close', 'release' ]);
+    expect(lock.release).toHaveBeenCalledTimes(1);
+    expect(order).toEqual([ 'acquire', 'getRepresentation', 'end', 'release' ]);
   });
 
   it('releases the lock on the resource when readable errors.', async(): Promise<void> => {
+    // Make the representation error
     const representation = await store.getRepresentation({ path: 'path' }, {});
-    const handleError = new Promise((resolve): any => {
-      representation.data.prependListener('error', (): any => {
-        order.push('error');
-        resolve();
-      });
-    });
-
     representation.data.destroy(new Error('Error on the Readable :('));
+    await registerEventOrder(representation.data, 'error');
 
-    await handleError;
+    // Verify the lock was acquired and released at the right time
     expect(locker.acquire).toHaveBeenCalledTimes(1);
     expect(locker.acquire).toHaveBeenLastCalledWith({ path: 'path' });
     expect(source.getRepresentation).toHaveBeenCalledTimes(1);
-
-    // Both the end and the close event will be invoked.
-    expect(lock.release).toHaveBeenCalledTimes(2);
-    expect(order).toEqual([ 'acquire', 'getRepresentation', 'error', 'release', 'release' ]);
+    expect(lock.release).toHaveBeenCalledTimes(1);
+    expect(order).toEqual([ 'acquire', 'getRepresentation', 'error', 'release' ]);
   });
 
   it('releases the lock on the resource when readable is destroyed.', async(): Promise<void> => {
+    // Make the representation close
     const representation = await store.getRepresentation({ path: 'path' }, {});
-    const handleError = new Promise((resolve): any => {
-      representation.data.prependListener('close', (): any => {
-        order.push('close');
-        resolve();
-      });
-    });
-
     representation.data.destroy();
+    await registerEventOrder(representation.data, 'close');
 
-    await handleError;
+    // Verify the lock was acquired and released at the right time
     expect(locker.acquire).toHaveBeenCalledTimes(1);
     expect(locker.acquire).toHaveBeenLastCalledWith({ path: 'path' });
     expect(source.getRepresentation).toHaveBeenCalledTimes(1);
     expect(lock.release).toHaveBeenCalledTimes(1);
     expect(order).toEqual([ 'acquire', 'getRepresentation', 'close', 'release' ]);
+  });
+
+  it('releases the lock only once when multiple events are triggered.', async(): Promise<void> => {
+    // Read all data from the representation and trigger an additional close event
+    const representation = await store.getRepresentation({ path: 'path' }, {});
+    representation.data.on('data', (): any => true);
+    representation.data.prependListener('end', (): any => {
+      order.push('end');
+      representation.data.destroy();
+    });
+    await registerEventOrder(representation.data, 'close');
+
+    // Verify the lock was acquired and released at the right time
+    expect(locker.acquire).toHaveBeenCalledTimes(1);
+    expect(locker.acquire).toHaveBeenLastCalledWith({ path: 'path' });
+    expect(source.getRepresentation).toHaveBeenCalledTimes(1);
+    expect(lock.release).toHaveBeenCalledTimes(1);
+    expect(order).toEqual([ 'acquire', 'getRepresentation', 'end', 'close', 'release' ]);
   });
 });

--- a/test/unit/storage/SingleThreadedResourceLocker.test.ts
+++ b/test/unit/storage/SingleThreadedResourceLocker.test.ts
@@ -65,4 +65,10 @@ describe('A SingleThreadedResourceLocker', (): void => {
     });
     expect(results).toEqual([ 2, 3, 1 ]);
   });
+
+  it('releases the lock without error when called twice.', async(): Promise<void> => {
+    const lock = await locker.acquire({ path: 'path' });
+    await expect(lock.release()).resolves.toBeUndefined();
+    await expect(lock.release()).resolves.toBeUndefined();
+  });
 });

--- a/test/unit/storage/SingleThreadedResourceLocker.test.ts
+++ b/test/unit/storage/SingleThreadedResourceLocker.test.ts
@@ -65,10 +65,4 @@ describe('A SingleThreadedResourceLocker', (): void => {
     });
     expect(results).toEqual([ 2, 3, 1 ]);
   });
-
-  it('releases the lock without error when called twice.', async(): Promise<void> => {
-    const lock = await locker.acquire({ path: 'path' });
-    await expect(lock.release()).resolves.toBeUndefined();
-    await expect(lock.release()).resolves.toBeUndefined();
-  });
 });


### PR DESCRIPTION
Closes #41

It will only release the lock on a getRepresentation when the Readable stream has ended reading data or when an error occurs.
The timeout mechanism has not yet been implemented in this PR.