### PR TITLE
Implement HEAD request support

### DIFF
--- a/config/presets/ldp/operation-handler.json
+++ b/config/presets/ldp/operation-handler.json
@@ -18,6 +18,12 @@
           }
         },
         {
+          "@type": "HeadOperationHandler",
+          "HeadOperationHandler:_store": {
+            "@id": "urn:solid-server:default:ResourceStore_Patching"
+          }
+        },
+        {
           "@type": "PatchOperationHandler",
           "PatchOperationHandler:_store": {
             "@id": "urn:solid-server:default:ResourceStore_Patching"

--- a/index.ts
+++ b/index.ts
@@ -42,6 +42,7 @@ export * from './src/logging/WinstonLoggerFactory';
 // LDP/Operations
 export * from './src/ldp/operations/DeleteOperationHandler';
 export * from './src/ldp/operations/GetOperationHandler';
+export * from './src/ldp/operations/HeadOperationHandler';
 export * from './src/ldp/operations/Operation';
 export * from './src/ldp/operations/OperationHandler';
 export * from './src/ldp/operations/PatchOperationHandler';

--- a/src/ldp/operations/HeadOperationHandler.ts
+++ b/src/ldp/operations/HeadOperationHandler.ts
@@ -1,0 +1,34 @@
+import { Readable } from 'stream';
+import type { ResourceStore } from '../../storage/ResourceStore';
+import { UnsupportedHttpError } from '../../util/errors/UnsupportedHttpError';
+import type { Operation } from './Operation';
+import { OperationHandler } from './OperationHandler';
+import type { ResponseDescription } from './ResponseDescription';
+
+/**
+ * Handles HEAD {@link Operation}s.
+ * Calls the getRepresentation function from a {@link ResourceStore}.
+ */
+export class HeadOperationHandler extends OperationHandler {
+  private readonly store: ResourceStore;
+
+  public constructor(store: ResourceStore) {
+    super();
+    this.store = store;
+  }
+
+  public async canHandle(input: Operation): Promise<void> {
+    if (input.method !== 'HEAD') {
+      throw new UnsupportedHttpError('This handler only supports HEAD operations.');
+    }
+  }
+
+  public async handle(input: Operation): Promise<ResponseDescription> {
+    const body = await this.store.getRepresentation(input.target, input.preferences);
+
+    // Close the Readable as we will not return it.
+    body.data.destroy();
+    body.data = new Readable();
+    return { identifier: input.target, body };
+  }
+}

--- a/src/ldp/operations/HeadOperationHandler.ts
+++ b/src/ldp/operations/HeadOperationHandler.ts
@@ -27,11 +27,14 @@ export class HeadOperationHandler extends OperationHandler {
     const body = await this.store.getRepresentation(input.target, input.preferences);
 
     // Close the Readable as we will not return it.
-    process.nextTick((): any => body.data.destroy());
-    body.data = new Readable();
-    body.data._read = function(): void {
-      body.data.push(null);
-    };
-    return { identifier: input.target, body };
+    return Promise.resolve()
+      .then((): any => body.data.destroy())
+      .then((): any => {
+        body.data = new Readable();
+        body.data._read = function(): void {
+          body.data.push(null);
+        };
+        return { identifier: input.target, body };
+      });
   }
 }

--- a/src/ldp/operations/HeadOperationHandler.ts
+++ b/src/ldp/operations/HeadOperationHandler.ts
@@ -27,8 +27,11 @@ export class HeadOperationHandler extends OperationHandler {
     const body = await this.store.getRepresentation(input.target, input.preferences);
 
     // Close the Readable as we will not return it.
-    body.data.destroy();
+    process.nextTick((): any => body.data.destroy());
     body.data = new Readable();
+    body.data._read = function(): void {
+      body.data.push(null);
+    };
     return { identifier: input.target, body };
   }
 }

--- a/src/ldp/operations/HeadOperationHandler.ts
+++ b/src/ldp/operations/HeadOperationHandler.ts
@@ -27,14 +27,11 @@ export class HeadOperationHandler extends OperationHandler {
     const body = await this.store.getRepresentation(input.target, input.preferences);
 
     // Close the Readable as we will not return it.
-    return Promise.resolve()
-      .then((): any => body.data.destroy())
-      .then((): any => {
-        body.data = new Readable();
-        body.data._read = function(): void {
-          body.data.push(null);
-        };
-        return { identifier: input.target, body };
-      });
+    body.data.destroy();
+    body.data = new Readable();
+    body.data._read = function(): void {
+      body.data.push(null);
+    };
+    return { identifier: input.target, body };
   }
 }

--- a/test/configs/Util.ts
+++ b/test/configs/Util.ts
@@ -14,6 +14,7 @@ import {
   DeleteOperationHandler,
   FileResourceStore,
   GetOperationHandler,
+  HeadOperationHandler,
   InMemoryResourceStore,
   InteractionController,
   MetadataController,
@@ -94,6 +95,7 @@ export const getPatchingStore = (store: ResourceStore): PatchingStore => {
 export const getOperationHandler = (store: ResourceStore): CompositeAsyncHandler<Operation, ResponseDescription> => {
   const handlers = [
     new GetOperationHandler(store),
+    new HeadOperationHandler(store),
     new PostOperationHandler(store),
     new PutOperationHandler(store),
     new PatchOperationHandler(store),

--- a/test/unit/ldp/operations/HeadOperationHandler.test.ts
+++ b/test/unit/ldp/operations/HeadOperationHandler.test.ts
@@ -23,6 +23,6 @@ describe('A HeadOperationHandler', (): void => {
     const result = await handler.handle({ target: { path: 'url' }} as Operation);
     expect(result.identifier.path).toBe('url');
     expect(result.body?.binary).toBe(false);
-    await expect(arrayifyStream(result.body?.data ?? streamifyArray([]))).resolves.toEqual([]);
+    await expect(arrayifyStream(result.body!.data)).resolves.toEqual([]);
   });
 });

--- a/test/unit/ldp/operations/HeadOperationHandler.test.ts
+++ b/test/unit/ldp/operations/HeadOperationHandler.test.ts
@@ -1,3 +1,4 @@
+import arrayifyStream from 'arrayify-stream';
 import streamifyArray from 'streamify-array';
 import { HeadOperationHandler } from '../../../../src/ldp/operations/HeadOperationHandler';
 import type { Operation } from '../../../../src/ldp/operations/Operation';
@@ -22,6 +23,6 @@ describe('A HeadOperationHandler', (): void => {
     const result = await handler.handle({ target: { path: 'url' }} as Operation);
     expect(result.identifier.path).toBe('url');
     expect(result.body?.binary).toBe(false);
-    expect(result.body?.data._read(64)).toBeUndefined();
+    await expect(arrayifyStream(result.body?.data ?? streamifyArray([]))).resolves.toEqual([]);
   });
 });

--- a/test/unit/ldp/operations/HeadOperationHandler.test.ts
+++ b/test/unit/ldp/operations/HeadOperationHandler.test.ts
@@ -1,4 +1,3 @@
-import { Readable } from 'stream';
 import streamifyArray from 'streamify-array';
 import { HeadOperationHandler } from '../../../../src/ldp/operations/HeadOperationHandler';
 import type { Operation } from '../../../../src/ldp/operations/Operation';
@@ -20,8 +19,9 @@ describe('A HeadOperationHandler', (): void => {
   });
 
   it('returns the representation from the store with the input identifier and empty data.', async(): Promise<void> => {
-    await expect(handler.handle({ target: { path: 'url' }} as Operation)).resolves.toEqual(
-      { identifier: { path: 'url' }, body: { binary: false, data: new Readable() }},
-    );
+    const result = await handler.handle({ target: { path: 'url' }} as Operation);
+    expect(result.identifier.path).toBe('url');
+    expect(result.body?.binary).toBe(false);
+    expect(result.body?.data._read(64)).toBeUndefined();
   });
 });

--- a/test/unit/ldp/operations/HeadOperationHandler.test.ts
+++ b/test/unit/ldp/operations/HeadOperationHandler.test.ts
@@ -1,0 +1,27 @@
+import { Readable } from 'stream';
+import streamifyArray from 'streamify-array';
+import { HeadOperationHandler } from '../../../../src/ldp/operations/HeadOperationHandler';
+import type { Operation } from '../../../../src/ldp/operations/Operation';
+import type { Representation } from '../../../../src/ldp/representation/Representation';
+import type { ResourceStore } from '../../../../src/storage/ResourceStore';
+import { UnsupportedHttpError } from '../../../../src/util/errors/UnsupportedHttpError';
+
+describe('A HeadOperationHandler', (): void => {
+  const store = {
+    getRepresentation: async(): Promise<Representation> => ({ binary: false, data: streamifyArray([ 1, 2, 3 ]) } as
+      Representation),
+  } as unknown as ResourceStore;
+  const handler = new HeadOperationHandler(store);
+
+  it('only supports HEAD operations.', async(): Promise<void> => {
+    await expect(handler.canHandle({ method: 'HEAD' } as Operation)).resolves.toBeUndefined();
+    await expect(handler.canHandle({ method: 'GET' } as Operation)).rejects.toThrow(UnsupportedHttpError);
+    await expect(handler.canHandle({ method: 'POST' } as Operation)).rejects.toThrow(UnsupportedHttpError);
+  });
+
+  it('returns the representation from the store with the input identifier and empty data.', async(): Promise<void> => {
+    await expect(handler.handle({ target: { path: 'url' }} as Operation)).resolves.toEqual(
+      { identifier: { path: 'url' }, body: { binary: false, data: new Readable() }},
+    );
+  });
+});


### PR DESCRIPTION
This closes #85.

~~I have not yet managed to fully cover the code in the `process.nextTick` in `HeadOperationHandler#30`.
An explicit expect to see that it's an empty Readable didn't work either, because jest expects a Readable for some reason, but gets an Object with the same content.~~