### PR TITLE
Monitor streams to catch errors

### DIFF
--- a/src/storage/accessors/SparqlDataAccessor.ts
+++ b/src/storage/accessors/SparqlDataAccessor.ts
@@ -24,6 +24,7 @@ import { NotFoundHttpError } from '../../util/errors/NotFoundHttpError';
 import { UnsupportedHttpError } from '../../util/errors/UnsupportedHttpError';
 import { UnsupportedMediaTypeHttpError } from '../../util/errors/UnsupportedMediaTypeHttpError';
 import type { MetadataController } from '../../util/MetadataController';
+import { StreamMonitor } from '../../util/StreamMonitor';
 import { CONTENT_TYPE, LDP } from '../../util/UriConstants';
 import { toNamedNode } from '../../util/UriUtil';
 import { ensureTrailingSlash } from '../../util/Util';
@@ -125,7 +126,12 @@ export class SparqlDataAccessor implements DataAccessor {
     if (this.isMetadataIdentifier(identifier)) {
       throw new ConflictHttpError('Not allowed to create NamedNodes with the metadata extension.');
     }
+
+    const monitor = new StreamMonitor(data, 'SparqlDataAccessor-writeDocument');
+
     const { name, parent } = await this.getRelatedNames(identifier);
+
+    monitor.release();
 
     const triples = await arrayifyStream(data) as Quad[];
     const def = defaultGraph();

--- a/src/storage/conversion/QuadToRdfConverter.ts
+++ b/src/storage/conversion/QuadToRdfConverter.ts
@@ -4,6 +4,7 @@ import type { Representation } from '../../ldp/representation/Representation';
 import { RepresentationMetadata } from '../../ldp/representation/RepresentationMetadata';
 import type { RepresentationPreferences } from '../../ldp/representation/RepresentationPreferences';
 import { INTERNAL_QUADS } from '../../util/ContentTypes';
+import { StreamMonitor } from '../../util/StreamMonitor';
 import { CONTENT_TYPE } from '../../util/UriConstants';
 import { checkRequest, matchingTypes } from './ConversionUtil';
 import type { RepresentationConverterArgs } from './RepresentationConverter';
@@ -22,7 +23,9 @@ export class QuadToRdfConverter extends TypedRepresentationConverter {
   }
 
   public async canHandle(input: RepresentationConverterArgs): Promise<void> {
+    const monitor = new StreamMonitor(input.representation.data, 'QuadToRdfConverter');
     checkRequest(input, [ INTERNAL_QUADS ], await rdfSerializer.getContentTypes());
+    monitor.release();
   }
 
   public async handle(input: RepresentationConverterArgs): Promise<Representation> {

--- a/src/storage/conversion/RdfToQuadConverter.ts
+++ b/src/storage/conversion/RdfToQuadConverter.ts
@@ -4,6 +4,7 @@ import type { Representation } from '../../ldp/representation/Representation';
 import { RepresentationMetadata } from '../../ldp/representation/RepresentationMetadata';
 import { INTERNAL_QUADS } from '../../util/ContentTypes';
 import { UnsupportedHttpError } from '../../util/errors/UnsupportedHttpError';
+import { StreamMonitor } from '../../util/StreamMonitor';
 import { CONTENT_TYPE } from '../../util/UriConstants';
 import { pipeSafe } from '../../util/Util';
 import { checkRequest } from './ConversionUtil';
@@ -23,7 +24,9 @@ export class RdfToQuadConverter extends TypedRepresentationConverter {
   }
 
   public async canHandle(input: RepresentationConverterArgs): Promise<void> {
+    const monitor = new StreamMonitor(input.representation.data, 'RdfToQuadConverter');
     checkRequest(input, await rdfParser.getContentTypes(), [ INTERNAL_QUADS ]);
+    monitor.release();
   }
 
   public async handle(input: RepresentationConverterArgs): Promise<Representation> {

--- a/src/util/StreamMonitor.ts
+++ b/src/util/StreamMonitor.ts
@@ -1,0 +1,62 @@
+import type { Readable } from 'stream';
+import { getLoggerFor } from '../logging/LogUtil';
+
+/**
+ * Class used to monitor streams for possible error events.
+ * This can be used in cases where a stream is received as input,
+ * but other async operations need to be executed before the stream is passed along.
+ * At that point Node.js might start buffering the stream,
+ * which can cause the server to crash since there is no error listener at that point.
+ */
+export class StreamMonitor {
+  protected readonly logger = getLoggerFor(this);
+
+  private readonly stream: Readable;
+  private error?: Error;
+
+  private readonly errorCb: (error: Error) => void;
+  private readonly endCb: () => void;
+  private released = false;
+
+  /**
+   * Creates a monitor on the given stream.
+   * `name` is used for logging in case the monitor is not released before the stream ending.
+   */
+  public constructor(stream: Readable, name?: string) {
+    this.stream = stream;
+
+    this.errorCb = (error: Error): void => {
+      this.error = error;
+    };
+    this.stream.on('error', this.errorCb);
+
+    this.endCb = (): void => {
+      setTimeout((): void => {
+        if (!this.released) {
+          this.logger.warn(`${name ?? 'unknown'} monitor was not released but stream ended`);
+        }
+      }, 1000);
+    };
+    this.stream.on('end', this.endCb);
+  }
+
+  /**
+   * Releases the monitor from the stream.
+   * Will throw an error if the stream emitted an error in the meantime.
+   * Will also throw an error if this function is called twice.
+   */
+  public release(): void {
+    if (this.released) {
+      throw new Error('Release called more than once');
+    }
+    this.released = true;
+
+    // Remove listeners to prevent unneeded event calls
+    this.stream.removeListener('error', this.errorCb);
+    this.stream.removeListener('end', this.endCb);
+
+    if (this.error) {
+      throw this.error;
+    }
+  }
+}

--- a/test/unit/ldp/AuthenticatedLdpHandler.test.ts
+++ b/test/unit/ldp/AuthenticatedLdpHandler.test.ts
@@ -1,3 +1,4 @@
+import streamifyArray from 'streamify-array';
 import type { CredentialsExtractor } from '../../../src/authentication/CredentialsExtractor';
 import type { Authorizer } from '../../../src/authorization/Authorizer';
 import type { AuthenticatedLdpHandlerArgs } from '../../../src/ldp/AuthenticatedLdpHandler';
@@ -76,5 +77,12 @@ describe('An AuthenticatedLdpHandler', (): void => {
     const handler = new AuthenticatedLdpHandler(args);
 
     await expect(handler.handle({ request: 'request' as any, response: {} as HttpResponse })).rejects.toEqual('apple');
+  });
+
+  it('can handle operations with data.', async(): Promise< void> => {
+    args.requestParser.handle = async(): Promise<any> => ({ body: { data: streamifyArray([ 'data' ]) }});
+    const handler = new AuthenticatedLdpHandler(args);
+
+    await expect(handler.handle({ request: 'request' as any, response: 'response' as any })).resolves.toBeUndefined();
   });
 });

--- a/test/unit/storage/conversion/ChainedConverter.test.ts
+++ b/test/unit/storage/conversion/ChainedConverter.test.ts
@@ -1,3 +1,4 @@
+import streamifyArray from 'streamify-array';
 import type { Representation } from '../../../../src/ldp/representation/Representation';
 import { RepresentationMetadata } from '../../../../src/ldp/representation/RepresentationMetadata';
 import type { RepresentationPreferences } from '../../../../src/ldp/representation/RepresentationPreferences';
@@ -52,7 +53,7 @@ describe('A ChainedConverter', (): void => {
     converter = new ChainedConverter(converters);
 
     const metadata = new RepresentationMetadata({ [CONTENT_TYPE]: 'text/turtle' });
-    representation = { metadata } as Representation;
+    representation = { data: streamifyArray([]), metadata } as Representation;
     preferences = { type: [{ value: 'internal/quads', weight: 1 }]};
     args = { representation, preferences, identifier: { path: 'path' }};
   });

--- a/test/unit/storage/conversion/QuadToRdfConverter.test.ts
+++ b/test/unit/storage/conversion/QuadToRdfConverter.test.ts
@@ -24,13 +24,13 @@ describe('A QuadToRdfConverter', (): void => {
   });
 
   it('can handle quad to turtle conversions.', async(): Promise<void> => {
-    const representation = { metadata } as Representation;
+    const representation = { data: streamifyArray([]), metadata } as Representation;
     const preferences: RepresentationPreferences = { type: [{ value: 'text/turtle', weight: 1 }]};
     await expect(converter.canHandle({ identifier, representation, preferences })).resolves.toBeUndefined();
   });
 
   it('can handle quad to JSON-LD conversions.', async(): Promise<void> => {
-    const representation = { metadata } as Representation;
+    const representation = { data: streamifyArray([]), metadata } as Representation;
     const preferences: RepresentationPreferences = { type: [{ value: 'application/ld+json', weight: 1 }]};
     await expect(converter.canHandle({ identifier, representation, preferences })).resolves.toBeUndefined();
   });

--- a/test/unit/storage/conversion/RdfToQuadConverter.test.ts
+++ b/test/unit/storage/conversion/RdfToQuadConverter.test.ts
@@ -26,14 +26,14 @@ describe('A RdfToQuadConverter.test.ts', (): void => {
 
   it('can handle turtle to quad conversions.', async(): Promise<void> => {
     const metadata = new RepresentationMetadata({ [CONTENT_TYPE]: 'text/turtle' });
-    const representation = { metadata } as Representation;
+    const representation = { data: streamifyArray([]), metadata } as Representation;
     const preferences: RepresentationPreferences = { type: [{ value: INTERNAL_QUADS, weight: 1 }]};
     await expect(converter.canHandle({ identifier, representation, preferences })).resolves.toBeUndefined();
   });
 
   it('can handle JSON-LD to quad conversions.', async(): Promise<void> => {
     const metadata = new RepresentationMetadata({ [CONTENT_TYPE]: 'application/ld+json' });
-    const representation = { metadata } as Representation;
+    const representation = { data: streamifyArray([]), metadata } as Representation;
     const preferences: RepresentationPreferences = { type: [{ value: INTERNAL_QUADS, weight: 1 }]};
     await expect(converter.canHandle({ identifier, representation, preferences })).resolves.toBeUndefined();
   });

--- a/test/unit/util/StreamMonitor.test.ts
+++ b/test/unit/util/StreamMonitor.test.ts
@@ -1,0 +1,81 @@
+import { Readable } from 'stream';
+import arrayifyStream from 'arrayify-stream';
+import { StreamMonitor } from '../../../src/util/StreamMonitor';
+
+class DummyMonitor extends StreamMonitor {
+  public logger: any;
+
+  public constructor(stream: Readable, name?: string) {
+    super(stream, name);
+    this.logger = jest.fn();
+  }
+}
+
+describe('A StreamMonitor', (): void => {
+  it('does nothing if it was released and the stream ended correctly.', async(): Promise<void> => {
+    const stream = Readable.from([ 'data' ]);
+    const monitor = new StreamMonitor(stream);
+    await expect(arrayifyStream(stream)).resolves.toEqual([ 'data' ]);
+    expect(monitor.release()).toBeUndefined();
+  });
+
+  it('errors if release is called twice.', async(): Promise<void> => {
+    const stream = Readable.from([ 'data' ]);
+    const monitor = new StreamMonitor(stream);
+    expect(monitor.release()).toBeUndefined();
+    expect((): void => monitor.release()).toThrow(new Error('Release called more than once'));
+  });
+
+  it('throws an error on release if there was an error in the stream.', async(): Promise<void> => {
+    const stream = Readable.from([ 'data' ]);
+    stream.read = (): any => {
+      stream.emit('error', new Error('bad data!'));
+      return null;
+    };
+    const monitor = new StreamMonitor(stream);
+    await expect(arrayifyStream(stream)).rejects.toThrow(new Error('bad data!'));
+    expect((): void => monitor.release()).toThrow(new Error('bad data!'));
+  });
+
+  it('logs a warning if the monitor is not released in time.', async(): Promise<void> => {
+    jest.useFakeTimers();
+
+    const stream = Readable.from([ 'data' ]);
+    const monitor = new DummyMonitor(stream);
+    monitor.logger = {
+      warn: jest.fn(),
+    };
+    await expect(arrayifyStream(stream)).resolves.toEqual([ 'data' ]);
+    jest.advanceTimersByTime(1000);
+    expect(monitor.logger.warn).toHaveBeenCalledTimes(1);
+    expect(monitor.logger.warn).toHaveBeenLastCalledWith(`unknown monitor was not released but stream ended`);
+  });
+
+  it('can log a monitor identifier to discover which monitor failed.', async(): Promise<void> => {
+    jest.useFakeTimers();
+
+    const stream = Readable.from([ 'data' ]);
+    const monitor = new DummyMonitor(stream, 'dummy');
+    monitor.logger = {
+      warn: jest.fn(),
+    };
+    await expect(arrayifyStream(stream)).resolves.toEqual([ 'data' ]);
+    jest.advanceTimersByTime(1000);
+    expect(monitor.logger.warn).toHaveBeenCalledTimes(1);
+    expect(monitor.logger.warn).toHaveBeenLastCalledWith(`dummy monitor was not released but stream ended`);
+  });
+
+  it('logs no warning if the monitor was released in time.', async(): Promise<void> => {
+    jest.useFakeTimers();
+
+    const stream = Readable.from([ 'data' ]);
+    const monitor = new DummyMonitor(stream);
+    monitor.logger = {
+      warn: jest.fn(),
+    };
+    await expect(arrayifyStream(stream)).resolves.toEqual([ 'data' ]);
+    expect(monitor.release()).toBeUndefined();
+    jest.advanceTimersByTime(1000);
+    expect(monitor.logger.warn).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
This closes #317.

Since this change has a big impact on how we handle streams, I made 2 PRs with different solutions to this problem, the other one being #327. I will keep discussion on what solution to choose to this PR, specifics for that solution can still be in the corresponding PR.

For context: both the core implementation (`stream.pipeline`) and libraries that I found (`pump`) related to this take as input a list of streams, and a callback function to call when there is an error. So the assumption is always made you have an error callback ready at the moment you create a stream. This completely breaks with our architectural design so I don't see how we would ever be able to use those.

The solution proposed here introduces a monitor that needs to be created every time a function does something async while it has a stream as input. This way, if Node starts buffering the stream during the async event, we still catch the error in the monitor. The monitor will then throw the error once it is released. This would only be necessary if the async event does not take the stream as input, if it does it would be the responsibility of that function to monitor. A warning will also be logged if the monitor does not get released (soon) after an "end" event fires.

The other solution is fully described in #327, but the idea there is that if an error listener is attached to a stream, it still receives the error even if the error was triggered before the listener was attached. So there the responsibility is shifted to the stream creators.

The reason I made the second implementation was because the monitor didn't feel completely right with me. Not that the other solution is perfect, but there it did help that it was a bit clearer when exactly it needed to be added. Both could also exist of course but that might be a bit much. 

Some notes I made while implementing the monitor:
 * I'm not a 100% sure that I covered all cases where this could be needed. It's not always clear if it's needed.
 * We would have to keep this into account when an interface changes to make a sync function async.
 * A situation where it is easy to miss is a function interface that takes e.g. a Representation as input, but the specific implementation of it is defined as `func(input: { metadata: RepresentationMetadata })` since it doesn't use the rest of the data. Potentially a monitor still needs to be added there if this function is async.
 * The monitor release might not be called if an error gets thrown by something else before the monitor was released.

#317 suggested logging a warning if multiple monitors were attached to a single stream, but I didn't see a safe way to do this. It would also not cover all cases since when we pipe there might be a monitor attached to the left stream of the pipe and a monitor to the right stream of the pipe, which we would not be able to warn about.