### PR TITLE
feat: Add heartbeat/expiring to locks

### DIFF
--- a/config/presets/storage-wrapper.json
+++ b/config/presets/storage-wrapper.json
@@ -3,7 +3,11 @@
   "@graph": [
     {
       "@id": "urn:solid-server:default:ResourceLocker",
-      "@type": "SingleThreadedResourceLocker"
+      "@type": "WrappedExpiringResourceLocker",
+      "WrappedExpiringResourceLocker:_locker": {
+        "@type": "SingleThreadedResourceLocker"
+      },
+      "WrappedExpiringResourceLocker:_expiration": 3000
     },
 
     {

--- a/index.ts
+++ b/index.ts
@@ -129,6 +129,7 @@ export * from './src/storage/ResourceStore';
 export * from './src/storage/RoutingResourceStore';
 export * from './src/storage/SingleThreadedResourceLocker';
 export * from './src/storage/UrlContainerManager';
+export * from './src/storage/WrappedExpiringResourceLocker';
 
 // Util/Errors
 export * from './src/util/errors/ConflictHttpError';

--- a/src/storage/ExpiringLock.ts
+++ b/src/storage/ExpiringLock.ts
@@ -1,0 +1,13 @@
+import type { EventEmitter } from 'events';
+import type { Lock } from './Lock';
+
+/**
+ * ExpiringLock used by a {@link ExpiringResourceLocker} for non-atomic operations.
+ * Emits an "expired" event when internal timer runs out and should call release function when this happen.
+ */
+export interface ExpiringLock extends Lock, EventEmitter {
+  /**
+   * Reset the unlock timer.
+   */
+  renew: () => void;
+}

--- a/src/storage/ExpiringLock.ts
+++ b/src/storage/ExpiringLock.ts
@@ -2,12 +2,13 @@ import type { EventEmitter } from 'events';
 import type { Lock } from './Lock';
 
 /**
- * ExpiringLock used by a {@link ExpiringResourceLocker} for non-atomic operations.
- * Emits an "expired" event when internal timer runs out and should call release function when this happen.
+ * Interface for a lock that expires after a certain period of inactivity.
+ * Activity can be signaled by calling `renew`, which resets the expiration timeout.
+ * When the lock has expired, an `expired` event is emitted and the lock is released.
  */
 export interface ExpiringLock extends Lock, EventEmitter {
   /**
-   * Reset the unlock timer.
+   * Reset the lock expiration timeout.
    */
   renew: () => void;
 }

--- a/src/storage/ExpiringResourceLocker.ts
+++ b/src/storage/ExpiringResourceLocker.ts
@@ -2,7 +2,6 @@ import type { ExpiringLock } from './ExpiringLock';
 import type { ResourceLocker } from './ResourceLocker';
 
 /**
- * Allows the locking of resources which is needed for non-atomic {@link ResourceStore}s.
- * Specific {@link ResourceLocker} to work with {@link ExpiringLock}s.
+ * Interface for a factory of expiring locks.
  */
 export interface ExpiringResourceLocker<T extends ExpiringLock = ExpiringLock> extends ResourceLocker<T> {}

--- a/src/storage/ExpiringResourceLocker.ts
+++ b/src/storage/ExpiringResourceLocker.ts
@@ -1,0 +1,8 @@
+import type { ExpiringLock } from './ExpiringLock';
+import type { ResourceLocker } from './ResourceLocker';
+
+/**
+ * Allows the locking of resources which is needed for non-atomic {@link ResourceStore}s.
+ * Specific {@link ResourceLocker} to work with {@link ExpiringLock}s.
+ */
+export interface ExpiringResourceLocker<T extends ExpiringLock = ExpiringLock> extends ResourceLocker<T> {}

--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -120,12 +120,9 @@ export class LockingResourceStore implements AtomicResourceStore {
    */
   protected createExpiringReadable(source: Readable, lock: ExpiringLock): Readable {
     // Destroy the source when a timeout occurs.
-    const destroySource = (): void => {
+    lock.on('expired', (): void => {
       source.destroy(new Error(`Stream reading timout exceeded`));
-    };
-
-    // Handle the destruction of the source when the lock expires.
-    lock.on('expired', destroySource);
+    });
 
     // Spy on the source to renew the lock upon reading.
     return Object.create(source, {

--- a/src/storage/ResourceLocker.ts
+++ b/src/storage/ResourceLocker.ts
@@ -4,12 +4,12 @@ import type { Lock } from './Lock';
 /**
  * Allows the locking of resources which is needed for non-atomic {@link ResourceStore}s.
  */
-export interface ResourceLocker {
+export interface ResourceLocker<T extends Lock = Lock> {
   /**
    * Lock the given resource.
    * @param identifier - Identifier of the resource that needs to be locked.
    *
    * @returns A promise containing the lock on the resource.
    */
-  acquire: (identifier: ResourceIdentifier) => Promise<Lock>;
+  acquire: (identifier: ResourceIdentifier) => Promise<T>;
 }

--- a/src/storage/WrappedExpiringLock.ts
+++ b/src/storage/WrappedExpiringLock.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events';
-import type { ResourceIdentifier } from '../ldp/representation/ResourceIdentifier';
 import { getLoggerFor } from '../logging/LogUtil';
 import type { ExpiringLock } from './ExpiringLock';
 import type { Lock } from './Lock';
@@ -15,19 +14,16 @@ export class WrappedExpiringLock extends EventEmitter implements ExpiringLock {
 
   protected readonly innerLock: Lock;
   protected readonly expiration: number;
-  protected readonly identifier: ResourceIdentifier;
   protected timeoutHandle?: NodeJS.Timeout;
 
   /**
    * @param innerLock - Instance of ResourceLocker to use for acquiring a lock.
    * @param expiration - Time in ms after which the lock expires.
-   * @param identifier - Identifier of the resource that needs to be locked.
    */
-  public constructor(innerLock: Lock, expiration: number, identifier: ResourceIdentifier) {
+  public constructor(innerLock: Lock, expiration: number) {
     super();
     this.innerLock = innerLock;
     this.expiration = expiration;
-    this.identifier = identifier;
     this.scheduleTimeout();
   }
 
@@ -49,7 +45,7 @@ export class WrappedExpiringLock extends EventEmitter implements ExpiringLock {
   }
 
   private async expire(): Promise<void> {
-    this.logger.verbose(`Lock for ${this.identifier.path} expired after ${this.expiration}ms`);
+    this.logger.verbose(`Lock expired after ${this.expiration}ms`);
     this.emit('expired');
     try {
       await this.innerLock.release();
@@ -63,7 +59,7 @@ export class WrappedExpiringLock extends EventEmitter implements ExpiringLock {
   }
 
   private scheduleTimeout(): void {
-    this.logger.verbose(`Renewed expiring lock for ${this.identifier.path}`);
+    this.logger.verbose(`Renewed expiring lock`);
     this.timeoutHandle = setTimeout((): any => this.expire(), this.expiration);
   }
 }

--- a/src/storage/WrappedExpiringLock.ts
+++ b/src/storage/WrappedExpiringLock.ts
@@ -1,0 +1,60 @@
+import { EventEmitter } from 'events';
+import type { ResourceIdentifier } from '../ldp/representation/ResourceIdentifier';
+import { getLoggerFor } from '../logging/LogUtil';
+import type { ExpiringLock } from './ExpiringLock';
+import type { Lock } from './Lock';
+
+/**
+ * An implementation of an expiring lock which defines the expiration logic.
+ *
+ * ExpiringLock used by a {@link ExpiringResourceLocker} for non-atomic operations.
+ * Emits an "expired" event when internal timer runs out and calls release function when this happen.
+ */
+export class WrappedExpiringLock extends EventEmitter implements ExpiringLock {
+  protected readonly logger = getLoggerFor(this);
+
+  protected readonly innerLock: Lock;
+  protected readonly readTimeout: number;
+  protected readonly identifier: ResourceIdentifier;
+  protected timeout: NodeJS.Timeout;
+
+  /**
+   * @param innerLock - Instance of ResourceLocker to use for acquiring a lock.
+   * @param readTimeout - Time in ms after which reading a representation times out, causing the lock to be released.
+   * @param identifier - Identifier of the resource that needs to be locked.
+   */
+  public constructor(innerLock: Lock, readTimeout: number, identifier: ResourceIdentifier) {
+    super();
+    this.innerLock = innerLock;
+    this.readTimeout = readTimeout;
+    this.identifier = identifier;
+    this.timeout = setTimeout((): any => this.emitExpired(), readTimeout);
+  }
+
+  /**
+   * Release this lock.
+   * @returns A promise resolving when the release is finished.
+   */
+  public async release(): Promise<void> {
+    clearTimeout(this.timeout);
+    return this.innerLock.release();
+  }
+
+  /**
+   * Reset the unlock timer.
+   */
+  public renew(): void {
+    this.logger.verbose(`Renewed expiring timer of the lock for ${this.identifier.path}`);
+    clearTimeout(this.timeout);
+    this.timeout = setTimeout((): any => this.emitExpired(), this.readTimeout);
+  }
+
+  /**
+   * This function will be called when the timer expires.
+   */
+  protected async emitExpired(): Promise<void> {
+    this.logger.verbose(`Lock expired after exceeding timeout of ${this.readTimeout}ms for ${this.identifier.path}`);
+    this.emit('expired');
+    return this.innerLock.release();
+  }
+}

--- a/src/storage/WrappedExpiringResourceLocker.ts
+++ b/src/storage/WrappedExpiringResourceLocker.ts
@@ -32,6 +32,6 @@ export class WrappedExpiringResourceLocker implements ExpiringResourceLocker {
    */
   public async acquire(identifier: ResourceIdentifier): Promise<ExpiringLock> {
     const innerLock = await this.locker.acquire(identifier);
-    return new WrappedExpiringLock(innerLock, this.expiration, identifier);
+    return new WrappedExpiringLock(innerLock, this.expiration);
   }
 }

--- a/src/storage/WrappedExpiringResourceLocker.ts
+++ b/src/storage/WrappedExpiringResourceLocker.ts
@@ -1,0 +1,37 @@
+import type { ResourceIdentifier } from '../ldp/representation/ResourceIdentifier';
+import { getLoggerFor } from '../logging/LogUtil';
+import type { ExpiringLock } from './ExpiringLock';
+import type { ExpiringResourceLocker } from './ExpiringResourceLocker';
+import type { ResourceLocker } from './ResourceLocker';
+import { WrappedExpiringLock } from './WrappedExpiringLock';
+
+/**
+ * Allows the locking of resources which is needed for non-atomic {@link ResourceStore}s.
+ * Differs from {@Link ResourceLocker} by adding expiration logic.
+ */
+export class WrappedExpiringResourceLocker implements ExpiringResourceLocker {
+  protected readonly logger = getLoggerFor(this);
+
+  protected readonly locker: ResourceLocker;
+  protected readonly readTimeout: number;
+
+  /**
+   * @param locker - Instance of ResourceLocker to use for acquiring a lock.
+   * @param readTimeout - Time in ms after which reading a representation times out, causing the lock to be released.
+   */
+  public constructor(locker: ResourceLocker, readTimeout: number) {
+    this.locker = locker;
+    this.readTimeout = readTimeout;
+  }
+
+  /**
+   * Lock the given resource with a lock providing expiration functionality.
+   * @param identifier - Identifier of the resource that needs to be locked.
+   *
+   * @returns A promise containing the expiring lock on the resource.
+   */
+  public async acquire(identifier: ResourceIdentifier): Promise<ExpiringLock> {
+    const innerLock = await this.locker.acquire(identifier);
+    return new WrappedExpiringLock(innerLock, this.readTimeout, identifier);
+  }
+}

--- a/src/storage/WrappedExpiringResourceLocker.ts
+++ b/src/storage/WrappedExpiringResourceLocker.ts
@@ -13,15 +13,15 @@ export class WrappedExpiringResourceLocker implements ExpiringResourceLocker {
   protected readonly logger = getLoggerFor(this);
 
   protected readonly locker: ResourceLocker;
-  protected readonly readTimeout: number;
+  protected readonly expiration: number;
 
   /**
    * @param locker - Instance of ResourceLocker to use for acquiring a lock.
-   * @param readTimeout - Time in ms after which reading a representation times out, causing the lock to be released.
+   * @param expiration - Time in ms after which the lock expires.
    */
-  public constructor(locker: ResourceLocker, readTimeout: number) {
+  public constructor(locker: ResourceLocker, expiration: number) {
     this.locker = locker;
-    this.readTimeout = readTimeout;
+    this.expiration = expiration;
   }
 
   /**
@@ -32,6 +32,6 @@ export class WrappedExpiringResourceLocker implements ExpiringResourceLocker {
    */
   public async acquire(identifier: ResourceIdentifier): Promise<ExpiringLock> {
     const innerLock = await this.locker.acquire(identifier);
-    return new WrappedExpiringLock(innerLock, this.readTimeout, identifier);
+    return new WrappedExpiringLock(innerLock, this.expiration, identifier);
   }
 }

--- a/test/unit/storage/LockingResourceStore.test.ts
+++ b/test/unit/storage/LockingResourceStore.test.ts
@@ -194,9 +194,9 @@ describe('A LockingResourceStore', (): void => {
     jest.useFakeTimers();
 
     // Spy on a real ResourceLocker instance
-    const strLocker = new WrappedExpiringResourceLocker(locker, 1000);
-    store = new LockingResourceStore(source, strLocker);
-    const acquireSpy = jest.spyOn(strLocker, 'acquire');
+    const expiringLocker = new WrappedExpiringResourceLocker(locker, 1000);
+    store = new LockingResourceStore(source, expiringLocker);
+    const acquireSpy = jest.spyOn(expiringLocker, 'acquire');
 
     const representation = await store.getRepresentation({ path: 'path' }, {});
     const errorCallback = jest.fn();
@@ -221,9 +221,9 @@ describe('A LockingResourceStore', (): void => {
     jest.useFakeTimers();
 
     // Spy on a real ResourceLocker instance
-    const strLocker = new WrappedExpiringResourceLocker(locker, 1000);
-    store = new LockingResourceStore(source, strLocker);
-    const acquireSpy = jest.spyOn(strLocker, 'acquire');
+    const expiringLocker = new WrappedExpiringResourceLocker(locker, 1000);
+    store = new LockingResourceStore(source, expiringLocker);
+    const acquireSpy = jest.spyOn(expiringLocker, 'acquire');
 
     const representation = await store.getRepresentation({ path: 'path' }, {});
     const errorCallback = jest.fn();

--- a/test/unit/storage/WrappedExpiringResourceLocker.test.ts
+++ b/test/unit/storage/WrappedExpiringResourceLocker.test.ts
@@ -1,0 +1,30 @@
+import { WrappedExpiringResourceLocker } from '../../../src/storage/WrappedExpiringResourceLocker';
+
+describe('A WrappedExpiringResourceLocker', (): void => {
+  it('emits an error event when releasing the lock errors.', async(): Promise<void> => {
+    jest.useFakeTimers();
+
+    // Create a locker that fails upon release
+    const faultyLocker = {
+      acquire(): any {
+        return {
+          async release(): Promise<never> {
+            throw new Error('Release error');
+          },
+        };
+      },
+    };
+    const expiringLocker = new WrappedExpiringResourceLocker(faultyLocker, 1000);
+    const expiringLock = await expiringLocker.acquire({} as any);
+    const errorCallback = jest.fn();
+    expiringLock.on('error', errorCallback);
+
+    // Let the lock expire
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+
+    // Verify the error has been emitted
+    expect(errorCallback).toHaveBeenCalledTimes(1);
+    expect(errorCallback).toHaveBeenLastCalledWith(new Error('Release error'));
+  });
+});


### PR DESCRIPTION
Closes #62.
I'm not sure if this is what is wanted, so feedback is welcome.

The `READ_TIMEOUT` variable could also be given to the acquire function but for now I have kept it the same as the current implementation.
I had to make some adjustments to the tests and for example, in the tests where the lock has to be time-out, I dropped the order check because here the real implementation was used for acquire and release so they could not be logged in the order list. If that would be a problem anyway, I can see if there is a way to check it anyway.