### PR TITLE
feat: Have ExtensionBasedMapper handle extensions correctly

### DIFF
--- a/src/ldp/http/BasicTargetExtractor.ts
+++ b/src/ldp/http/BasicTargetExtractor.ts
@@ -1,6 +1,7 @@
 import type { TLSSocket } from 'tls';
 import { format } from 'url';
 import type { HttpRequest } from '../../server/HttpRequest';
+import { toCanonicalUrl } from '../../util/Util';
 import type { ResourceIdentifier } from '../representation/ResourceIdentifier';
 import { TargetExtractor } from './TargetExtractor';
 
@@ -28,6 +29,6 @@ export class BasicTargetExtractor extends TargetExtractor {
       pathname: input.url,
     });
 
-    return { path: url };
+    return { path: toCanonicalUrl(url) };
   }
 }

--- a/src/storage/ExtensionBasedMapper.ts
+++ b/src/storage/ExtensionBasedMapper.ts
@@ -1,11 +1,13 @@
+import { promises as fsPromises } from 'fs';
 import { posix } from 'path';
-import { types } from 'mime-types';
+import * as mime from 'mime-types';
 import type { ResourceIdentifier } from '../ldp/representation/ResourceIdentifier';
 import { APPLICATION_OCTET_STREAM, TEXT_TURTLE } from '../util/ContentTypes';
 import { ConflictHttpError } from '../util/errors/ConflictHttpError';
 import { NotFoundHttpError } from '../util/errors/NotFoundHttpError';
+import { UnsupportedHttpError } from '../util/errors/UnsupportedHttpError';
 import { trimTrailingSlashes } from '../util/Util';
-import type { FileIdentifierMapper } from './FileIdentifierMapper';
+import type { FileIdentifierMapper, ResourceLink } from './FileIdentifierMapper';
 
 const { join: joinPath, normalize: normalizePath } = posix;
 
@@ -22,52 +24,136 @@ export interface ResourcePath {
   documentName?: string;
 }
 
+/**
+ * A mapper that stores the content-type of resources in the file path extension.
+ * In case the extension of the identifier does not correspond to the correct content-type,
+ * a new extension will be appended (with a `$` in front of it).
+ * E.g. if the path is `input.ttl` with content-type `text/plain`, the path would actually be `input.ttl$.txt`.
+ * This new extension is stripped again when generating an identifier.
+ */
 export class ExtensionBasedMapper implements FileIdentifierMapper {
-  private readonly base: string;
-  private readonly prootFilepath: string;
+  private readonly baseRequestURI: string;
+  private readonly rootFilepath: string;
   private readonly types: Record<string, any>;
 
   public constructor(base: string, rootFilepath: string, overrideTypes = { acl: TEXT_TURTLE, metadata: TEXT_TURTLE }) {
-    this.base = base;
-    this.prootFilepath = rootFilepath;
-    this.types = { ...types, ...overrideTypes };
-  }
-
-  public get baseRequestURI(): string {
-    return trimTrailingSlashes(this.base);
-  }
-
-  public get rootFilepath(): string {
-    return trimTrailingSlashes(this.prootFilepath);
+    this.baseRequestURI = trimTrailingSlashes(base);
+    this.rootFilepath = trimTrailingSlashes(normalizePath(rootFilepath));
+    this.types = { ...mime.types, ...overrideTypes };
   }
 
   /**
-   * Strips the baseRequestURI from the identifier and checks if the stripped base URI matches the store's one.
-   * @param identifier - Incoming identifier.
+   * Maps the given resource identifier / URL to a file path.
+   * Determines the content-type if no content-type was provided.
+   * For containers the content-type input gets ignored.
+   * @param identifier - The input identifier.
+   * @param contentType - The (optional) content-type of the resource.
    *
-   * @throws {@link NotFoundHttpError}
-   * If the identifier does not match the baseRequestURI path of the store.
-   *
-   * @returns Absolute path of the file.
+   * @returns A ResourceLink with all the necessary metadata.
    */
-  public mapUrlToFilePath(identifier: ResourceIdentifier, id = ''): string {
-    return this.getAbsolutePath(this.getRelativePath(identifier), id);
-  }
+  public async mapUrlToFilePath(identifier: ResourceIdentifier, contentType?: string): Promise<ResourceLink> {
+    let path = this.getRelativePath(identifier);
 
-  /**
-   * Strips the rootFilepath path from the filepath and adds the baseRequestURI in front of it.
-   * @param path - The file path.
-   *
-   * @throws {@Link Error}
-   * If the file path does not match the rootFilepath path of the store.
-   *
-   * @returns Url of the file.
-   */
-  public mapFilePathToUrl(path: string): string {
-    if (!path.startsWith(this.rootFilepath)) {
-      throw new Error(`File ${path} is not part of the file storage at ${this.rootFilepath}.`);
+    if (!path.startsWith('/')) {
+      throw new UnsupportedHttpError('URL needs a / after the base.');
     }
-    return this.baseRequestURI + path.slice(this.rootFilepath.length);
+
+    if (path.includes('/..')) {
+      throw new UnsupportedHttpError('Disallowed /.. segment in URL.');
+    }
+
+    path = this.getAbsolutePath(path);
+
+    // Container
+    if (identifier.path.endsWith('/')) {
+      return {
+        identifier,
+        filePath: path,
+      };
+    }
+
+    // Would conflict with how new extensions get stored
+    if (/\$\.\w+$/u.test(path)) {
+      throw new UnsupportedHttpError('Identifiers cannot contain a dollar sign before their extension.');
+    }
+
+    // Existing file
+    if (!contentType) {
+      const [ , folder, documentName ] = /^(.*\/)(.*)$/u.exec(path)!;
+
+      let fileName: string | undefined;
+      try {
+        const files = await fsPromises.readdir(folder);
+        fileName = files.find(
+          (file): boolean =>
+            file.startsWith(documentName) && /^(?:\$\..+)?$/u.test(file.slice(documentName.length)),
+        );
+      } catch {
+        // Parent folder does not exist (or is not a folder)
+        throw new NotFoundHttpError();
+      }
+
+      // File doesn't exist
+      if (!fileName) {
+        throw new NotFoundHttpError();
+      }
+
+      return {
+        identifier,
+        filePath: joinPath(folder, fileName),
+        contentType: this.getContentTypeFromExtension(fileName),
+      };
+    }
+
+    // If the extension of the identifier matches a different content-type than the one that is given,
+    // we need to add a new extension to match the correct type.
+    if (contentType !== this.getContentTypeFromExtension(path)) {
+      const extension = mime.extension(contentType);
+      if (!extension) {
+        throw new UnsupportedHttpError(`Unsupported content-type ${contentType}.`);
+      }
+      path = `${path}$.${extension}`;
+    }
+
+    return {
+      identifier,
+      filePath: path,
+      contentType,
+    };
+  }
+
+  /**
+   * Maps the given file path to an URL and determines the content-type
+   * @param filePath - The input file path.
+   * @param isContainer - If the path corresponds to a file.
+   *
+   * @returns A ResourceLink with all the necessary metadata.
+   */
+  public async mapFilePathToUrl(filePath: string, isContainer: boolean): Promise<ResourceLink> {
+    if (!filePath.startsWith(this.rootFilepath)) {
+      throw new Error(`File ${filePath} is not part of the file storage at ${this.rootFilepath}.`);
+    }
+
+    let relative = filePath.slice(this.rootFilepath.length);
+    if (isContainer) {
+      return {
+        identifier: { path: encodeURI(this.baseRequestURI + relative) },
+        filePath,
+      };
+    }
+
+    // Files
+    const extension = this.getExtension(relative);
+    const contentType = this.getContentTypeFromExtension(relative);
+    if (extension && relative.endsWith(`$.${extension}`)) {
+      relative = relative.slice(0, -(extension.length + 2));
+    }
+
+    return {
+      identifier: { path: encodeURI(this.baseRequestURI + relative) },
+      filePath,
+      contentType,
+    };
   }
 
   /**
@@ -76,9 +162,19 @@ export class ExtensionBasedMapper implements FileIdentifierMapper {
    *
    * @returns Content type of the file.
    */
-  public getContentTypeFromExtension(path: string): string {
+  private getContentTypeFromExtension(path: string): string {
+    const extension = this.getExtension(path);
+    return (extension && this.types[extension.toLowerCase()]) || APPLICATION_OCTET_STREAM;
+  }
+
+  /**
+   * Extracts the extension (without dot) from a path.
+   * Custom functin since `path.extname` does not work on all cases (e.g. ".acl")
+   * @param path - Input path to parse.
+   */
+  private getExtension(path: string): string | null {
     const extension = /\.([^./]+)$/u.exec(path);
-    return (extension && this.types[extension[1].toLowerCase()]) || APPLICATION_OCTET_STREAM;
+    return extension && extension[1];
   }
 
   /**
@@ -88,7 +184,7 @@ export class ExtensionBasedMapper implements FileIdentifierMapper {
    *
    * @returns Absolute path of the file.
    */
-  public getAbsolutePath(path: string, identifier = ''): string {
+  private getAbsolutePath(path: string, identifier = ''): string {
     return joinPath(this.rootFilepath, path, identifier);
   }
 
@@ -105,7 +201,7 @@ export class ExtensionBasedMapper implements FileIdentifierMapper {
     if (!identifier.path.startsWith(this.baseRequestURI)) {
       throw new NotFoundHttpError();
     }
-    return identifier.path.slice(this.baseRequestURI.length);
+    return decodeURI(identifier.path).slice(this.baseRequestURI.length);
   }
 
   /**
@@ -116,7 +212,7 @@ export class ExtensionBasedMapper implements FileIdentifierMapper {
    * @throws {@link ConflictHttpError}
    * If the root identifier is passed.
    *
-   * @returns A ResourcePath object containing path and (optional) slug fields.
+   * @returns A ResourcePath object containing (absolute) path and (optional) slug fields.
    */
   public extractDocumentName(identifier: ResourceIdentifier): ResourcePath {
     const [ , containerPath, documentName ] = /^(.*\/)([^/]+\/?)?$/u.exec(this.getRelativePath(identifier)) ?? [];
@@ -125,9 +221,9 @@ export class ExtensionBasedMapper implements FileIdentifierMapper {
       throw new ConflictHttpError('Container with that identifier already exists (root).');
     }
     return {
-      containerPath: normalizePath(containerPath),
+      containerPath: this.getAbsolutePath(normalizePath(containerPath)),
 
-      // If documentName is not undefined, return normalized documentName
+      // If documentName is defined, return normalized documentName
       documentName: typeof documentName === 'string' ? normalizePath(documentName) : undefined,
     };
   }

--- a/src/storage/FileIdentifierMapper.ts
+++ b/src/storage/FileIdentifierMapper.ts
@@ -1,21 +1,40 @@
 import type { ResourceIdentifier } from '../ldp/representation/ResourceIdentifier';
 
+export interface ResourceLink {
+  /**
+   * Identifier of a resource.
+   */
+  identifier: ResourceIdentifier;
+  /**
+   * File path of a resource.
+   */
+  filePath: string;
+  /**
+   * Content-type for a data resource (not defined for containers).
+   */
+  contentType?: string;
+}
+
 /**
  * Supports mapping a file to an URL and back.
  */
 export interface FileIdentifierMapper {
   /**
-   * Maps the given file path to an URL.
-   * @param file - The input file path.
+   * Maps the given file path to an URL and determines the content-type
+   * @param filePath - The input file path.
+   * @param isContainer - If the path corresponds to a file.
    *
-   * @returns The URL as a string.
+   * @returns A ResourceLink with all the necessary metadata.
    */
-  mapFilePathToUrl: (filePath: string) => string;
+  mapFilePathToUrl: (filePath: string, isContainer: boolean) => Promise<ResourceLink>;
   /**
    * Maps the given resource identifier / URL to a file path.
-   * @param url - The input URL.
+   * Determines the content-type if no content-type was provided.
+   * For containers the content-type input gets ignored.
+   * @param identifier - The input identifier.
+   * @param contentType - The (optional) content-type of the resource.
    *
-   * @returns The file path as a string.
+   * @returns A ResourceLink with all the necessary metadata.
    */
-  mapUrlToFilePath: (identifier: ResourceIdentifier) => string;
+  mapUrlToFilePath: (identifier: ResourceIdentifier, contentType?: string) => Promise<ResourceLink>;
 }

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -66,3 +66,16 @@ export const pipeStreamsAndErrors = <T extends Writable>(readable: Readable, des
   readable.on('error', (error): boolean => destination.emit('error', new UnsupportedHttpError(error.message)));
   return destination;
 };
+
+/**
+ * Converts a URL string to the "canonical" version that should be used internally for consistency.
+ * Decodes all percent encodings and then makes sure only the necessary characters are encoded again.
+ */
+export const toCanonicalUrl = (url: string): string => {
+  const match = /(\w+:\/\/[^/]+\/)(.*)/u.exec(url);
+  if (!match) {
+    throw new UnsupportedHttpError(`Invalid URL ${url}`);
+  }
+  const [ , domain, path ] = match;
+  return encodeURI(domain + path.split('/').map(decodeURIComponent).join('/'));
+};

--- a/test/unit/ldp/http/BasicTargetExtractor.test.ts
+++ b/test/unit/ldp/http/BasicTargetExtractor.test.ts
@@ -16,12 +16,18 @@ describe('A BasicTargetExtractor', (): void => {
   });
 
   it('returns the input URL.', async(): Promise<void> => {
-    await expect(extractor.handle({ url: 'url', headers: { host: 'test.com' }} as any)).resolves.toEqual({ path: 'http://test.com/url' });
+    await expect(extractor.handle({ url: 'url', headers: { host: 'test.com' }} as any))
+      .resolves.toEqual({ path: 'http://test.com/url' });
   });
 
   it('uses https protocol if the connection is secure.', async(): Promise<void> => {
     await expect(extractor.handle(
       { url: 'url', headers: { host: 'test.com' }, connection: { encrypted: true } as any } as any,
     )).resolves.toEqual({ path: 'https://test.com/url' });
+  });
+
+  it('decodes relevant percent encodings.', async(): Promise<void> => {
+    await expect(extractor.handle({ url: '/a%20path%26/name', headers: { host: 'test.com' }} as any))
+      .resolves.toEqual({ path: 'http://test.com/a%20path&/name' });
   });
 });

--- a/test/unit/storage/ExtensionBasedMapper.test.ts
+++ b/test/unit/storage/ExtensionBasedMapper.test.ts
@@ -1,20 +1,157 @@
+import fs from 'fs';
 import { ExtensionBasedMapper } from '../../../src/storage/ExtensionBasedMapper';
+import { ConflictHttpError } from '../../../src/util/errors/ConflictHttpError';
+import { NotFoundHttpError } from '../../../src/util/errors/NotFoundHttpError';
+import { UnsupportedHttpError } from '../../../src/util/errors/UnsupportedHttpError';
+import { trimTrailingSlashes } from '../../../src/util/Util';
+
+jest.mock('fs');
 
 describe('An ExtensionBasedMapper', (): void => {
   const base = 'http://test.com/';
   const rootFilepath = 'uploads/';
-  const resourceMapper = new ExtensionBasedMapper(base, rootFilepath);
+  const mapper = new ExtensionBasedMapper(base, rootFilepath);
+  let fsPromises: { [ id: string ]: jest.Mock };
 
-  it('returns the correct url of a file.', async(): Promise<void> => {
-    let result = resourceMapper.mapFilePathToUrl(`${rootFilepath}test.txt`);
-    expect(result).toEqual(`${base}test.txt`);
-
-    result = resourceMapper.mapFilePathToUrl(`${rootFilepath}image.jpg`);
-    expect(result).toEqual(`${base}image.jpg`);
+  beforeEach(async(): Promise<void> => {
+    jest.clearAllMocks();
+    fs.promises = {
+      readdir: jest.fn(),
+    } as any;
+    fsPromises = fs.promises as any;
   });
 
-  it('errors when filepath does not contain rootFilepath.', async(): Promise<void> => {
-    expect((): string => resourceMapper.mapFilePathToUrl('random/test.txt')).toThrow(Error);
-    expect((): string => resourceMapper.mapFilePathToUrl('test.txt')).toThrow(Error);
+  describe('mapUrlToFilePath', (): void => {
+    it('throws 404 if the input path does not contain the base.', async(): Promise<void> => {
+      await expect(mapper.mapUrlToFilePath({ path: 'invalid' })).rejects.toThrow(NotFoundHttpError);
+    });
+
+    it('throws 404 if the relative path does not start with a slash.', async(): Promise<void> => {
+      await expect(mapper.mapUrlToFilePath({ path: `${trimTrailingSlashes(base)}test` }))
+        .rejects.toThrow(new UnsupportedHttpError('URL needs a / after the base.'));
+    });
+
+    it('throws 400 if the input path contains relative parts.', async(): Promise<void> => {
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test/../test2` }))
+        .rejects.toThrow(new UnsupportedHttpError('Disallowed /.. segment in URL.'));
+    });
+
+    it('returns the corresponding file path for container identifiers.', async(): Promise<void> => {
+      await expect(mapper.mapUrlToFilePath({ path: `${base}container/` })).resolves.toEqual({
+        identifier: { path: `${base}container/` },
+        filePath: `${rootFilepath}container/`,
+      });
+    });
+
+    it('rejects URLs that end with "$.{extension}".', async(): Promise<void> => {
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test$.txt` }))
+        .rejects.toThrow(new UnsupportedHttpError('Identifiers cannot contain a dollar sign before their extension.'));
+    });
+
+    it('throws 404 when looking in a folder that does not exist.', async(): Promise<void> => {
+      fsPromises.readdir.mockImplementation((): void => {
+        throw new Error('does not exist');
+      });
+      await expect(mapper.mapUrlToFilePath({ path: `${base}no/test.txt` })).rejects.toThrow(NotFoundHttpError);
+    });
+
+    it('throws 404 when looking for a file that does not exist.', async(): Promise<void> => {
+      fsPromises.readdir.mockReturnValue([ 'test.ttl' ]);
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` })).rejects.toThrow(NotFoundHttpError);
+    });
+
+    it('determines the content-type based on the extension.', async(): Promise<void> => {
+      fsPromises.readdir.mockReturnValue([ 'test.txt' ]);
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` })).resolves.toEqual({
+        identifier: { path: `${base}test.txt` },
+        filePath: `${rootFilepath}test.txt`,
+        contentType: 'text/plain',
+      });
+    });
+
+    it('matches even if the content-type does not match the extension.', async(): Promise<void> => {
+      fsPromises.readdir.mockReturnValue([ 'test.txt$.ttl' ]);
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` })).resolves.toEqual({
+        identifier: { path: `${base}test.txt` },
+        filePath: `${rootFilepath}test.txt$.ttl`,
+        contentType: 'text/turtle',
+      });
+    });
+
+    it('generates a file path if the content-type was provided.', async(): Promise<void> => {
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` }, 'text/plain')).resolves.toEqual({
+        identifier: { path: `${base}test.txt` },
+        filePath: `${rootFilepath}test.txt`,
+        contentType: 'text/plain',
+      });
+    });
+
+    it('adds an extension if the given extension does not match the given content-type.', async(): Promise<void> => {
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` }, 'text/turtle')).resolves.toEqual({
+        identifier: { path: `${base}test.txt` },
+        filePath: `${rootFilepath}test.txt$.ttl`,
+        contentType: 'text/turtle',
+      });
+    });
+
+    it('throws 400 if the given content-type is not recognized.', async(): Promise<void> => {
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` }, 'fake/data'))
+        .rejects.toThrow(new UnsupportedHttpError(`Unsupported content-type fake/data.`));
+    });
+  });
+
+  describe('mapFilePathToUrl', (): void => {
+    it('throws an error if the input path does not contain the root file path.', async(): Promise<void> => {
+      await expect(mapper.mapFilePathToUrl('invalid', true)).rejects.toThrow(Error);
+    });
+
+    it('returns a generated identifier for directories.', async(): Promise<void> => {
+      await expect(mapper.mapFilePathToUrl(`${rootFilepath}container/`, true)).resolves.toEqual({
+        identifier: { path: `${base}container/` },
+        filePath: `${rootFilepath}container/`,
+      });
+    });
+
+    it('returns a generated identifier for files with corresponding content-type.', async(): Promise<void> => {
+      await expect(mapper.mapFilePathToUrl(`${rootFilepath}test.txt`, false)).resolves.toEqual({
+        identifier: { path: `${base}test.txt` },
+        filePath: `${rootFilepath}test.txt`,
+        contentType: 'text/plain',
+      });
+    });
+
+    it('removes appended extensions.', async(): Promise<void> => {
+      await expect(mapper.mapFilePathToUrl(`${rootFilepath}test.txt$.ttl`, false)).resolves.toEqual({
+        identifier: { path: `${base}test.txt` },
+        filePath: `${rootFilepath}test.txt$.ttl`,
+        contentType: 'text/turtle',
+      });
+    });
+
+    it('sets the content-type to application/octet-stream if there is no extension.', async(): Promise<void> => {
+      await expect(mapper.mapFilePathToUrl(`${rootFilepath}test`, false)).resolves.toEqual({
+        identifier: { path: `${base}test` },
+        filePath: `${rootFilepath}test`,
+        contentType: 'application/octet-stream',
+      });
+    });
+  });
+
+  describe('extractDocumentName', (): void => {
+    it('throws an error if the input corresponds to root.', async(): Promise<void> => {
+      expect((): any => mapper.extractDocumentName({ path: base })).toThrow(ConflictHttpError);
+      expect((): any => mapper.extractDocumentName({ path: trimTrailingSlashes(base) }))
+        .toThrow(ConflictHttpError);
+    });
+
+    it('parses the identifier into container file path and document name.', async(): Promise<void> => {
+      expect(mapper.extractDocumentName({ path: `${base}test` })).toEqual({
+        containerPath: rootFilepath,
+        documentName: 'test',
+      });
+      expect(mapper.extractDocumentName({ path: `${base}test/` })).toEqual({
+        containerPath: `${rootFilepath}test/`,
+      });
+    });
   });
 });

--- a/test/unit/util/Util.test.ts
+++ b/test/unit/util/Util.test.ts
@@ -1,5 +1,6 @@
 import streamifyArray from 'streamify-array';
-import { ensureTrailingSlash, matchingMediaType, readableToString } from '../../../src/util/Util';
+import { UnsupportedHttpError } from '../../../src/util/errors/UnsupportedHttpError';
+import { ensureTrailingSlash, matchingMediaType, readableToString, toCanonicalUrl } from '../../../src/util/Util';
 
 describe('Util function', (): void => {
   describe('ensureTrailingSlash', (): void => {
@@ -29,6 +30,17 @@ describe('Util function', (): void => {
       expect(matchingMediaType('text/*', 'application/*')).toBeFalsy();
       expect(matchingMediaType('text/plain', 'application/*')).toBeFalsy();
       expect(matchingMediaType('text/plain', 'text/turtle')).toBeFalsy();
+    });
+  });
+
+  describe('toCanonicalUrl', (): void => {
+    it('makes sure only the necessary parts are encoded.', async(): Promise<void> => {
+      expect(toCanonicalUrl('http://test.com/a%20path%26/name'))
+        .toEqual('http://test.com/a%20path&/name');
+    });
+
+    it('errors on invalid URLs.', async(): Promise<void> => {
+      expect((): any => toCanonicalUrl('notAnUrl')).toThrow(new UnsupportedHttpError('Invalid URL notAnUrl'));
     });
   });
 });


### PR DESCRIPTION
This resolves #150 and part of #151. 

It does not handle #146 yet. That would require more changes in the file store which is not the focus of this PR (and I don't want to do many changes there until #167 is handled).

Several changes were necessary in the file store and the file store tests (some of the mocks broke since the `fs` calls aren't in the same order anymore), but the main thing to look at is what happens in the `ExtensionBasedMapper`.

It is not fully yet as I would want it. It should only have the 2 public functions from the interface, but some of the other public functions would require more drastic changes to the file store to remove, for which I refer to my comment above.