### PR TITLE
fix: Retain status codes when combining errors

### DIFF
--- a/src/util/errors/HttpError.ts
+++ b/src/util/errors/HttpError.ts
@@ -1,8 +1,8 @@
 /**
- * An abstract class for all errors that could be thrown by Solid.
+ * A class for all errors that could be thrown by Solid.
  * All errors inheriting from this should fix the status code thereby hiding the HTTP internals from other components.
  */
-export abstract class HttpError extends Error {
+export class HttpError extends Error {
   public statusCode: number;
 
   /**
@@ -11,7 +11,7 @@ export abstract class HttpError extends Error {
    * @param name - Error name. Useful for logging and stack tracing.
    * @param message - Message to be thrown.
    */
-  protected constructor(statusCode: number, name: string, message?: string) {
+  public constructor(statusCode: number, name: string, message?: string) {
     super(message);
     this.statusCode = statusCode;
     this.name = name;

--- a/src/util/errors/InternalServerError.ts
+++ b/src/util/errors/InternalServerError.ts
@@ -1,0 +1,9 @@
+import { HttpError } from './HttpError';
+/**
+ * A generic error message, given when an unexpected condition was encountered and no more specific message is suitable.
+ */
+export class InternalServerError extends HttpError {
+  public constructor(message?: string) {
+    super(500, 'InternalServerError', message);
+  }
+}


### PR DESCRIPTION
Resolves #23 .

This does put some status code logic in the CompositeAsyncHandler but not sure how to do this otherwise since this is quite ingrained.