### PR TITLE
change: set bin name to community-solid-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   },
   "main": "index.js",
   "license": "MIT",
-  "bin": "bin/server.js",
+  "bin": {
+    "community-solid-server": "bin/server.js"
+  },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",
     "build:ts": "tsc",


### PR DESCRIPTION
Also tested the bin, and everything seems to be working.

We should reserve some time to check and see if this also still works after publishing. Since it works with `npm link` without problems, I don't expect major issues here.

Closes #93