### PR TITLE
fix: Give SimpleResourceStore root a content-type

### DIFF
--- a/src/storage/SimpleResourceStore.ts
+++ b/src/storage/SimpleResourceStore.ts
@@ -27,7 +27,7 @@ export class SimpleResourceStore implements ResourceStore {
       '': {
         dataType: DATA_TYPE_BINARY,
         data: streamifyArray([]),
-        metadata: { raw: [], profiles: []},
+        metadata: { raw: [], profiles: [], contentType: 'text/turtle' },
       },
     };
   }


### PR DESCRIPTION
We should at some point change this class to be a correct ResourceStore, but for now this at least allows GET requests to root to not fail.