### PR TITLE
build: Add eslint cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ coverage
 *.js.map
 *.d.ts
 
+.eslintcache
+
 !.eslintrc.js
 !test/eslintrc.js
 !jest.config.js

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build:ts": "tsc",
     "build:components": "componentsjs-generator -s src",
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | coveralls",
-    "lint": "eslint . --ext .ts",
+    "lint": "eslint . --ext .ts --cache",
     "prepare": "npm run build",
     "start": "node ./bin/server.js -p 3000",
     "test": "jest",


### PR DESCRIPTION
Since updating all the eslint dependencies (or just because we have more files, dunno), eslint has really been taking a lot of time for me. This should fix most of that. Doing this as PR because I'm not sure if there are any potential issues with eslint cache any of you are aware of? If not we'll see if this keeps working correctly.