### PR TITLE
Implement empty canHandle on base class

### DIFF
--- a/src/authentication/UnsecureWebIdExtractor.ts
+++ b/src/authentication/UnsecureWebIdExtractor.ts
@@ -6,10 +6,6 @@ import { CredentialsExtractor } from './CredentialsExtractor';
  * Credentials extractor which simply interprets the contents of the Authorization header as a webID.
  */
 export class UnsecureWebIdExtractor extends CredentialsExtractor {
-  public async canHandle(): Promise<void> {
-    // Supports all requests
-  }
-
   public async handle(input: HttpRequest): Promise<Credentials> {
     return { webID: input.headers.authorization };
   }

--- a/src/authorization/AllowEverythingAuthorizer.ts
+++ b/src/authorization/AllowEverythingAuthorizer.ts
@@ -4,10 +4,6 @@ import { Authorizer } from './Authorizer';
  * Authorizer which allows all access independent of the identifier and requested permissions.
  */
 export class AllowEverythingAuthorizer extends Authorizer {
-  public async canHandle(): Promise<void> {
-    // Can handle all requests
-  }
-
   public async handle(): Promise<void> {
     // Allows all actions
   }

--- a/src/authorization/WebAclAuthorizer.ts
+++ b/src/authorization/WebAclAuthorizer.ts
@@ -35,10 +35,6 @@ export class WebAclAuthorizer extends Authorizer {
     this.resourceStore = resourceStore;
   }
 
-  public async canHandle(): Promise<void> {
-    // Can handle everything
-  }
-
   /**
    * Checks if an agent is allowed to execute the requested actions.
    * Will throw an error if this is not the case.

--- a/src/ldp/http/AcceptPreferenceParser.ts
+++ b/src/ldp/http/AcceptPreferenceParser.ts
@@ -19,10 +19,6 @@ export class AcceptPreferenceParser extends PreferenceParser {
     super();
   }
 
-  public async canHandle(): Promise<void> {
-    // Supports all HttpRequests
-  }
-
   public async handle(input: HttpRequest): Promise<RepresentationPreferences> {
     const result: RepresentationPreferences = {};
     const headers:

--- a/src/ldp/http/BasicRequestParser.ts
+++ b/src/ldp/http/BasicRequestParser.ts
@@ -31,10 +31,6 @@ export class BasicRequestParser extends RequestParser {
     Object.assign(this, args);
   }
 
-  public async canHandle(): Promise<void> {
-    // Can handle all requests
-  }
-
   public async handle(request: HttpRequest): Promise<Operation> {
     const { method } = request;
     if (!method) {

--- a/src/ldp/http/BasicTargetExtractor.ts
+++ b/src/ldp/http/BasicTargetExtractor.ts
@@ -13,10 +13,6 @@ import { TargetExtractor } from './TargetExtractor';
 export class BasicTargetExtractor extends TargetExtractor {
   protected readonly logger = getLoggerFor(this);
 
-  public async canHandle(): Promise<void> {
-    // Can handle all URLs
-  }
-
   public async handle(request: HttpRequest): Promise<ResourceIdentifier> {
     if (!request.url) {
       this.logger.error('The request has no URL');

--- a/src/ldp/http/RawBodyParser.ts
+++ b/src/ldp/http/RawBodyParser.ts
@@ -10,10 +10,6 @@ import { BodyParser } from './BodyParser';
 export class RawBodyParser extends BodyParser {
   protected readonly logger = getLoggerFor(this);
 
-  public async canHandle(): Promise<void> {
-    // All content-types are supported
-  }
-
   // Note that the only reason this is a union is in case the body is empty.
   // If this check gets moved away from the BodyParsers this union could be removed
   public async handle({ request, metadata }: BodyParserArgs): Promise<Representation | undefined> {

--- a/src/ldp/http/metadata/BasicMetadataExtractor.ts
+++ b/src/ldp/http/metadata/BasicMetadataExtractor.ts
@@ -14,10 +14,6 @@ export class BasicMetadataExtractor extends MetadataExtractor {
     this.parsers = parsers;
   }
 
-  public async canHandle(): Promise<void> {
-    // Can handle all requests
-  }
-
   public async handle(request: HttpRequest):
   Promise<RepresentationMetadata> {
     const metadata = new RepresentationMetadata();

--- a/src/util/AsyncHandler.ts
+++ b/src/util/AsyncHandler.ts
@@ -9,7 +9,10 @@ export abstract class AsyncHandler<TInput, TOutput = void> {
    *
    * @returns A promise resolving if this input can be handled, rejecting with an Error if not.
    */
-  public abstract canHandle(input: TInput): Promise<void>;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async canHandle(input: TInput): Promise<void> {
+    // Support any input by default
+  }
 
   /**
    * Handles the given input. This should only be done if the {@link canHandle} function returned `true`.

--- a/test/unit/authentication/UnsecureWebIdExtractor.ts
+++ b/test/unit/authentication/UnsecureWebIdExtractor.ts
@@ -5,7 +5,7 @@ describe('An UnsecureWebIdExtractor', (): void => {
   const extractor = new UnsecureWebIdExtractor();
 
   it('can handle all input.', async(): Promise<void> => {
-    await expect(extractor.canHandle()).resolves.toBeUndefined();
+    await expect(extractor.canHandle({} as HttpRequest)).resolves.toBeUndefined();
   });
 
   it('returns undefined if there is no input.', async(): Promise<void> => {

--- a/test/unit/authorization/AllowEverythingAuthorizer.test.ts
+++ b/test/unit/authorization/AllowEverythingAuthorizer.test.ts
@@ -4,7 +4,7 @@ describe('An AllowEverythingAuthorizer', (): void => {
   const authorizer = new AllowEverythingAuthorizer();
 
   it('can handle everything.', async(): Promise<void> => {
-    await expect(authorizer.canHandle()).resolves.toBeUndefined();
+    await expect(authorizer.canHandle({} as any)).resolves.toBeUndefined();
   });
 
   it('always returns undefined.', async(): Promise<void> => {

--- a/test/unit/authorization/WebAclAuthorizer.test.ts
+++ b/test/unit/authorization/WebAclAuthorizer.test.ts
@@ -43,7 +43,7 @@ describe('A WebAclAuthorizer', (): void => {
 
   it('handles all inputs.', async(): Promise<void> => {
     authorizer = new WebAclAuthorizer(aclManager, containerManager, null as any);
-    await expect(authorizer.canHandle()).resolves.toBeUndefined();
+    await expect(authorizer.canHandle({} as any)).resolves.toBeUndefined();
   });
 
   it('allows access if the acl file allows all agents.', async(): Promise<void> => {

--- a/test/unit/ldp/http/AcceptPreferenceParser.test.ts
+++ b/test/unit/ldp/http/AcceptPreferenceParser.test.ts
@@ -5,7 +5,7 @@ describe('An AcceptPreferenceParser', (): void => {
   const preferenceParser = new AcceptPreferenceParser();
 
   it('can handle all input.', async(): Promise<void> => {
-    await expect(preferenceParser.canHandle()).resolves.toBeUndefined();
+    await expect(preferenceParser.canHandle({} as HttpRequest)).resolves.toBeUndefined();
   });
 
   it('returns an empty result if there is no relevant input.', async(): Promise<void> => {

--- a/test/unit/ldp/http/BasicRequestParser.test.ts
+++ b/test/unit/ldp/http/BasicRequestParser.test.ts
@@ -21,7 +21,7 @@ describe('A BasicRequestParser', (): void => {
   });
 
   it('can handle any input.', async(): Promise<void> => {
-    await expect(requestParser.canHandle()).resolves.toBeUndefined();
+    await expect(requestParser.canHandle({} as any)).resolves.toBeUndefined();
   });
 
   it('errors if there is no input.', async(): Promise<void> => {

--- a/test/unit/ldp/http/BasicTargetExtractor.test.ts
+++ b/test/unit/ldp/http/BasicTargetExtractor.test.ts
@@ -4,7 +4,7 @@ describe('A BasicTargetExtractor', (): void => {
   const extractor = new BasicTargetExtractor();
 
   it('can handle any input.', async(): Promise<void> => {
-    await expect(extractor.canHandle()).resolves.toBeUndefined();
+    await expect(extractor.canHandle({} as any)).resolves.toBeUndefined();
   });
 
   it('errors if there is no URL.', async(): Promise<void> => {

--- a/test/unit/ldp/http/RawBodyParser.test.ts
+++ b/test/unit/ldp/http/RawBodyParser.test.ts
@@ -15,7 +15,7 @@ describe('A RawBodyparser', (): void => {
   });
 
   it('accepts all input.', async(): Promise<void> => {
-    await expect(bodyParser.canHandle()).resolves.toBeUndefined();
+    await expect(bodyParser.canHandle({} as any)).resolves.toBeUndefined();
   });
 
   it('returns empty output if there was no content length or transfer encoding.', async(): Promise<void> => {

--- a/test/unit/ldp/http/metadata/BasicMetadataExtractor.test.ts
+++ b/test/unit/ldp/http/metadata/BasicMetadataExtractor.test.ts
@@ -28,7 +28,7 @@ describe(' A BasicMetadataExtractor', (): void => {
   ]);
 
   it('can handle all requests.', async(): Promise<void> => {
-    await expect(handler.canHandle()).resolves.toBeUndefined();
+    await expect(handler.canHandle({} as any)).resolves.toBeUndefined();
   });
 
   it('will add metadata from the parsers.', async(): Promise<void> => {

--- a/test/unit/server/ExpressHttpServer.test.ts
+++ b/test/unit/server/ExpressHttpServer.test.ts
@@ -12,10 +12,6 @@ const handle = async(input: { request: HttpRequest; response: HttpResponse }): P
 };
 
 class SimpleHttpHandler extends HttpHandler {
-  public async canHandle(): Promise<void> {
-    // Supports all HttpRequests
-  }
-
   public async handle(input: { request: HttpRequest; response: HttpResponse }): Promise<void> {
     return handle(input);
   }

--- a/test/unit/util/AsyncHandler.test.ts
+++ b/test/unit/util/AsyncHandler.test.ts
@@ -1,7 +1,17 @@
-import type { AsyncHandler } from '../../../src/util/AsyncHandler';
+import { AsyncHandler } from '../../../src/util/AsyncHandler';
 import { StaticAsyncHandler } from '../../util/StaticAsyncHandler';
 
 describe('An AsyncHandler', (): void => {
+  it('supports any input by default.', async(): Promise<void> => {
+    class EmptyHandler<T> extends AsyncHandler<T, null> {
+      public async handle(): Promise<null> {
+        return null;
+      }
+    }
+    const handler = new EmptyHandler<string>();
+    await expect(handler.canHandle('test')).resolves.toBeUndefined();
+  });
+
   it('calls canHandle and handle when handleSafe is called.', async(): Promise<void> => {
     const handlerTrue: AsyncHandler<any, any> = new StaticAsyncHandler(true, null);
     const canHandleFn = jest.fn(async(input: any): Promise<void> => input);


### PR DESCRIPTION
Saves some lines; unless we think that being explicit is nicer.