### PR TITLE
Add a metadata parser

### DIFF
--- a/config/config-default.json
+++ b/config/config-default.json
@@ -5,6 +5,7 @@
     "files-scs:config/presets/http.json",
     "files-scs:config/presets/ldp.json",
     "files-scs:config/presets/ldp/credentials-extractor.json",
+    "files-scs:config/presets/ldp/metadata-handler.json",
     "files-scs:config/presets/ldp/operation-handler.json",
     "files-scs:config/presets/ldp/permissions-extractor.json",
     "files-scs:config/presets/ldp/request-parser.json",

--- a/config/presets/ldp/metadata-handler.json
+++ b/config/presets/ldp/metadata-handler.json
@@ -1,0 +1,20 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "@id": "urn:solid-server:default:MetadataExtractor",
+      "@type": "BasicMetadataExtractor",
+      "BasicMetadataExtractor:_parsers": [
+        {
+          "@type": "ContentTypeParser"
+        },
+        {
+          "@type": "LinkTypeParser"
+        },
+        {
+          "@type": "SlugParser"
+        }
+      ]
+    }
+  ]
+}

--- a/config/presets/ldp/request-parser.json
+++ b/config/presets/ldp/request-parser.json
@@ -10,6 +10,9 @@
       "BasicRequestParser:_preferenceParser": {
         "@type": "AcceptPreferenceParser"
       },
+      "BasicRequestParser:_metadataExtractor": {
+        "@id": "urn:solid-server:default:MetadataExtractor"
+      },
       "BasicRequestParser:_bodyParser": {
         "@type": "CompositeAsyncHandler",
         "CompositeAsyncHandler:_handlers": [

--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,14 @@ export * from './src/authorization/WebAclAuthorizer';
 export * from './src/init/CliRunner';
 export * from './src/init/Setup';
 
+// LDP/HTTP/Metadata
+export * from './src/ldp/http/metadata/BasicMetadataExtractor';
+export * from './src/ldp/http/metadata/ContentTypeParser';
+export * from './src/ldp/http/metadata/LinkTypeParser';
+export * from './src/ldp/http/metadata/MetadataExtractor';
+export * from './src/ldp/http/metadata/MetadataParser';
+export * from './src/ldp/http/metadata/SlugParser';
+
 // LDP/HTTP
 export * from './src/ldp/http/AcceptPreferenceParser';
 export * from './src/ldp/http/BasicRequestParser';

--- a/index.ts
+++ b/index.ts
@@ -108,7 +108,7 @@ export * from './src/util/errors/UnsupportedHttpError';
 export * from './src/util/errors/UnsupportedMediaTypeHttpError';
 
 // Util
-export * from './src/util/AcceptParser';
+export * from './src/util/HeaderUtil';
 export * from './src/util/AsyncHandler';
 export * from './src/util/CompositeAsyncHandler';
 export * from './src/util/InteractionController';

--- a/src/ldp/http/AcceptPreferenceParser.ts
+++ b/src/ldp/http/AcceptPreferenceParser.ts
@@ -1,11 +1,11 @@
 import type { HttpRequest } from '../../server/HttpRequest';
-import type { AcceptHeader } from '../../util/AcceptParser';
+import type { AcceptHeader } from '../../util/HeaderUtil';
 import {
   parseAccept,
   parseAcceptCharset,
   parseAcceptEncoding,
   parseAcceptLanguage,
-} from '../../util/AcceptParser';
+} from '../../util/HeaderUtil';
 import type { RepresentationPreference } from '../representation/RepresentationPreference';
 import type { RepresentationPreferences } from '../representation/RepresentationPreferences';
 import { PreferenceParser } from './PreferenceParser';

--- a/src/ldp/http/BasicRequestParser.ts
+++ b/src/ldp/http/BasicRequestParser.ts
@@ -1,6 +1,7 @@
 import type { HttpRequest } from '../../server/HttpRequest';
 import type { Operation } from '../operations/Operation';
 import type { BodyParser } from './BodyParser';
+import type { MetadataExtractor } from './metadata/MetadataExtractor';
 import type { PreferenceParser } from './PreferenceParser';
 import { RequestParser } from './RequestParser';
 import type { TargetExtractor } from './TargetExtractor';
@@ -11,16 +12,18 @@ import type { TargetExtractor } from './TargetExtractor';
 export interface SimpleRequestParserArgs {
   targetExtractor: TargetExtractor;
   preferenceParser: PreferenceParser;
+  metadataExtractor: MetadataExtractor;
   bodyParser: BodyParser;
 }
 
 /**
  * Creates an {@link Operation} from an incoming {@link HttpRequest} by aggregating the results
- * of a {@link TargetExtractor}, {@link PreferenceParser}, and {@link BodyParser}.
+ * of a {@link TargetExtractor}, {@link PreferenceParser}, {@link MetadataExtractor}, and {@link BodyParser}.
  */
 export class BasicRequestParser extends RequestParser {
   private readonly targetExtractor!: TargetExtractor;
   private readonly preferenceParser!: PreferenceParser;
+  private readonly metadataExtractor!: MetadataExtractor;
   private readonly bodyParser!: BodyParser;
 
   public constructor(args: SimpleRequestParserArgs) {
@@ -38,7 +41,8 @@ export class BasicRequestParser extends RequestParser {
     }
     const target = await this.targetExtractor.handleSafe(input);
     const preferences = await this.preferenceParser.handleSafe(input);
-    const body = await this.bodyParser.handleSafe(input);
+    const metadata = await this.metadataExtractor.handleSafe(input);
+    const body = await this.bodyParser.handleSafe({ request: input, metadata });
 
     return { method: input.method, target, preferences, body };
   }

--- a/src/ldp/http/BodyParser.ts
+++ b/src/ldp/http/BodyParser.ts
@@ -1,8 +1,22 @@
 import type { HttpRequest } from '../../server/HttpRequest';
 import { AsyncHandler } from '../../util/AsyncHandler';
 import type { Representation } from '../representation/Representation';
+import type { RepresentationMetadata } from '../representation/RepresentationMetadata';
+
+export interface BodyParserArgs {
+  /**
+   * Request that contains the (potential) body.
+   */
+  request: HttpRequest;
+  /**
+   * Metadata that has already been parsed from the request.
+   * Can be updated by the BodyParser with extra metadata.
+   */
+  metadata: RepresentationMetadata;
+}
 
 /**
  * Parses the body of an incoming {@link HttpRequest} and converts it to a {@link Representation}.
  */
-export abstract class BodyParser extends AsyncHandler<HttpRequest, Representation | undefined> {}
+export abstract class BodyParser extends
+  AsyncHandler<BodyParserArgs, Representation | undefined> {}

--- a/src/ldp/http/RawBodyParser.ts
+++ b/src/ldp/http/RawBodyParser.ts
@@ -1,14 +1,10 @@
-import type { HttpRequest } from '../../server/HttpRequest';
 import { UnsupportedHttpError } from '../../util/errors/UnsupportedHttpError';
-import { CONTENT_TYPE, HTTP, RDF } from '../../util/UriConstants';
 import type { Representation } from '../representation/Representation';
-import { RepresentationMetadata } from '../representation/RepresentationMetadata';
+import type { BodyParserArgs } from './BodyParser';
 import { BodyParser } from './BodyParser';
 
 /**
  * Converts incoming {@link HttpRequest} to a Representation without any further parsing.
- * Naively parses the mediatype from the content-type header.
- * Some other metadata is also generated, but this should probably be done in an external handler.
  */
 export class RawBodyParser extends BodyParser {
   public async canHandle(): Promise<void> {
@@ -17,56 +13,23 @@ export class RawBodyParser extends BodyParser {
 
   // Note that the only reason this is a union is in case the body is empty.
   // If this check gets moved away from the BodyParsers this union could be removed
-  public async handle(input: HttpRequest): Promise<Representation | undefined> {
+  public async handle({ request, metadata }: BodyParserArgs): Promise<Representation | undefined> {
     // RFC7230, §3.3: The presence of a message body in a request
     // is signaled by a Content-Length or Transfer-Encoding header field.
-    if (!input.headers['content-length'] && !input.headers['transfer-encoding']) {
+    if (!request.headers['content-length'] && !request.headers['transfer-encoding']) {
       return;
     }
 
     // While RFC7231 allows treating a body without content type as an octet stream,
     // such an omission likely signals a mistake, so force clients to make this explicit.
-    if (!input.headers['content-type']) {
+    if (!request.headers['content-type']) {
       throw new UnsupportedHttpError('An HTTP request body was passed without Content-Type header');
     }
 
     return {
       binary: true,
-      data: input,
-      metadata: this.parseMetadata(input),
+      data: request,
+      metadata,
     };
-  }
-
-  private parseMetadata(input: HttpRequest): RepresentationMetadata {
-    const contentType = /^[^;]*/u.exec(input.headers['content-type']!)![0];
-
-    const metadata = new RepresentationMetadata({ [CONTENT_TYPE]: contentType });
-
-    const { link, slug } = input.headers;
-
-    if (slug) {
-      if (Array.isArray(slug)) {
-        throw new UnsupportedHttpError('At most 1 slug header is allowed.');
-      }
-      metadata.set(HTTP.slug, slug);
-    }
-
-    // There are similarities here to Accept header parsing so that library should become more generic probably
-    if (link) {
-      const linkArray = Array.isArray(link) ? link : [ link ];
-      const parsedLinks = linkArray.map((entry): { url: string; rel: string } => {
-        const [ , url, rest ] = /^<([^>]*)>(.*)$/u.exec(entry) ?? [];
-        const [ , rel ] = /^ *; *rel="(.*)"$/u.exec(rest) ?? [];
-        return { url, rel };
-      });
-      for (const entry of parsedLinks) {
-        if (entry.rel === 'type') {
-          metadata.set(RDF.type, entry.url);
-          break;
-        }
-      }
-    }
-
-    return metadata;
   }
 }

--- a/src/ldp/http/SparqlUpdateBodyParser.ts
+++ b/src/ldp/http/SparqlUpdateBodyParser.ts
@@ -1,53 +1,50 @@
 import { PassThrough } from 'stream';
+import type { Algebra } from 'sparqlalgebrajs';
 import { translate } from 'sparqlalgebrajs';
-import type { HttpRequest } from '../../server/HttpRequest';
 import { APPLICATION_SPARQL_UPDATE } from '../../util/ContentTypes';
 import { UnsupportedHttpError } from '../../util/errors/UnsupportedHttpError';
 import { UnsupportedMediaTypeHttpError } from '../../util/errors/UnsupportedMediaTypeHttpError';
-import { CONTENT_TYPE } from '../../util/UriConstants';
-import { readableToString } from '../../util/Util';
-import { RepresentationMetadata } from '../representation/RepresentationMetadata';
+import { pipeStreamsAndErrors, readableToString } from '../../util/Util';
+import type { BodyParserArgs } from './BodyParser';
 import { BodyParser } from './BodyParser';
 import type { SparqlUpdatePatch } from './SparqlUpdatePatch';
 
 /**
  * {@link BodyParser} that supports `application/sparql-update` content.
  * Will convert the incoming update string to algebra in a {@link SparqlUpdatePatch}.
- * Still needs access to a handler for parsing metadata.
  */
 export class SparqlUpdateBodyParser extends BodyParser {
-  public async canHandle(input: HttpRequest): Promise<void> {
-    if (input.headers['content-type'] !== APPLICATION_SPARQL_UPDATE) {
+  public async canHandle({ request }: BodyParserArgs): Promise<void> {
+    if (request.headers['content-type'] !== APPLICATION_SPARQL_UPDATE) {
       throw new UnsupportedMediaTypeHttpError('This parser only supports SPARQL UPDATE data.');
     }
   }
 
-  public async handle(input: HttpRequest): Promise<SparqlUpdatePatch> {
+  public async handle({ request, metadata }: BodyParserArgs): Promise<SparqlUpdatePatch> {
+    // Note that readableObjectMode is only defined starting from Node 12
+    // It is impossible to check if object mode is enabled in Node 10 (without accessing private variables)
+    const options = { objectMode: request.readableObjectMode };
+    const toAlgebraStream = new PassThrough(options);
+    const dataCopy = new PassThrough(options);
+    pipeStreamsAndErrors(request, toAlgebraStream);
+    pipeStreamsAndErrors(request, dataCopy);
+    let algebra: Algebra.Operation;
     try {
-      // Note that readableObjectMode is only defined starting from Node 12
-      // It is impossible to check if object mode is enabled in Node 10 (without accessing private variables)
-      const options = { objectMode: input.readableObjectMode };
-      const toAlgebraStream = new PassThrough(options);
-      const dataCopy = new PassThrough(options);
-      input.pipe(toAlgebraStream);
-      input.pipe(dataCopy);
       const sparql = await readableToString(toAlgebraStream);
-      const algebra = translate(sparql, { quads: true });
-
-      const metadata = new RepresentationMetadata({ [CONTENT_TYPE]: APPLICATION_SPARQL_UPDATE });
-
-      // Prevent body from being requested again
-      return {
-        algebra,
-        binary: true,
-        data: dataCopy,
-        metadata,
-      };
+      algebra = translate(sparql, { quads: true });
     } catch (error: unknown) {
       if (error instanceof Error) {
         throw new UnsupportedHttpError(error.message);
       }
       throw new UnsupportedHttpError();
     }
+
+    // Prevent body from being requested again
+    return {
+      algebra,
+      binary: true,
+      data: dataCopy,
+      metadata,
+    };
   }
 }

--- a/src/ldp/http/metadata/BasicMetadataExtractor.ts
+++ b/src/ldp/http/metadata/BasicMetadataExtractor.ts
@@ -1,0 +1,29 @@
+import type { HttpRequest } from '../../../server/HttpRequest';
+import { RepresentationMetadata } from '../../representation/RepresentationMetadata';
+import { MetadataExtractor } from './MetadataExtractor';
+import type { MetadataParser } from './MetadataParser';
+
+/**
+ * MetadataExtractor that lets each of its MetadataParsers add metadata based on the HttpRequest.
+ */
+export class BasicMetadataExtractor extends MetadataExtractor {
+  private readonly parsers: MetadataParser[];
+
+  public constructor(parsers: MetadataParser[]) {
+    super();
+    this.parsers = parsers;
+  }
+
+  public async canHandle(): Promise<void> {
+    // Can handle all requests
+  }
+
+  public async handle(request: HttpRequest):
+  Promise<RepresentationMetadata> {
+    const metadata = new RepresentationMetadata();
+    for (const parser of this.parsers) {
+      await parser.parse(request, metadata);
+    }
+    return metadata;
+  }
+}

--- a/src/ldp/http/metadata/ContentTypeParser.ts
+++ b/src/ldp/http/metadata/ContentTypeParser.ts
@@ -1,0 +1,17 @@
+import type { HttpRequest } from '../../../server/HttpRequest';
+import type { RepresentationMetadata } from '../../representation/RepresentationMetadata';
+import type { MetadataParser } from './MetadataParser';
+
+/**
+ * Parser for the `content-type` header.
+ * Currently only stores the media type and ignores other parameters such as charset.
+ */
+export class ContentTypeParser implements MetadataParser {
+  public async parse(request: HttpRequest, metadata: RepresentationMetadata): Promise<void> {
+    const contentType = request.headers['content-type'];
+    if (contentType) {
+      // Will need to use HeaderUtil once parameters need to be parsed
+      metadata.contentType = /^[^;]*/u.exec(contentType)![0].trim();
+    }
+  }
+}

--- a/src/ldp/http/metadata/LinkTypeParser.ts
+++ b/src/ldp/http/metadata/LinkTypeParser.ts
@@ -1,0 +1,38 @@
+import { DataFactory } from 'n3';
+import { getLoggerFor } from '../../../logging/LogUtil';
+import type { HttpRequest } from '../../../server/HttpRequest';
+import { parseParameters, splitAndClean, transformQuotedStrings } from '../../../util/HeaderUtil';
+import { RDF } from '../../../util/UriConstants';
+import type { RepresentationMetadata } from '../../representation/RepresentationMetadata';
+import type { MetadataParser } from './MetadataParser';
+
+/**
+ * Parses Link headers with "rel=type" parameters and adds them as RDF.type metadata.
+ */
+export class LinkTypeParser implements MetadataParser {
+  protected readonly logger = getLoggerFor(this);
+
+  public async parse(request: HttpRequest, metadata: RepresentationMetadata): Promise<void> {
+    const link = request.headers.link ?? [];
+    const entries: string[] = Array.isArray(link) ? link : [ link ];
+    for (const entry of entries) {
+      this.parseLink(entry, metadata);
+    }
+  }
+
+  protected parseLink(linkEntry: string, metadata: RepresentationMetadata): void {
+    const { result, replacements } = transformQuotedStrings(linkEntry);
+    for (const part of splitAndClean(result)) {
+      const [ link, ...parameters ] = part.split(/\s*;\s*/u);
+      if (/^[^<]|[^>]$/u.test(link)) {
+        this.logger.warn(`Invalid link header ${part}.`);
+        continue;
+      }
+      for (const { name, value } of parseParameters(parameters, replacements)) {
+        if (name === 'rel' && value === 'type') {
+          metadata.add(RDF.type, DataFactory.namedNode(link.slice(1, -1)));
+        }
+      }
+    }
+  }
+}

--- a/src/ldp/http/metadata/MetadataExtractor.ts
+++ b/src/ldp/http/metadata/MetadataExtractor.ts
@@ -1,0 +1,9 @@
+import type { HttpRequest } from '../../../server/HttpRequest';
+import { AsyncHandler } from '../../../util/AsyncHandler';
+import type { RepresentationMetadata } from '../../representation/RepresentationMetadata';
+
+/**
+ * Parses the metadata of a {@link HttpRequest} into a {@link RepresentationMetadata}.
+ */
+export abstract class MetadataExtractor extends
+  AsyncHandler<HttpRequest, RepresentationMetadata> {}

--- a/src/ldp/http/metadata/MetadataParser.ts
+++ b/src/ldp/http/metadata/MetadataParser.ts
@@ -1,0 +1,15 @@
+import type { HttpRequest } from '../../../server/HttpRequest';
+import type { RepresentationMetadata } from '../../representation/RepresentationMetadata';
+
+/**
+ * A parser that takes a specific part of an HttpRequest and converts it to medata,
+ * such as the value of a header entry.
+ */
+export interface MetadataParser {
+  /**
+   * Potentially adds metadata to the RepresentationMetadata based on the HttpRequest contents.
+   * @param request - Request with potential metadata.
+   * @param metadata - Metadata objects that should be updated.
+   */
+  parse: (request: HttpRequest, metadata: RepresentationMetadata) => Promise<void>;
+}

--- a/src/ldp/http/metadata/SlugParser.ts
+++ b/src/ldp/http/metadata/SlugParser.ts
@@ -1,0 +1,20 @@
+import type { HttpRequest } from '../../../server/HttpRequest';
+import { UnsupportedHttpError } from '../../../util/errors/UnsupportedHttpError';
+import { HTTP } from '../../../util/UriConstants';
+import type { RepresentationMetadata } from '../../representation/RepresentationMetadata';
+import type { MetadataParser } from './MetadataParser';
+
+/**
+ * Converts the contents of the slug header to metadata.
+ */
+export class SlugParser implements MetadataParser {
+  public async parse(request: HttpRequest, metadata: RepresentationMetadata): Promise<void> {
+    const { slug } = request.headers;
+    if (slug) {
+      if (Array.isArray(slug)) {
+        throw new UnsupportedHttpError('At most 1 slug header is allowed.');
+      }
+      metadata.set(HTTP.slug, slug);
+    }
+  }
+}

--- a/test/configs/BasicHandlersConfig.ts
+++ b/test/configs/BasicHandlersConfig.ts
@@ -15,10 +15,13 @@ import {
 } from '../../index';
 
 import type { ServerConfig } from './ServerConfig';
-import { getInMemoryResourceStore,
+import {
+  getInMemoryResourceStore,
   getOperationHandler,
   getConvertingStore,
-  getPatchingStore, getBasicRequestParser } from './Util';
+  getPatchingStore,
+  getBasicRequestParser,
+} from './Util';
 
 /**
  * BasicHandlersConfig works with

--- a/test/configs/FileResourceStoreConfig.ts
+++ b/test/configs/FileResourceStoreConfig.ts
@@ -12,7 +12,12 @@ import {
   UnsecureWebIdExtractor,
 } from '../../index';
 import type { ServerConfig } from './ServerConfig';
-import { getFileResourceStore, getOperationHandler, getConvertingStore, getBasicRequestParser } from './Util';
+import {
+  getFileResourceStore,
+  getOperationHandler,
+  getConvertingStore,
+  getBasicRequestParser,
+} from './Util';
 
 /**
  * FileResourceStoreConfig works with

--- a/test/configs/Util.ts
+++ b/test/configs/Util.ts
@@ -1,21 +1,22 @@
 import { join } from 'path';
 import type { BodyParser,
-  HttpRequest,
   Operation,
-  Representation,
   RepresentationConverter,
   ResourceStore,
   ResponseDescription } from '../../index';
 import {
   AcceptPreferenceParser,
+  BasicMetadataExtractor,
   BasicRequestParser,
   BasicTargetExtractor,
   CompositeAsyncHandler,
+  ContentTypeParser,
   DeleteOperationHandler,
   FileResourceStore,
   GetOperationHandler,
   InMemoryResourceStore,
   InteractionController,
+  LinkTypeParser,
   MetadataController,
   PatchingStore,
   PatchOperationHandler,
@@ -24,6 +25,7 @@ import {
   RawBodyParser,
   RepresentationConvertingStore,
   SingleThreadedResourceLocker,
+  SlugParser,
   SparqlUpdatePatchHandler,
   UrlBasedAclManager,
   UrlContainerManager,
@@ -103,6 +105,15 @@ export const getOperationHandler = (store: ResourceStore): CompositeAsyncHandler
 };
 
 /**
+ * Creates a BasicMetadataExtractor with parsers for content-type, slugs and link types.
+ */
+export const getBasicMetadataExtractor = (): BasicMetadataExtractor => new BasicMetadataExtractor([
+  new ContentTypeParser(),
+  new SlugParser(),
+  new LinkTypeParser(),
+]);
+
+/**
  * Gives a basic request parser based on some body parses.
  * @param bodyParsers - Optional list of body parsers, default is RawBodyParser.
  *
@@ -116,11 +127,12 @@ export const getBasicRequestParser = (bodyParsers: BodyParser[] = []): BasicRequ
     // If no body parser is given (array is empty), default to RawBodyParser
     bodyParser = new RawBodyParser();
   } else {
-    bodyParser = new CompositeAsyncHandler<HttpRequest, Representation | undefined>(bodyParsers);
+    bodyParser = new CompositeAsyncHandler(bodyParsers);
   }
   return new BasicRequestParser({
     targetExtractor: new BasicTargetExtractor(),
     preferenceParser: new AcceptPreferenceParser(),
+    metadataExtractor: getBasicMetadataExtractor(),
     bodyParser,
   });
 };

--- a/test/integration/RequestParser.test.ts
+++ b/test/integration/RequestParser.test.ts
@@ -4,15 +4,18 @@ import streamifyArray from 'streamify-array';
 import { AcceptPreferenceParser } from '../../src/ldp/http/AcceptPreferenceParser';
 import { BasicRequestParser } from '../../src/ldp/http/BasicRequestParser';
 import { BasicTargetExtractor } from '../../src/ldp/http/BasicTargetExtractor';
+import { BasicMetadataExtractor } from '../../src/ldp/http/metadata/BasicMetadataExtractor';
+import { ContentTypeParser } from '../../src/ldp/http/metadata/ContentTypeParser';
 import { RawBodyParser } from '../../src/ldp/http/RawBodyParser';
 import { RepresentationMetadata } from '../../src/ldp/representation/RepresentationMetadata';
 import type { HttpRequest } from '../../src/server/HttpRequest';
 
 describe('A BasicRequestParser with simple input parsers', (): void => {
   const targetExtractor = new BasicTargetExtractor();
-  const bodyParser = new RawBodyParser();
   const preferenceParser = new AcceptPreferenceParser();
-  const requestParser = new BasicRequestParser({ targetExtractor, bodyParser, preferenceParser });
+  const metadataExtractor = new BasicMetadataExtractor([ new ContentTypeParser() ]);
+  const bodyParser = new RawBodyParser();
+  const requestParser = new BasicRequestParser({ targetExtractor, preferenceParser, metadataExtractor, bodyParser });
 
   it('can parse an incoming request.', async(): Promise<void> => {
     const request = streamifyArray([ '<http://test.com/s> <http://test.com/p> <http://test.com/o>.' ]) as HttpRequest;

--- a/test/unit/ldp/http/BasicRequestParser.test.ts
+++ b/test/unit/ldp/http/BasicRequestParser.test.ts
@@ -1,20 +1,23 @@
 import { BasicRequestParser } from '../../../../src/ldp/http/BasicRequestParser';
 import type { BodyParser } from '../../../../src/ldp/http/BodyParser';
+import type { MetadataExtractor } from '../../../../src/ldp/http/metadata/MetadataExtractor';
 import type { PreferenceParser } from '../../../../src/ldp/http/PreferenceParser';
 import type { TargetExtractor } from '../../../../src/ldp/http/TargetExtractor';
 import { StaticAsyncHandler } from '../../../util/StaticAsyncHandler';
 
 describe('A BasicRequestParser', (): void => {
   let targetExtractor: TargetExtractor;
-  let bodyParser: BodyParser;
   let preferenceParser: PreferenceParser;
+  let metadataExtractor: MetadataExtractor;
+  let bodyParser: BodyParser;
   let requestParser: BasicRequestParser;
 
   beforeEach(async(): Promise<void> => {
     targetExtractor = new StaticAsyncHandler(true, 'target' as any);
-    bodyParser = new StaticAsyncHandler(true, 'body' as any);
     preferenceParser = new StaticAsyncHandler(true, 'preference' as any);
-    requestParser = new BasicRequestParser({ targetExtractor, bodyParser, preferenceParser });
+    metadataExtractor = new StaticAsyncHandler(true, 'metadata' as any);
+    bodyParser = new StaticAsyncHandler(true, 'body' as any);
+    requestParser = new BasicRequestParser({ targetExtractor, preferenceParser, metadataExtractor, bodyParser });
   });
 
   it('can handle any input.', async(): Promise<void> => {
@@ -26,11 +29,12 @@ describe('A BasicRequestParser', (): void => {
   });
 
   it('returns the output of all input parsers after calling handle.', async(): Promise<void> => {
+    bodyParser.handle = ({ metadata }): any => ({ data: 'body', metadata });
     await expect(requestParser.handle({ url: 'url', method: 'GET' } as any)).resolves.toEqual({
       method: 'GET',
       target: 'target',
       preferences: 'preference',
-      body: 'body',
+      body: { data: 'body', metadata: 'metadata' },
     });
   });
 });

--- a/test/unit/ldp/http/RawBodyParser.test.ts
+++ b/test/unit/ldp/http/RawBodyParser.test.ts
@@ -1,87 +1,54 @@
 import arrayifyStream from 'arrayify-stream';
 import streamifyArray from 'streamify-array';
+import type { BodyParserArgs } from '../../../../src/ldp/http/BodyParser';
 import { RawBodyParser } from '../../../../src/ldp/http/RawBodyParser';
 import { RepresentationMetadata } from '../../../../src/ldp/representation/RepresentationMetadata';
 import type { HttpRequest } from '../../../../src/server/HttpRequest';
-import { UnsupportedHttpError } from '../../../../src/util/errors/UnsupportedHttpError';
 import 'jest-rdf';
-import { HTTP, RDF } from '../../../../src/util/UriConstants';
 
 describe('A RawBodyparser', (): void => {
   const bodyParser = new RawBodyParser();
+  let input: BodyParserArgs;
+
+  beforeEach(async(): Promise<void> => {
+    input = { request: { headers: {}} as HttpRequest, metadata: new RepresentationMetadata() };
+  });
 
   it('accepts all input.', async(): Promise<void> => {
     await expect(bodyParser.canHandle()).resolves.toBeUndefined();
   });
 
   it('returns empty output if there was no content length or transfer encoding.', async(): Promise<void> => {
-    const input = streamifyArray([ '' ]) as HttpRequest;
-    input.headers = {};
+    input.request = streamifyArray([ '' ]) as HttpRequest;
+    input.request.headers = {};
     await expect(bodyParser.handle(input)).resolves.toBeUndefined();
   });
 
   it('errors when a content length was specified without content type.', async(): Promise<void> => {
-    const input = streamifyArray([ 'abc' ]) as HttpRequest;
-    input.headers = { 'content-length': '0' };
+    input.request = streamifyArray([ 'abc' ]) as HttpRequest;
+    input.request.headers = { 'content-length': '0' };
     await expect(bodyParser.handle(input)).rejects
       .toThrow('An HTTP request body was passed without Content-Type header');
   });
 
   it('errors when a transfer encoding was specified without content type.', async(): Promise<void> => {
-    const input = streamifyArray([ 'abc' ]) as HttpRequest;
-    input.headers = { 'transfer-encoding': 'chunked' };
+    input.request = streamifyArray([ 'abc' ]) as HttpRequest;
+    input.request.headers = { 'transfer-encoding': 'chunked' };
     await expect(bodyParser.handle(input)).rejects
       .toThrow('An HTTP request body was passed without Content-Type header');
   });
 
   it('returns a Representation if there was data.', async(): Promise<void> => {
-    const input = streamifyArray([ '<http://test.com/s> <http://test.com/p> <http://test.com/o>.' ]) as HttpRequest;
-    input.headers = { 'transfer-encoding': 'chunked', 'content-type': 'text/turtle' };
+    input.request = streamifyArray([ '<http://test.com/s> <http://test.com/p> <http://test.com/o>.' ]) as HttpRequest;
+    input.request.headers = { 'transfer-encoding': 'chunked', 'content-type': 'text/turtle' };
     const result = (await bodyParser.handle(input))!;
     expect(result).toEqual({
       binary: true,
-      data: input,
-      metadata: expect.any(RepresentationMetadata),
+      data: input.request,
+      metadata: input.metadata,
     });
-    expect(result.metadata.contentType).toEqual('text/turtle');
     await expect(arrayifyStream(result.data)).resolves.toEqual(
       [ '<http://test.com/s> <http://test.com/p> <http://test.com/o>.' ],
     );
-  });
-
-  it('adds the slug header to the metadata.', async(): Promise<void> => {
-    const input = {} as HttpRequest;
-    input.headers = { 'transfer-encoding': 'chunked', 'content-type': 'text/turtle', slug: 'slugText' };
-    const result = (await bodyParser.handle(input))!;
-    expect(result.metadata.contentType).toEqual('text/turtle');
-    expect(result.metadata.get(HTTP.slug)?.value).toEqual('slugText');
-  });
-
-  it('errors if there are multiple slugs.', async(): Promise<void> => {
-    const input = {} as HttpRequest;
-    input.headers = { 'transfer-encoding': 'chunked',
-      'content-type': 'text/turtle',
-      slug: [ 'slugTextA', 'slugTextB' ]};
-    await expect(bodyParser.handle(input)).rejects.toThrow(UnsupportedHttpError);
-  });
-
-  it('adds the link type headers to the metadata.', async(): Promise<void> => {
-    const input = {} as HttpRequest;
-    input.headers = { 'transfer-encoding': 'chunked',
-      'content-type': 'text/turtle',
-      link: '<http://www.w3.org/ns/ldp#Container>; rel="type"' };
-    const result = (await bodyParser.handle(input))!;
-    expect(result.metadata.contentType).toEqual('text/turtle');
-    expect(result.metadata.get(RDF.type)?.value).toEqual('http://www.w3.org/ns/ldp#Container');
-  });
-
-  it('ignores unknown link headers.', async(): Promise<void> => {
-    const input = {} as HttpRequest;
-    input.headers = { 'transfer-encoding': 'chunked',
-      'content-type': 'text/turtle',
-      link: [ '<unrelatedLink>', 'badLink' ]};
-    const result = (await bodyParser.handle(input))!;
-    expect(result.metadata.quads()).toHaveLength(1);
-    expect(result.metadata.contentType).toEqual('text/turtle');
   });
 });

--- a/test/unit/ldp/http/SparqlUpdateBodyParser.test.ts
+++ b/test/unit/ldp/http/SparqlUpdateBodyParser.test.ts
@@ -1,43 +1,52 @@
 import { namedNode, quad } from '@rdfjs/data-model';
-import arrayifyStream from 'arrayify-stream';
 import { Algebra } from 'sparqlalgebrajs';
 import * as algebra from 'sparqlalgebrajs';
 import streamifyArray from 'streamify-array';
+import type { BodyParserArgs } from '../../../../src/ldp/http/BodyParser';
 import { SparqlUpdateBodyParser } from '../../../../src/ldp/http/SparqlUpdateBodyParser';
+import { RepresentationMetadata } from '../../../../src/ldp/representation/RepresentationMetadata';
 import type { HttpRequest } from '../../../../src/server/HttpRequest';
 import { UnsupportedHttpError } from '../../../../src/util/errors/UnsupportedHttpError';
 import { UnsupportedMediaTypeHttpError } from '../../../../src/util/errors/UnsupportedMediaTypeHttpError';
+import { readableToString } from '../../../../src/util/Util';
 
 describe('A SparqlUpdateBodyParser', (): void => {
   const bodyParser = new SparqlUpdateBodyParser();
+  let input: BodyParserArgs;
+
+  beforeEach(async(): Promise<void> => {
+    input = { request: { headers: {}} as HttpRequest, metadata: new RepresentationMetadata() };
+  });
 
   it('only accepts application/sparql-update content.', async(): Promise<void> => {
-    await expect(bodyParser.canHandle({ headers: {}} as HttpRequest)).rejects.toThrow(UnsupportedMediaTypeHttpError);
-    await expect(bodyParser.canHandle({ headers: { 'content-type': 'text/plain' }} as HttpRequest))
-      .rejects.toThrow(UnsupportedMediaTypeHttpError);
-    await expect(bodyParser.canHandle({ headers: { 'content-type': 'application/sparql-update' }} as HttpRequest))
-      .resolves.toBeUndefined();
+    await expect(bodyParser.canHandle(input)).rejects.toThrow(UnsupportedMediaTypeHttpError);
+    input.request.headers = { 'content-type': 'text/plain' };
+    await expect(bodyParser.canHandle(input)).rejects.toThrow(UnsupportedMediaTypeHttpError);
+    input.request.headers = { 'content-type': 'application/sparql-update' };
+    await expect(bodyParser.canHandle(input)).resolves.toBeUndefined();
   });
 
   it('errors when handling invalid SPARQL updates.', async(): Promise<void> => {
-    await expect(bodyParser.handle(streamifyArray([ 'VERY INVALID UPDATE' ]) as HttpRequest))
-      .rejects.toThrow(UnsupportedHttpError);
+    input.request = streamifyArray([ 'VERY INVALID UPDATE' ]) as HttpRequest;
+    await expect(bodyParser.handle(input)).rejects.toThrow(UnsupportedHttpError);
   });
 
   it('errors when receiving an unexpected error.', async(): Promise<void> => {
     const mock = jest.spyOn(algebra, 'translate').mockImplementationOnce((): any => {
       throw 'apple';
     });
-    await expect(bodyParser.handle(streamifyArray(
-      [ 'DELETE DATA { <http://test.com/s> <http://test.com/p> <http://test.com/o>}' ],
-    ) as HttpRequest)).rejects.toThrow(UnsupportedHttpError);
+    input.request = streamifyArray(
+      [ 'DELETE DATA { <http://test.com/s> <http://test.com/p> <http://test.com/o> }' ],
+    ) as HttpRequest;
+    await expect(bodyParser.handle(input)).rejects.toThrow(UnsupportedHttpError);
     mock.mockRestore();
   });
 
   it('converts SPARQL updates to algebra.', async(): Promise<void> => {
-    const result = await bodyParser.handle(streamifyArray(
-      [ 'DELETE DATA { <http://test.com/s> <http://test.com/p> <http://test.com/o>}' ],
-    ) as HttpRequest);
+    input.request = streamifyArray(
+      [ 'DELETE DATA { <http://test.com/s> <http://test.com/p> <http://test.com/o> }' ],
+    ) as HttpRequest;
+    const result = await bodyParser.handle(input);
     expect(result.algebra.type).toBe(Algebra.types.DELETE_INSERT);
     expect((result.algebra as Algebra.DeleteInsert).delete).toBeRdfIsomorphic([ quad(
       namedNode('http://test.com/s'),
@@ -45,11 +54,11 @@ describe('A SparqlUpdateBodyParser', (): void => {
       namedNode('http://test.com/o'),
     ) ]);
     expect(result.binary).toBe(true);
-    expect(result.metadata.contentType).toEqual('application/sparql-update');
+    expect(result.metadata).toBe(input.metadata);
 
     // Workaround for Node 10 not exposing objectMode
-    expect((await arrayifyStream(result.data)).join('')).toEqual(
-      'DELETE DATA { <http://test.com/s> <http://test.com/p> <http://test.com/o>}',
+    expect(await readableToString(result.data)).toEqual(
+      'DELETE DATA { <http://test.com/s> <http://test.com/p> <http://test.com/o> }',
     );
   });
 });

--- a/test/unit/ldp/http/metadata/BasicMetadataExtractor.test.ts
+++ b/test/unit/ldp/http/metadata/BasicMetadataExtractor.test.ts
@@ -1,0 +1,38 @@
+import { BasicMetadataExtractor } from '../../../../../src/ldp/http/metadata/BasicMetadataExtractor';
+import type { MetadataParser } from '../../../../../src/ldp/http/metadata/MetadataParser';
+import type { RepresentationMetadata } from '../../../../../src/ldp/representation/RepresentationMetadata';
+import type { HttpRequest } from '../../../../../src/server/HttpRequest';
+import { RDF } from '../../../../../src/util/UriConstants';
+
+class BasicParser implements MetadataParser {
+  private readonly header: string;
+
+  public constructor(header: string) {
+    this.header = header;
+  }
+
+  public async parse(input: HttpRequest, metadata: RepresentationMetadata): Promise<void> {
+    const header = input.headers[this.header];
+    if (header) {
+      if (typeof header === 'string') {
+        metadata.add(RDF.type, header);
+      }
+    }
+  }
+}
+
+describe(' A BasicMetadataExtractor', (): void => {
+  const handler = new BasicMetadataExtractor([
+    new BasicParser('aa'),
+    new BasicParser('bb'),
+  ]);
+
+  it('can handle all requests.', async(): Promise<void> => {
+    await expect(handler.canHandle()).resolves.toBeUndefined();
+  });
+
+  it('will add metadata from the parsers.', async(): Promise<void> => {
+    const metadata = await handler.handle({ headers: { aa: 'valA', bb: 'valB' } as any } as HttpRequest);
+    expect(metadata.getAll(RDF.type).map((term): any => term.value)).toEqual([ 'valA', 'valB' ]);
+  });
+});

--- a/test/unit/ldp/http/metadata/ContentTypeParser.test.ts
+++ b/test/unit/ldp/http/metadata/ContentTypeParser.test.ts
@@ -1,0 +1,26 @@
+import { ContentTypeParser } from '../../../../../src/ldp/http/metadata/ContentTypeParser';
+import { RepresentationMetadata } from '../../../../../src/ldp/representation/RepresentationMetadata';
+import type { HttpRequest } from '../../../../../src/server/HttpRequest';
+
+describe('A ContentTypeParser', (): void => {
+  const parser = new ContentTypeParser();
+  let request: HttpRequest;
+  let metadata: RepresentationMetadata;
+
+  beforeEach(async(): Promise<void> => {
+    request = { headers: {}} as HttpRequest;
+    metadata = new RepresentationMetadata();
+  });
+
+  it('does nothing if there is no content-type header.', async(): Promise<void> => {
+    await expect(parser.parse(request, metadata)).resolves.toBeUndefined();
+    expect(metadata.quads()).toHaveLength(0);
+  });
+
+  it('sets the given content-type as metadata.', async(): Promise<void> => {
+    request.headers['content-type'] = 'text/plain;charset=UTF-8';
+    await expect(parser.parse(request, metadata)).resolves.toBeUndefined();
+    expect(metadata.quads()).toHaveLength(1);
+    expect(metadata.contentType).toBe('text/plain');
+  });
+});

--- a/test/unit/ldp/http/metadata/LinkTypeParser.test.ts
+++ b/test/unit/ldp/http/metadata/LinkTypeParser.test.ts
@@ -1,0 +1,61 @@
+import { LinkTypeParser } from '../../../../../src/ldp/http/metadata/LinkTypeParser';
+import { RepresentationMetadata } from '../../../../../src/ldp/representation/RepresentationMetadata';
+import { setGlobalLoggerFactory } from '../../../../../src/logging/LogUtil';
+import { VoidLoggerFactory } from '../../../../../src/logging/VoidLoggerFactory';
+import type { HttpRequest } from '../../../../../src/server/HttpRequest';
+import { RDF } from '../../../../../src/util/UriConstants';
+
+describe('A LinkTypeParser', (): void => {
+  const parser = new LinkTypeParser();
+  let request: HttpRequest;
+  let metadata: RepresentationMetadata;
+
+  beforeAll(async(): Promise<void> => {
+    setGlobalLoggerFactory(new VoidLoggerFactory());
+  });
+
+  beforeEach(async(): Promise<void> => {
+    request = { headers: {}} as HttpRequest;
+    metadata = new RepresentationMetadata();
+  });
+
+  it('does nothing if there are no type headers.', async(): Promise<void> => {
+    await parser.parse(request, metadata);
+    expect(metadata.quads()).toHaveLength(0);
+  });
+
+  it('stores link headers with rel = type as metadata.', async(): Promise<void> => {
+    request.headers.link = '<http://test.com/type>;rel="type"';
+    await expect(parser.parse(request, metadata)).resolves.toBeUndefined();
+    expect(metadata.quads()).toHaveLength(1);
+    expect(metadata.get(RDF.type)?.value).toBe('http://test.com/type');
+  });
+
+  it('supports multiple link headers.', async(): Promise<void> => {
+    request.headers.link = [ '<http://test.com/typeA>;rel="type"', '<http://test.com/typeB>;rel=type' ];
+    await expect(parser.parse(request, metadata)).resolves.toBeUndefined();
+    expect(metadata.quads()).toHaveLength(2);
+    expect(metadata.getAll(RDF.type).map((term): any => term.value))
+      .toEqual([ 'http://test.com/typeA', 'http://test.com/typeB' ]);
+  });
+
+  it('supports multiple link header values in the same entry.', async(): Promise<void> => {
+    request.headers.link = '<http://test.com/typeA>;rel="type" , <http://test.com/typeB>;rel=type';
+    await expect(parser.parse(request, metadata)).resolves.toBeUndefined();
+    expect(metadata.quads()).toHaveLength(2);
+    expect(metadata.getAll(RDF.type).map((term): any => term.value))
+      .toEqual([ 'http://test.com/typeA', 'http://test.com/typeB' ]);
+  });
+
+  it('ignores invalid link headers.', async(): Promise<void> => {
+    request.headers.link = 'http://test.com/type;rel="type"';
+    await parser.parse(request, metadata);
+    expect(metadata.quads()).toHaveLength(0);
+  });
+
+  it('ignores non-type link headers.', async(): Promise<void> => {
+    request.headers.link = '<http://test.com/typeA>;rel="notype" , <http://test.com/typeB>';
+    await expect(parser.parse(request, metadata)).resolves.toBeUndefined();
+    expect(metadata.quads()).toHaveLength(0);
+  });
+});

--- a/test/unit/ldp/http/metadata/SlugParser.test.ts
+++ b/test/unit/ldp/http/metadata/SlugParser.test.ts
@@ -1,0 +1,34 @@
+import { SlugParser } from '../../../../../src/ldp/http/metadata/SlugParser';
+import { RepresentationMetadata } from '../../../../../src/ldp/representation/RepresentationMetadata';
+import type { HttpRequest } from '../../../../../src/server/HttpRequest';
+import { UnsupportedHttpError } from '../../../../../src/util/errors/UnsupportedHttpError';
+import { HTTP } from '../../../../../src/util/UriConstants';
+
+describe('A SlugParser', (): void => {
+  const parser = new SlugParser();
+  let request: HttpRequest;
+  let metadata: RepresentationMetadata;
+
+  beforeEach(async(): Promise<void> => {
+    request = { headers: {}} as HttpRequest;
+    metadata = new RepresentationMetadata();
+  });
+
+  it('does nothing if there is no slug header.', async(): Promise<void> => {
+    await expect(parser.parse(request, metadata)).resolves.toBeUndefined();
+    expect(metadata.quads()).toHaveLength(0);
+  });
+
+  it('errors if there are multiple slug headers.', async(): Promise<void> => {
+    request.headers.slug = [ 'slugA', 'slugB' ];
+    await expect(parser.parse(request, metadata))
+      .rejects.toThrow(new UnsupportedHttpError('At most 1 slug header is allowed.'));
+  });
+
+  it('stores the slug metadata.', async(): Promise<void> => {
+    request.headers.slug = 'slugA';
+    await expect(parser.parse(request, metadata)).resolves.toBeUndefined();
+    expect(metadata.quads()).toHaveLength(1);
+    expect(metadata.get(HTTP.slug)?.value).toBe('slugA');
+  });
+});

--- a/test/unit/util/HeaderUtil.test.ts
+++ b/test/unit/util/HeaderUtil.test.ts
@@ -3,9 +3,9 @@ import {
   parseAcceptCharset,
   parseAcceptEncoding,
   parseAcceptLanguage,
-} from '../../../src/util/AcceptParser';
+} from '../../../src/util/HeaderUtil';
 
-describe('AcceptParser', (): void => {
+describe('HeaderUtil', (): void => {
   describe('parseAccept function', (): void => {
     it('parses empty Accept headers.', async(): Promise<void> => {
       expect(parseAccept('')).toEqual([]);
@@ -39,7 +39,7 @@ describe('AcceptParser', (): void => {
       expect(parseAccept('audio/basic; param1="val" ; q=0.5 ;param2="\\\\\\"valid"')).toEqual([
         { range: 'audio/basic',
           weight: 0.5,
-          parameters: { mediaType: { param1: '"val"' }, extension: { param2: '"\\\\\\"valid"' }}},
+          parameters: { mediaType: { param1: 'val' }, extension: { param2: '\\\\\\"valid' }}},
       ]);
     });
 
@@ -59,15 +59,15 @@ describe('AcceptParser', (): void => {
     });
 
     it('rejects Accept Headers with invalid parameters.', async(): Promise<void> => {
-      expect((): any => parseAccept('a/b; a')).toThrow('Invalid Accept parameter:');
-      expect((): any => parseAccept('a/b; a=\\')).toThrow('Invalid Accept parameter:');
-      expect((): any => parseAccept('a/b; q=1 ; a=\\')).toThrow('Invalid Accept parameter:');
-      expect((): any => parseAccept('a/b; q=1 ; a')).not.toThrow('Invalid Accept parameter:');
+      expect((): any => parseAccept('a/b; a')).toThrow('Invalid Accept parameter');
+      expect((): any => parseAccept('a/b; a=\\')).toThrow('Invalid parameter value');
+      expect((): any => parseAccept('a/b; q=1 ; a=\\')).toThrow('Invalid parameter value');
+      expect((): any => parseAccept('a/b; q=1 ; a')).not.toThrow('Invalid Accept parameter');
     });
 
     it('rejects Accept Headers with quoted parameters.', async(): Promise<void> => {
       expect((): any => parseAccept('a/b; a="\\""')).not.toThrow();
-      expect((): any => parseAccept('a/b; a="\\\u007F"')).toThrow('Invalid quoted string in Accept header:');
+      expect((): any => parseAccept('a/b; a="\\\u007F"')).toThrow('Invalid quoted string in header:');
     });
   });
 
@@ -82,6 +82,7 @@ describe('AcceptParser', (): void => {
     it('rejects invalid Accept-Charset Headers.', async(): Promise<void> => {
       expect((): any => parseAcceptCharset('a/b')).toThrow('Invalid Accept-Charset range:');
       expect((): any => parseAcceptCharset('a; q=text')).toThrow('Invalid q value:');
+      expect((): any => parseAcceptCharset('a; c=d')).toThrow('Only q parameters are allowed');
     });
   });
 
@@ -101,6 +102,7 @@ describe('AcceptParser', (): void => {
     it('rejects invalid Accept-Encoding Headers.', async(): Promise<void> => {
       expect((): any => parseAcceptEncoding('a/b')).toThrow('Invalid Accept-Encoding range:');
       expect((): any => parseAcceptEncoding('a; q=text')).toThrow('Invalid q value:');
+      expect((): any => parseAcceptCharset('a; c=d')).toThrow('Only q parameters are allowed');
     });
   });
 
@@ -122,6 +124,7 @@ describe('AcceptParser', (): void => {
       expect((): any => parseAcceptLanguage('a-b-c-d')).not.toThrow('Invalid Accept-Language range:');
 
       expect((): any => parseAcceptLanguage('a; q=text')).toThrow('Invalid q value:');
+      expect((): any => parseAcceptCharset('a; c=d')).toThrow('Only q parameters are allowed');
     });
   });
 });


### PR DESCRIPTION
Resolves #75 .

Since we now have decent metadata support, we still need a clean way to put the incoming metadata in there. So this is my suggestion for it.

Note that for the MetadataParsers their functionality is similar to AsyncHandlers but I used a new interface since the contracts is slightly different (it's no problem if they can't handle it, and all parsers should be executed regardless of the result of others).