### PR TITLE
lint: enable no-extraneous-dependencies rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,5 +46,6 @@ module.exports = {
       }
     }],
     'unused-imports/no-unused-imports-ts': 'error',
+    'import/no-extraneous-dependencies': 'error'
   },
 };

--- a/src/ldp/representation/RepresentationMetadata.ts
+++ b/src/ldp/representation/RepresentationMetadata.ts
@@ -1,7 +1,7 @@
 /**
  * Contains metadata relevant to a representation.
  */
-import { Quad } from 'rdf-js';
+import type { Quad } from 'rdf-js';
 
 /**
  * Metadata corresponding to a {@link Representation}.

--- a/src/storage/FileResourceStore.ts
+++ b/src/storage/FileResourceStore.ts
@@ -2,7 +2,7 @@ import { createReadStream, createWriteStream, promises as fsPromises, Stats } fr
 import { posix } from 'path';
 import { Readable } from 'stream';
 import { contentType as getContentTypeFromExtension } from 'mime-types';
-import { Quad } from 'rdf-js';
+import type { Quad } from 'rdf-js';
 import streamifyArray from 'streamify-array';
 import { RuntimeConfig } from '../init/RuntimeConfig';
 import { Representation } from '../ldp/representation/Representation';

--- a/src/storage/patch/SparqlUpdatePatchHandler.ts
+++ b/src/storage/patch/SparqlUpdatePatchHandler.ts
@@ -1,7 +1,7 @@
 import { Readable } from 'stream';
 import { defaultGraph } from '@rdfjs/data-model';
 import { Store } from 'n3';
-import { BaseQuad } from 'rdf-js';
+import type { BaseQuad } from 'rdf-js';
 import { someTerms } from 'rdf-terms';
 import { Algebra } from 'sparqlalgebrajs';
 import { SparqlUpdatePatch } from '../../ldp/http/SparqlUpdatePatch';

--- a/src/util/MetadataController.ts
+++ b/src/util/MetadataController.ts
@@ -2,7 +2,7 @@ import { Stats } from 'fs';
 import { Readable } from 'stream';
 import arrayifyStream from 'arrayify-stream';
 import { DataFactory, StreamParser, StreamWriter } from 'n3';
-import { NamedNode, Quad } from 'rdf-js';
+import type { NamedNode, Quad } from 'rdf-js';
 import streamifyArray from 'streamify-array';
 import { TEXT_TURTLE } from '../util/ContentTypes';
 import { LDP, RDF, STAT, TERMS, XML } from './Prefixes';

--- a/test/unit/ldp/http/BasicResponseWriter.test.ts
+++ b/test/unit/ldp/http/BasicResponseWriter.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { createResponse, MockResponse } from 'node-mocks-http';
-import { Quad } from 'rdf-js';
+import type { Quad } from 'rdf-js';
 import streamifyArray from 'streamify-array';
 import { BasicResponseWriter } from '../../../../src/ldp/http/BasicResponseWriter';
 import { ResponseDescription } from '../../../../src/ldp/operations/ResponseDescription';

--- a/test/unit/storage/patch/SparqlUpdatePatchHandler.test.ts
+++ b/test/unit/storage/patch/SparqlUpdatePatchHandler.test.ts
@@ -1,6 +1,6 @@
 import { namedNode, quad } from '@rdfjs/data-model';
 import arrayifyStream from 'arrayify-stream';
-import { Quad } from 'rdf-js';
+import type { Quad } from 'rdf-js';
 import { translate } from 'sparqlalgebrajs';
 import streamifyArray from 'streamify-array';
 import { SparqlUpdatePatch } from '../../../../src/ldp/http/SparqlUpdatePatch';


### PR DESCRIPTION
This also uses the new `import type` syntax for importing rdf-js types,
as it is required for making this new linter rule pass.

Closes #132