### PR TITLE
refactor: Make piping consistent

### DIFF
--- a/src/ldp/http/BasicResponseWriter.ts
+++ b/src/ldp/http/BasicResponseWriter.ts
@@ -2,6 +2,7 @@ import { getLoggerFor } from '../../logging/LogUtil';
 import type { HttpResponse } from '../../server/HttpResponse';
 import { INTERNAL_QUADS } from '../../util/ContentTypes';
 import { UnsupportedHttpError } from '../../util/errors/UnsupportedHttpError';
+import { pipeSafe } from '../../util/Util';
 import type { MetadataWriter } from './metadata/MetadataWriter';
 import type { ResponseDescription } from './response/ResponseDescription';
 import { ResponseWriter } from './ResponseWriter';
@@ -33,7 +34,10 @@ export class BasicResponseWriter extends ResponseWriter {
     input.response.writeHead(input.result.statusCode);
 
     if (input.result.data) {
-      input.result.data.pipe(input.response);
+      const pipe = pipeSafe(input.result.data, input.response);
+      pipe.on('error', (error): void => {
+        this.logger.error(`Writing to HttpResponse failed with message ${error.message}`);
+      });
     } else {
       // If there is input data the response will end once the input stream ends
       input.response.end();

--- a/src/ldp/http/SparqlUpdateBodyParser.ts
+++ b/src/ldp/http/SparqlUpdateBodyParser.ts
@@ -5,7 +5,7 @@ import { getLoggerFor } from '../../logging/LogUtil';
 import { APPLICATION_SPARQL_UPDATE } from '../../util/ContentTypes';
 import { UnsupportedHttpError } from '../../util/errors/UnsupportedHttpError';
 import { UnsupportedMediaTypeHttpError } from '../../util/errors/UnsupportedMediaTypeHttpError';
-import { pipeStreamsAndErrors, readableToString } from '../../util/Util';
+import { pipeSafe, readableToString } from '../../util/Util';
 import type { BodyParserArgs } from './BodyParser';
 import { BodyParser } from './BodyParser';
 import type { SparqlUpdatePatch } from './SparqlUpdatePatch';
@@ -29,10 +29,8 @@ export class SparqlUpdateBodyParser extends BodyParser {
     // Note that readableObjectMode is only defined starting from Node 12
     // It is impossible to check if object mode is enabled in Node 10 (without accessing private variables)
     const options = { objectMode: request.readableObjectMode };
-    const toAlgebraStream = new PassThrough(options);
-    const dataCopy = new PassThrough(options);
-    pipeStreamsAndErrors(request, toAlgebraStream);
-    pipeStreamsAndErrors(request, dataCopy);
+    const toAlgebraStream = pipeSafe(request, new PassThrough(options));
+    const dataCopy = pipeSafe(request, new PassThrough(options));
     let algebra: Algebra.Operation;
     try {
       const sparql = await readableToString(toAlgebraStream);

--- a/src/storage/conversion/RdfToQuadConverter.ts
+++ b/src/storage/conversion/RdfToQuadConverter.ts
@@ -5,7 +5,7 @@ import { RepresentationMetadata } from '../../ldp/representation/RepresentationM
 import { INTERNAL_QUADS } from '../../util/ContentTypes';
 import { UnsupportedHttpError } from '../../util/errors/UnsupportedHttpError';
 import { CONTENT_TYPE } from '../../util/UriConstants';
-import { pipeStreamsAndErrors } from '../../util/Util';
+import { pipeSafe } from '../../util/Util';
 import { checkRequest } from './ConversionUtil';
 import type { RepresentationConverterArgs } from './RepresentationConverter';
 import { TypedRepresentationConverter } from './TypedRepresentationConverter';
@@ -39,8 +39,8 @@ export class RdfToQuadConverter extends TypedRepresentationConverter {
 
     // Wrap the stream such that errors are transformed
     // (Node 10 requires both writableObjectMode and readableObjectMode)
-    const data = new PassThrough({ writableObjectMode: true, readableObjectMode: true });
-    pipeStreamsAndErrors(rawQuads, data, (error): Error => new UnsupportedHttpError(error.message));
+    const pass = new PassThrough({ writableObjectMode: true, readableObjectMode: true });
+    const data = pipeSafe(rawQuads, pass, (error): Error => new UnsupportedHttpError(error.message));
 
     return {
       binary: false,

--- a/src/util/MetadataController.ts
+++ b/src/util/MetadataController.ts
@@ -7,7 +7,7 @@ import { RepresentationMetadata } from '../ldp/representation/RepresentationMeta
 import { TEXT_TURTLE } from './ContentTypes';
 import { LDP, RDF } from './UriConstants';
 import { toNamedNode } from './UriUtil';
-import { pipeStreamsAndErrors, pushQuad } from './Util';
+import { pipeSafe, pushQuad } from './Util';
 
 export class MetadataController {
   /**
@@ -46,7 +46,7 @@ export class MetadataController {
    * @returns The Readable object.
    */
   public serializeQuads(quads: Quad[]): Readable {
-    return pipeStreamsAndErrors(streamifyArray(quads), new StreamWriter({ format: TEXT_TURTLE }));
+    return pipeSafe(streamifyArray(quads), new StreamWriter({ format: TEXT_TURTLE }));
   }
 
   /**
@@ -56,6 +56,6 @@ export class MetadataController {
    * @returns A promise containing the array of quads.
    */
   public async parseQuads(readable: Readable): Promise<Quad[]> {
-    return await arrayifyStream(pipeStreamsAndErrors(readable, new StreamParser({ format: TEXT_TURTLE })));
+    return await arrayifyStream(pipeSafe(readable, new StreamParser({ format: TEXT_TURTLE })));
   }
 }


### PR DESCRIPTION
Initially I wanted to use `stream.pipeline` in `pipeStreamsAndErrors` but that still doesn't consistently emit error events so I didn't use it in the end.

Also closes #116 (and closes #310) due to the changes in the response writer.