### PR TITLE
Make internal/quads unacceptable as output format

### DIFF
--- a/src/ldp/representation/RepresentationPreference.ts
+++ b/src/ldp/representation/RepresentationPreference.ts
@@ -7,7 +7,12 @@ export interface RepresentationPreference {
    */
   value: string;
   /**
-   * How important this preference is in a value going from 0 to 1.
+   * How preferred this value is in a number going from 0 to 1.
+   * Follows the quality values rule from RFC 7231:
+   *
+   * "The weight is normalized to a real number in the range 0 through 1,
+   * where 0.001 is the least preferred and 1 is the most preferred; a
+   * value of 0 means "not acceptable"."
    */
   weight: number;
 }

--- a/src/storage/conversion/ConversionUtil.ts
+++ b/src/storage/conversion/ConversionUtil.ts
@@ -1,26 +1,51 @@
 import type { RepresentationPreference } from '../../ldp/representation/RepresentationPreference';
 import type { RepresentationPreferences } from '../../ldp/representation/RepresentationPreferences';
+import { InternalServerError } from '../../util/errors/InternalServerError';
 import { UnsupportedHttpError } from '../../util/errors/UnsupportedHttpError';
 import { matchingMediaType } from '../../util/Util';
 import type { RepresentationConverterArgs } from './RepresentationConverter';
 
 /**
- * Filters out the media types from the preferred types that correspond to one of the supported types.
+ * Filters media types based on the given preferences.
+ * Based on RFC 7231 - Content negotiation.
+ *
  * @param preferences - Preferences for output type.
- * @param supported - Types supported by the parser.
+ * @param types - Media types to compare to the preferences.
  *
  * @throws UnsupportedHttpError
- * If the type preferences are undefined.
+ * If the type preferences are undefined or if there are duplicate preferences.
  *
- * @returns The filtered list of preferences.
+ * @returns The weighted and filtered list of matching types.
  */
-export const matchingTypes = (preferences: RepresentationPreferences, supported: string[]):
+export const matchingTypes = (preferences: RepresentationPreferences, types: string[]):
 RepresentationPreference[] => {
   if (!Array.isArray(preferences.type)) {
     throw new UnsupportedHttpError('Output type required for conversion.');
   }
-  return preferences.type.filter(({ value, weight }): boolean => weight > 0 &&
-    supported.some((type): boolean => matchingMediaType(value, type)));
+
+  const prefMap = preferences.type.reduce((map: Record<string, number>, pref): Record<string, number> => {
+    if (map[pref.value]) {
+      throw new UnsupportedHttpError(`Duplicate type preference found: ${pref.value}`);
+    }
+    map[pref.value] = pref.weight;
+    return map;
+  }, {});
+
+  // RFC 7231
+  //    Media ranges can be overridden by more specific media ranges or
+  //    specific media types.  If more than one media range applies to a
+  //    given type, the most specific reference has precedence.
+  const weightedSupported = types.map((type): RepresentationPreference => {
+    const match = /^([^/]+)\/([^\s;]+)/u.exec(type);
+    if (!match) {
+      throw new InternalServerError(`Unexpected type preference: ${type}`);
+    }
+    const [ , main, sub ] = match;
+    const weight = prefMap[type] ?? prefMap[`${main}/${sub}`] ?? prefMap[`${main}/*`] ?? prefMap['*/*'] ?? 0;
+    return { value: type, weight };
+  });
+
+  return weightedSupported.filter((preference): boolean => preference.weight !== 0);
 };
 
 /**

--- a/src/storage/conversion/ConversionUtil.ts
+++ b/src/storage/conversion/ConversionUtil.ts
@@ -1,5 +1,6 @@
 import type { RepresentationPreference } from '../../ldp/representation/RepresentationPreference';
 import type { RepresentationPreferences } from '../../ldp/representation/RepresentationPreferences';
+import { INTERNAL_ALL } from '../../util/ContentTypes';
 import { InternalServerError } from '../../util/errors/InternalServerError';
 import { UnsupportedHttpError } from '../../util/errors/UnsupportedHttpError';
 import { matchingMediaType } from '../../util/Util';
@@ -8,6 +9,9 @@ import type { RepresentationConverterArgs } from './RepresentationConverter';
 /**
  * Filters media types based on the given preferences.
  * Based on RFC 7231 - Content negotiation.
+ * Will add a default `internal/*;q=0` to the preferences to prevent accidental use of internal types.
+ * Since more specific media ranges override less specific ones,
+ * this will be ignored if there is a specific internal type preference.
  *
  * @param preferences - Preferences for output type.
  * @param types - Media types to compare to the preferences.
@@ -30,6 +34,11 @@ RepresentationPreference[] => {
     map[pref.value] = pref.weight;
     return map;
   }, {});
+
+  // Prevent accidental use of internal types
+  if (!prefMap[INTERNAL_ALL]) {
+    prefMap[INTERNAL_ALL] = 0;
+  }
 
   // RFC 7231
   //    Media ranges can be overridden by more specific media ranges or

--- a/src/util/ContentTypes.ts
+++ b/src/util/ContentTypes.ts
@@ -4,4 +4,5 @@ export const APPLICATION_OCTET_STREAM = 'application/octet-stream';
 export const APPLICATION_SPARQL_UPDATE = 'application/sparql-update';
 
 // Internal (non-exposed) content types
+export const INTERNAL_ALL = 'internal/*';
 export const INTERNAL_QUADS = 'internal/quads';


### PR DESCRIPTION
This closes #306 and closes #276 . It does not yet resolve the issue of making sure the patching store does not send quads back to the file store, but that should just be a config change after #297 is resolved.

I like how we can now reject content-types using weight 0, not a big fan of how there is now just a line always adding this preference in `AcceptPreferenceParser`, but it seemed like the best place to add it. Could also add an input parameter taking forbidden content-types into account but that seems a bit overkill.