### PR TITLE
Implement a first draft of the RoutingResourceStore

### DIFF
--- a/src/storage/RoutingResourceStore.ts
+++ b/src/storage/RoutingResourceStore.ts
@@ -1,0 +1,45 @@
+import { Patch } from '../ldp/http/Patch';
+import { Representation } from '../ldp/representation/Representation';
+import { RepresentationPreferences } from '../ldp/representation/RepresentationPreferences';
+import { ResourceIdentifier } from '../ldp/representation/ResourceIdentifier';
+import { ResourceRouter } from '../util/ResourceRouter';
+import { Conditions } from './Conditions';
+import { ResourceStore } from './ResourceStore';
+
+/**
+ * Store that calls a specific store based on certain rules defined by the ResourceRouter.
+ */
+export class RoutingResourceStore implements ResourceStore {
+  private readonly resourceRouter: ResourceRouter;
+
+  public constructor(resourceRouter: ResourceRouter) {
+    this.resourceRouter = resourceRouter;
+  }
+
+  public async addResource(container: ResourceIdentifier, representation: Representation,
+    conditions: Conditions | undefined): Promise<ResourceIdentifier> {
+    return this.resourceRouter.findResourceStore(container, representation)
+      .addResource(container, representation, conditions);
+  }
+
+  public async deleteResource(identifier: ResourceIdentifier, conditions: Conditions | undefined): Promise<void> {
+    return this.resourceRouter.findResourceStore(identifier).deleteResource(identifier, conditions);
+  }
+
+  public async getRepresentation(identifier: ResourceIdentifier, preferences: RepresentationPreferences,
+    conditions: Conditions | undefined): Promise<Representation> {
+    return this.resourceRouter.findResourceStore(identifier, undefined, preferences)
+      .getRepresentation(identifier, preferences, conditions);
+  }
+
+  public async modifyResource(identifier: ResourceIdentifier, patch: Patch, conditions: Conditions | undefined):
+  Promise<void> {
+    return this.resourceRouter.findResourceStore(identifier, patch).modifyResource(identifier, patch, conditions);
+  }
+
+  public async setRepresentation(identifier: ResourceIdentifier, representation: Representation,
+    conditions: Conditions | undefined): Promise<void> {
+    return this.resourceRouter.findResourceStore(identifier, representation)
+      .setRepresentation(identifier, representation, conditions);
+  }
+}

--- a/src/util/ResourceRouter.ts
+++ b/src/util/ResourceRouter.ts
@@ -1,0 +1,39 @@
+import { Representation } from '../ldp/representation/Representation';
+import { RepresentationPreferences } from '../ldp/representation/RepresentationPreferences';
+import { ResourceIdentifier } from '../ldp/representation/ResourceIdentifier';
+import { ResourceStore } from '../storage/ResourceStore';
+import { RouterRule } from './rules/RouterRule';
+
+export class ResourceRouter {
+  private readonly rules: RouterRule[];
+
+  /**
+   * @param rules - Rules to be used. First rule has highest priority.
+   */
+  public constructor(rules: RouterRule[]) {
+    this.rules = rules;
+  }
+
+  /**
+   * Find the appropriate ResourceStore to which the request should be routed based on the incoming parameters.
+   * @param identifier - Incoming ResourceIdentifier.
+   * @param representation - Optional incoming Representation.
+   * @param preferences - Optional incoming RepresentationPreferences.
+   *
+   * @throws {@link Error}
+   * If no appropriate ResourceStore could be found.
+   */
+  public findResourceStore(identifier: ResourceIdentifier, representation?: Representation,
+    preferences?: RepresentationPreferences): ResourceStore {
+    let resourceStore: ResourceStore | undefined;
+    let i = 0;
+    while (i < this.rules.length && typeof resourceStore === 'undefined') {
+      resourceStore = this.rules[i].getMatchingResourceStore(identifier, representation, preferences);
+      i += 1;
+    }
+    if (typeof resourceStore === 'undefined') {
+      throw new Error('Cannot find a suitable ResourceStore for the incoming request.');
+    }
+    return resourceStore;
+  }
+}

--- a/src/util/rules/ContentTypeRouterRule.ts
+++ b/src/util/rules/ContentTypeRouterRule.ts
@@ -1,0 +1,36 @@
+import { Representation } from '../../ldp/representation/Representation';
+import { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
+import { ResourceStore } from '../../storage/ResourceStore';
+import { SparqlResourceStore } from '../../storage/SparqlResourceStore';
+import { CONTENT_TYPE_QUADS } from '../ContentTypes';
+import { RouterRule } from './RouterRule';
+
+export class ContentTypeRouterRule implements RouterRule {
+  private readonly sparqlResourceStore: SparqlResourceStore;
+
+  /**
+   * @param sparqlResourceStore - Instance of SparqlResourceStore to use.
+   */
+  public constructor(sparqlResourceStore: SparqlResourceStore) {
+    this.sparqlResourceStore = sparqlResourceStore;
+  }
+
+  /**
+   * Find the appropriate ResourceStore to which the request should be routed based on the incoming parameters.
+   * Looks at the content type to decide.
+   * @param identifier - Incoming ResourceIdentifier.
+   * @param representation - Optional incoming Representation.
+   */
+  public getMatchingResourceStore(identifier: ResourceIdentifier, representation?: Representation):
+  ResourceStore | undefined {
+    if (typeof representation === 'undefined' || typeof representation.metadata.contentType === 'undefined') {
+      return undefined;
+    }
+    switch (representation.metadata.contentType) {
+      case CONTENT_TYPE_QUADS:
+        return this.sparqlResourceStore;
+      default:
+        return undefined;
+    }
+  }
+}

--- a/src/util/rules/DataTypeRouterRule.ts
+++ b/src/util/rules/DataTypeRouterRule.ts
@@ -1,0 +1,42 @@
+import { Representation } from '../../ldp/representation/Representation';
+import { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
+import { FileResourceStore } from '../../storage/FileResourceStore';
+import { ResourceStore } from '../../storage/ResourceStore';
+import { SparqlResourceStore } from '../../storage/SparqlResourceStore';
+import { DATA_TYPE_BINARY, DATA_TYPE_QUAD } from '../ContentTypes';
+import { RouterRule } from './RouterRule';
+
+export class DataTypeRouterRule implements RouterRule {
+  private readonly fileResourceStore: FileResourceStore;
+  private readonly sparqlResourceStore: SparqlResourceStore;
+
+  /**
+   * @param fileResourceStore - Instance of FileResourceStore to use.
+   * @param sparqlResourceStore - Instance of SparqlResourceStore to use.
+   */
+  public constructor(fileResourceStore: FileResourceStore, sparqlResourceStore: SparqlResourceStore) {
+    this.fileResourceStore = fileResourceStore;
+    this.sparqlResourceStore = sparqlResourceStore;
+  }
+
+  /**
+   * Find the appropriate ResourceStore to which the request should be routed based on the incoming parameters.
+   * Looks at the data type to decide.
+   * @param identifier - Incoming ResourceIdentifier.
+   * @param representation - Optional incoming Representation.
+   */
+  public getMatchingResourceStore(identifier: ResourceIdentifier, representation?: Representation):
+  ResourceStore | undefined {
+    if (typeof representation === 'undefined' || typeof representation.dataType === 'undefined') {
+      return undefined;
+    }
+    switch (representation.dataType) {
+      case DATA_TYPE_BINARY:
+        return this.fileResourceStore;
+      case DATA_TYPE_QUAD:
+        return this.sparqlResourceStore;
+      default:
+        return undefined;
+    }
+  }
+}

--- a/src/util/rules/DefaultRouterRule.ts
+++ b/src/util/rules/DefaultRouterRule.ts
@@ -1,0 +1,21 @@
+import { FileResourceStore } from '../../storage/FileResourceStore';
+import { ResourceStore } from '../../storage/ResourceStore';
+import { RouterRule } from './RouterRule';
+
+export class DefaultRouterRule implements RouterRule {
+  private readonly fileResourceStore: FileResourceStore;
+
+  /**
+   * @param fileResourceStore - Instance of FileResourceStore to use.
+   */
+  public constructor(fileResourceStore: FileResourceStore) {
+    this.fileResourceStore = fileResourceStore;
+  }
+
+  /**
+   * Returns the FileResourceStore in all cases.
+   */
+  public getMatchingResourceStore(): ResourceStore | undefined {
+    return this.fileResourceStore;
+  }
+}

--- a/src/util/rules/RouterRule.ts
+++ b/src/util/rules/RouterRule.ts
@@ -1,0 +1,23 @@
+import { Representation } from '../../ldp/representation/Representation';
+import { RepresentationPreferences } from '../../ldp/representation/RepresentationPreferences';
+import { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
+import { ResourceStore } from '../../storage/ResourceStore';
+
+/**
+ * A RouterRule represents a rule that decides which instance of a
+ * ResourceStore should be used to handle the incoming request.
+ */
+export interface RouterRule {
+
+  /**
+   * Find the appropriate ResourceStore to which the request should be routed based on the incoming parameters.
+   * @param identifier - Incoming ResourceIdentifier.
+   * @param representation - Optional incoming Representation.
+   * @param preferences - Optional incoming RepresentationPreferences.
+   */
+  getMatchingResourceStore: (
+    identifier: ResourceIdentifier,
+    representation?: Representation,
+    preferences?: RepresentationPreferences,
+  ) => ResourceStore | undefined;
+}


### PR DESCRIPTION
This implements a first draft of the RoutingResourceStore that I wrote in my remaining time.
A RouterRule decides if it can forward the request to a certain instance of a ResourceStore based on the incoming parameters, if not it will return undefined and ask the same question to the next rule.
If no rule given to the ResourceRouter can decide, an Error is thrown (can be adapted to a specific error).
Some simple rule implementations have already been written, such as a DefaultRouterRule that always returns an instance from the FileResourceStore. But more rules need to be written.
In this implementation an instance of the ResourceStore is given to the RouterRule, this can be changed but was my first logical thought.
No tests were written yet.

This idea was discussed in #59.