### PR TITLE
Move base normalization to RuntimeConfig

### DIFF
--- a/src/init/RuntimeConfig.ts
+++ b/src/init/RuntimeConfig.ts
@@ -1,3 +1,5 @@
+import { ensureTrailingSlash } from '../util/Util';
+
 /**
  * This class holds all configuration options that can be defined by the user via the command line.
  *
@@ -14,10 +16,13 @@ export class RuntimeConfig implements RuntimeConfigData {
 
   public reset(data: RuntimeConfigData): void {
     this.pport = data.port ?? 3000;
-    this.pbase = data.base ?? `http://localhost:${this.port}/`;
+    this.pbase = ensureTrailingSlash(data.base ?? `http://localhost:${this.port}/`);
     this.prootFilepath = data.rootFilepath ?? process.cwd();
   }
 
+  /**
+   * The returned URL is ensured to have a trailing slash.
+   */
   public get base(): string {
     return this.pbase;
   }

--- a/src/storage/UrlContainerManager.ts
+++ b/src/storage/UrlContainerManager.ts
@@ -15,7 +15,7 @@ export class UrlContainerManager implements ContainerManager {
 
   public async getContainer(id: ResourceIdentifier): Promise<ResourceIdentifier> {
     const path = this.canonicalUrl(id.path);
-    if (this.canonicalUrl(this.runtimeConfig.base) === path) {
+    if (this.runtimeConfig.base === path) {
       throw new Error('Root does not have a container.');
     }
 
@@ -30,6 +30,6 @@ export class UrlContainerManager implements ContainerManager {
   }
 
   private canonicalUrl(path: string): string {
-    return ensureTrailingSlash(new URL(path).toString());
+    return ensureTrailingSlash(path.toString());
   }
 }

--- a/test/unit/init/RuntimeConfig.test.ts
+++ b/test/unit/init/RuntimeConfig.test.ts
@@ -40,4 +40,9 @@ describe('RuntimeConfig', (): void => {
     expect(config.port).toEqual(1234);
     expect(config.base).toEqual('http://example.org/');
   });
+
+  it('ensures trailing slash in base.', async(): Promise<void> => {
+    const config = new RuntimeConfig({ base: 'http://example.org' });
+    expect(config.base).toEqual('http://example.org/');
+  });
 });


### PR DESCRIPTION
Some small cleanup work to normalize `base` in `RuntimeConfig`, and allow variants to be retrieved.