### PR TITLE
feat: Fully support storing content-type in file extensions

### DIFF
--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -339,7 +339,7 @@ export class DataAccessorBasedStore implements ResourceStore {
 
   /**
    * Create containers starting from the root until the given identifier corresponds to an existing container.
-   * Will throw errors if the identifier of the last existing "container" corresponds to an existing data resource.
+   * Will throw errors if the identifier of the last existing "container" corresponds to an existing document.
    * @param container - Identifier of the container which will need to exist.
    */
   protected async createRecursiveContainers(container: ResourceIdentifier): Promise<void> {

--- a/src/storage/ExtensionBasedMapper.ts
+++ b/src/storage/ExtensionBasedMapper.ts
@@ -41,7 +41,7 @@ export class ExtensionBasedMapper implements FileIdentifierMapper {
   private readonly rootFilepath: string;
   private readonly types: Record<string, any>;
 
-  public constructor(base: string, rootFilepath: string, overrideTypes = { acl: TEXT_TURTLE, metadata: TEXT_TURTLE }) {
+  public constructor(base: string, rootFilepath: string, overrideTypes = { acl: TEXT_TURTLE, meta: TEXT_TURTLE }) {
     this.baseRequestURI = trimTrailingSlashes(base);
     this.rootFilepath = trimTrailingSlashes(normalizePath(rootFilepath));
     this.types = { ...mime.types, ...overrideTypes };

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -140,7 +140,7 @@ describe('A FileDataAccessor', (): void => {
     });
   });
 
-  describe('writing a data resource', (): void => {
+  describe('writing a document', (): void => {
     it('throws a 404 if the identifier does not start with the base.', async(): Promise<void> => {
       await expect(accessor.writeDocument({ path: 'badpath' }, streamifyArray([]), metadata))
         .rejects.toThrow(NotFoundHttpError);
@@ -262,7 +262,7 @@ describe('A FileDataAccessor', (): void => {
       await expect(accessor.deleteResource({ path: `${base}container` })).rejects.toThrow(NotFoundHttpError);
     });
 
-    it('deletes the corresponding file for data resources.', async(): Promise<void> => {
+    it('deletes the corresponding file for document.', async(): Promise<void> => {
       cache.data = { resource: 'apple' };
       await expect(accessor.deleteResource({ path: `${base}resource` })).resolves.toBeUndefined();
       expect(cache.data.resource).toBeUndefined();

--- a/test/unit/storage/accessors/InMemoryDataAccessor.test.ts
+++ b/test/unit/storage/accessors/InMemoryDataAccessor.test.ts
@@ -27,7 +27,7 @@ describe('An InMemoryDataAccessor', (): void => {
   });
 
   describe('reading and writing data', (): void => {
-    it('throws a 404 if the identifier does not match an existing data resource.', async(): Promise<void> => {
+    it('throws a 404 if the identifier does not match an existing document.', async(): Promise<void> => {
       await expect(accessor.getData({ path: `${base}resource` })).rejects.toThrow(NotFoundHttpError);
       await expect(accessor.getData({ path: `${base}container/resource` })).rejects.toThrow(NotFoundHttpError);
     });
@@ -36,7 +36,7 @@ describe('An InMemoryDataAccessor', (): void => {
       await expect(accessor.getData({ path: base })).rejects.toThrow(NotFoundHttpError);
     });
 
-    it('throws an error if part of the path matches a data resource.', async(): Promise<void> => {
+    it('throws an error if part of the path matches a document.', async(): Promise<void> => {
       await accessor.writeDocument({ path: `${base}resource` }, streamifyArray([ 'data' ]), metadata);
       await expect(accessor.getData({ path: `${base}resource/resource2` })).rejects.toThrow(new Error('Invalid path.'));
     });
@@ -52,7 +52,7 @@ describe('An InMemoryDataAccessor', (): void => {
   });
 
   describe('reading and writing metadata', (): void => {
-    it('throws a 404 if the identifier does not match an existing data resource.', async(): Promise<void> => {
+    it('throws a 404 if the identifier does not match an existing document.', async(): Promise<void> => {
       await expect(accessor.getMetadata({ path: `${base}resource` })).rejects.toThrow(NotFoundHttpError);
     });
 
@@ -85,7 +85,7 @@ describe('An InMemoryDataAccessor', (): void => {
       );
     });
 
-    it('adds stored metadata when requesting data resource metadata.', async(): Promise<void> => {
+    it('adds stored metadata when requesting document metadata.', async(): Promise<void> => {
       const inputMetadata = new RepresentationMetadata(`${base}resource`, { [RDF.type]: toNamedNode(LDP.Resource) });
       await accessor.writeDocument({ path: `${base}resource` }, streamifyArray([ 'data' ]), inputMetadata);
       metadata = await accessor.getMetadata({ path: `${base}resource` });


### PR DESCRIPTION
Resolves #146 .

Makes sure to update the file path if the content-type gets updated and makes the metadata paths be independent of the content-type.

Also renamed all references from "data resource" to "document" for consistency.