### PR TITLE
Wrap streams to catch errors

### DIFF
--- a/src/init/Setup.ts
+++ b/src/init/Setup.ts
@@ -1,4 +1,3 @@
-import streamifyArray from 'streamify-array';
 import type { AclManager } from '../authorization/AclManager';
 import { RepresentationMetadata } from '../ldp/representation/RepresentationMetadata';
 import type { LoggerFactory } from '../logging/LoggerFactory';
@@ -6,6 +5,7 @@ import { getLoggerFor, setGlobalLoggerFactory } from '../logging/LogUtil';
 import type { ExpressHttpServerFactory } from '../server/ExpressHttpServerFactory';
 import type { ResourceStore } from '../storage/ResourceStore';
 import { TEXT_TURTLE } from '../util/ContentTypes';
+import { guardedStreamFrom } from '../util/StreamUtil';
 import { CONTENT_TYPE } from '../util/UriConstants';
 
 /**
@@ -65,7 +65,7 @@ export class Setup {
         baseAclId,
         {
           binary: true,
-          data: streamifyArray([ acl ]),
+          data: guardedStreamFrom([ acl ]),
           metadata,
         },
       );

--- a/src/ldp/http/response/OkResponseDescription.ts
+++ b/src/ldp/http/response/OkResponseDescription.ts
@@ -1,4 +1,5 @@
 import type { Readable } from 'stream';
+import type { Guarded } from '../../../util/GuardedStream';
 import type { RepresentationMetadata } from '../../representation/RepresentationMetadata';
 import { ResponseDescription } from './ResponseDescription';
 
@@ -10,7 +11,7 @@ export class OkResponseDescription extends ResponseDescription {
    * @param metadata - Metadata concerning the response.
    * @param data - Potential data. @ignored
    */
-  public constructor(metadata: RepresentationMetadata, data?: Readable) {
+  public constructor(metadata: RepresentationMetadata, data?: Guarded<Readable>) {
     super(200, metadata, data);
   }
 }

--- a/src/ldp/http/response/ResponseDescription.ts
+++ b/src/ldp/http/response/ResponseDescription.ts
@@ -1,4 +1,5 @@
 import type { Readable } from 'stream';
+import type { Guarded } from '../../../util/GuardedStream';
 import type { RepresentationMetadata } from '../../representation/RepresentationMetadata';
 
 /**
@@ -7,14 +8,14 @@ import type { RepresentationMetadata } from '../../representation/Representation
 export class ResponseDescription {
   public readonly statusCode: number;
   public readonly metadata?: RepresentationMetadata;
-  public readonly data?: Readable;
+  public readonly data?: Guarded<Readable>;
 
   /**
    * @param statusCode - Status code to return.
    * @param metadata - Metadata corresponding to the response (and data potentially).
    * @param data - Data that needs to be returned. @ignored
    */
-  public constructor(statusCode: number, metadata?: RepresentationMetadata, data?: Readable) {
+  public constructor(statusCode: number, metadata?: RepresentationMetadata, data?: Guarded<Readable>) {
     this.statusCode = statusCode;
     this.metadata = metadata;
     this.data = data;

--- a/src/ldp/representation/Representation.ts
+++ b/src/ldp/representation/Representation.ts
@@ -1,4 +1,5 @@
 import type { Readable } from 'stream';
+import type { Guarded } from '../../util/GuardedStream';
 import type { RepresentationMetadata } from './RepresentationMetadata';
 
 /**
@@ -12,7 +13,7 @@ export interface Representation {
   /**
    * The raw data stream for this representation.
    */
-  data: Readable;
+  data: Guarded<Readable>;
   /**
    * Whether the data stream consists of binary/string chunks
    * (as opposed to complex objects).

--- a/src/server/ExpressHttpServerFactory.ts
+++ b/src/server/ExpressHttpServerFactory.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import type { Express } from 'express';
 import express from 'express';
 import { getLoggerFor } from '../logging/LogUtil';
+import { guardStream } from '../util/GuardedStream';
 import type { HttpHandler } from './HttpHandler';
 import type { HttpServerFactory } from './HttpServerFactory';
 
@@ -40,7 +41,7 @@ export class ExpressHttpServerFactory implements HttpServerFactory {
     app.use(async(request, response, done): Promise<void> => {
       try {
         this.logger.info(`Received request for ${request.url}`);
-        await this.handler.handleSafe({ request, response });
+        await this.handler.handleSafe({ request: guardStream(request), response });
       } catch (error: unknown) {
         const errMsg = error instanceof Error ? `${error.name}: ${error.message}\n${error.stack}` : 'Unknown error.';
         this.logger.error(errMsg);

--- a/src/server/HttpRequest.ts
+++ b/src/server/HttpRequest.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage } from 'http';
+import type { Guarded } from '../util/GuardedStream';
 
 /**
  * An incoming HTTP request;
  */
-export type HttpRequest = IncomingMessage;
+export type HttpRequest = Guarded<IncomingMessage>;

--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -4,6 +4,7 @@ import type { Representation } from '../ldp/representation/Representation';
 import type { RepresentationPreferences } from '../ldp/representation/RepresentationPreferences';
 import type { ResourceIdentifier } from '../ldp/representation/ResourceIdentifier';
 import { getLoggerFor } from '../logging/LogUtil';
+import type { Guarded } from '../util/GuardedStream';
 import type { AtomicResourceStore } from './AtomicResourceStore';
 import type { Conditions } from './Conditions';
 import type { ExpiringLock } from './ExpiringLock';
@@ -118,7 +119,7 @@ export class LockingResourceStore implements AtomicResourceStore {
    * @param source - The readable to wrap
    * @param lock - The lock for the corresponding identifier.
    */
-  protected createExpiringReadable(source: Readable, lock: ExpiringLock): Readable {
+  protected createExpiringReadable(source: Guarded<Readable>, lock: ExpiringLock): Readable {
     // Destroy the source when a timeout occurs.
     lock.on('expired', (): void => {
       source.destroy(new Error(`Stream reading timout exceeded`));

--- a/src/storage/accessors/DataAccessor.ts
+++ b/src/storage/accessors/DataAccessor.ts
@@ -2,6 +2,7 @@ import type { Readable } from 'stream';
 import type { Representation } from '../../ldp/representation/Representation';
 import type { RepresentationMetadata } from '../../ldp/representation/RepresentationMetadata';
 import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
+import type { Guarded } from '../../util/GuardedStream';
 
 /**
  * A DataAccessor is the building block closest to the actual data storage.
@@ -27,7 +28,7 @@ export interface DataAccessor {
    * It can be assumed that the incoming identifier will always correspond to a document.
    * @param identifier - Identifier for which the data is requested.
    */
-  getData: (identifier: ResourceIdentifier) => Promise<Readable>;
+  getData: (identifier: ResourceIdentifier) => Promise<Guarded<Readable>>;
 
   /**
    * Returns the metadata corresponding to the identifier.
@@ -42,7 +43,8 @@ export interface DataAccessor {
    * @param data - Data to store.
    * @param metadata - Metadata to store.
    */
-  writeDocument: (identifier: ResourceIdentifier, data: Readable, metadata: RepresentationMetadata) => Promise<void>;
+  writeDocument: (identifier: ResourceIdentifier, data: Guarded<Readable>, metadata: RepresentationMetadata) =>
+  Promise<void>;
 
   /**
    * Writes metadata for a container.

--- a/src/storage/conversion/QuadToRdfConverter.ts
+++ b/src/storage/conversion/QuadToRdfConverter.ts
@@ -4,6 +4,7 @@ import type { Representation } from '../../ldp/representation/Representation';
 import { RepresentationMetadata } from '../../ldp/representation/RepresentationMetadata';
 import type { RepresentationPreferences } from '../../ldp/representation/RepresentationPreferences';
 import { INTERNAL_QUADS } from '../../util/ContentTypes';
+import { guardStream } from '../../util/GuardedStream';
 import { CONTENT_TYPE } from '../../util/UriConstants';
 import { validateRequestArgs, matchingTypes } from './ConversionUtil';
 import type { RepresentationConverterArgs } from './RepresentationConverter';
@@ -34,7 +35,7 @@ export class QuadToRdfConverter extends TypedRepresentationConverter {
     const metadata = new RepresentationMetadata(quads.metadata, { [CONTENT_TYPE]: contentType });
     return {
       binary: true,
-      data: rdfSerializer.serialize(quads.data, { contentType }) as Readable,
+      data: guardStream(rdfSerializer.serialize(quads.data, { contentType }) as Readable),
       metadata,
     };
   }

--- a/src/storage/patch/SparqlUpdatePatchHandler.ts
+++ b/src/storage/patch/SparqlUpdatePatchHandler.ts
@@ -11,6 +11,7 @@ import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdenti
 import { getLoggerFor } from '../../logging/LogUtil';
 import { INTERNAL_QUADS } from '../../util/ContentTypes';
 import { UnsupportedHttpError } from '../../util/errors/UnsupportedHttpError';
+import { guardStream } from '../../util/GuardedStream';
 import { CONTENT_TYPE } from '../../util/UriConstants';
 import type { ResourceLocker } from '../ResourceLocker';
 import type { ResourceStore } from '../ResourceStore';
@@ -77,7 +78,7 @@ export class SparqlUpdatePatchHandler extends PatchHandler {
     const metadata = new RepresentationMetadata(input.identifier.path, { [CONTENT_TYPE]: INTERNAL_QUADS });
     const representation: Representation = {
       binary: false,
-      data: store.match() as Readable,
+      data: guardStream(store.match() as Readable),
       metadata,
     };
     await this.source.setRepresentation(input.identifier, representation);

--- a/src/util/GuardedStream.ts
+++ b/src/util/GuardedStream.ts
@@ -1,0 +1,97 @@
+import { getLoggerFor } from '../logging/LogUtil';
+
+// Until Typescript adds Nominal types this is how to do it.
+// This can be generalized should we need it in the future for other cases.
+// Also using the guard to store the intermediate variables.
+// See the following issue:
+//   https://github.com/microsoft/TypeScript/issues/202
+
+const logger = getLoggerFor('GuardedStream');
+
+// Using symbols to make sure we don't override existing parameters
+const guard = Symbol('guard');
+const errorGuard = Symbol('error');
+const timeoutGuard = Symbol('timeout');
+
+// Class used to guard streams
+class Guard {
+  protected [guard]: boolean;
+}
+
+// Hidden interface for guard-related variables
+interface StoredErrorStream extends NodeJS.EventEmitter {
+  [errorGuard]?: Error;
+  [timeoutGuard]?: NodeJS.Timeout;
+}
+
+/**
+ * A stream that is guarded.
+ * This means that if this stream emits an error before a listener is attached,
+ * it will store the error and emit it once a listener is added.
+ */
+export type Guarded<T extends NodeJS.EventEmitter> = T & Guard;
+
+/**
+ * Callback that is used when a stream emits an error and no error listener is attached.
+ * Used to store the error and start the logger timer.
+ */
+const defaultErrorListener = function(this: StoredErrorStream, err: Error): void {
+  this[errorGuard] = err;
+  this[timeoutGuard] = setTimeout((): void => {
+    logger.error(`No error listener was attached but error was thrown: ${err.message}`);
+  }, 1000);
+};
+
+let attachDefaultErrorListener: (this: StoredErrorStream, event: string) => void;
+
+/**
+ * Callback that is used when a new listener is attached to remove the current error-related fallback functions,
+ * or to emit an error if one was thrown in the meantime.
+ */
+const removeDefaultErrorListener = function(this: StoredErrorStream, event: string, listener: (err: Error) => void):
+void {
+  if (event === 'error') {
+    this.removeListener('error', defaultErrorListener);
+    this.removeListener('newListener', removeDefaultErrorListener);
+    this.on('removeListener', attachDefaultErrorListener);
+    if (this[timeoutGuard]) {
+      clearTimeout(this[timeoutGuard]!);
+    }
+    if (this[errorGuard]) {
+      setImmediate((): void => listener(this[errorGuard]!));
+    }
+  }
+};
+
+/**
+ * Callback that is used to make sure the error-related fallback functions are re-applied
+ * when all error listeners are removed.
+ */
+attachDefaultErrorListener = function(this: StoredErrorStream, event: string): void {
+  if (event === 'error' && this.listenerCount('error') === 0) {
+    this.on('error', defaultErrorListener);
+    this.on('newListener', removeDefaultErrorListener);
+    this.removeListener('removeListener', attachDefaultErrorListener);
+  }
+};
+
+/**
+ * Makes sure that listeners always receive the error event of a stream,
+ * even if it was thrown before the listener was attached.
+ * If the input is already guarded nothing will happen.
+ * @param stream - Stream that can potentially throw an error.
+ *
+ * @returns The wrapped stream.
+ */
+export const guardStream = <T extends NodeJS.EventEmitter>(stream: T): Guarded<T> => {
+  const guarded = stream as Guarded<T>;
+  if (guarded[guard]) {
+    return guarded;
+  }
+
+  guarded.on('error', defaultErrorListener);
+  guarded.on('newListener', removeDefaultErrorListener);
+
+  guarded[guard] = true;
+  return guarded;
+};

--- a/src/util/QuadUtil.ts
+++ b/src/util/QuadUtil.ts
@@ -4,6 +4,7 @@ import { DataFactory, StreamParser, StreamWriter } from 'n3';
 import type { Literal, NamedNode, Quad } from 'rdf-js';
 import streamifyArray from 'streamify-array';
 import { TEXT_TURTLE } from './ContentTypes';
+import type { Guarded } from './GuardedStream';
 import { pipeSafely } from './StreamUtil';
 
 /**
@@ -19,7 +20,7 @@ export const pushQuad =
  *
  * @returns The Readable object.
  */
-export const serializeQuads = (quads: Quad[]): Readable =>
+export const serializeQuads = (quads: Quad[]): Guarded<Readable> =>
   pipeSafely(streamifyArray(quads), new StreamWriter({ format: TEXT_TURTLE }));
 
 /**
@@ -28,5 +29,5 @@ export const serializeQuads = (quads: Quad[]): Readable =>
  *
  * @returns A promise containing the array of quads.
  */
-export const parseQuads = async(readable: Readable): Promise<Quad[]> =>
+export const parseQuads = async(readable: Guarded<Readable>): Promise<Quad[]> =>
   arrayifyStream(pipeSafely(readable, new StreamParser({ format: TEXT_TURTLE })));

--- a/test/integration/FullConfig.acl.test.ts
+++ b/test/integration/FullConfig.acl.test.ts
@@ -5,6 +5,7 @@ import { RepresentationMetadata } from '../../src/ldp/representation/Representat
 import { FileDataAccessor } from '../../src/storage/accessors/FileDataAccessor';
 import { InMemoryDataAccessor } from '../../src/storage/accessors/InMemoryDataAccessor';
 import { ExtensionBasedMapper } from '../../src/storage/mapping/ExtensionBasedMapper';
+import { guardStream } from '../../src/util/GuardedStream';
 import { ensureTrailingSlash } from '../../src/util/PathUtil';
 import { CONTENT_TYPE, LDP } from '../../src/util/UriConstants';
 import { AuthenticatedDataAccessorBasedConfig } from '../configs/AuthenticatedDataAccessorBasedConfig';
@@ -42,7 +43,7 @@ describe.each([ dataAccessorStore, inMemoryDataAccessorStore ])('A server using 
       // Use store instead of file access so tests also work for non-file backends
       await config.store.setRepresentation({ path: `${BASE}/permanent.txt` }, {
         binary: true,
-        data: createReadStream(join(__dirname, '../assets/permanent.txt')),
+        data: guardStream(createReadStream(join(__dirname, '../assets/permanent.txt'))),
         metadata: new RepresentationMetadata({ [CONTENT_TYPE]: 'text/plain' }),
       });
     });

--- a/test/integration/RepresentationConverter.test.ts
+++ b/test/integration/RepresentationConverter.test.ts
@@ -1,10 +1,9 @@
-import streamifyArray from 'streamify-array';
 import type { Representation } from '../../src/ldp/representation/Representation';
 import { RepresentationMetadata } from '../../src/ldp/representation/RepresentationMetadata';
 import { ChainedConverter } from '../../src/storage/conversion/ChainedConverter';
 import { QuadToRdfConverter } from '../../src/storage/conversion/QuadToRdfConverter';
 import { RdfToQuadConverter } from '../../src/storage/conversion/RdfToQuadConverter';
-import { readableToString } from '../../src/util/StreamUtil';
+import { guardedStreamFrom, readableToString } from '../../src/util/StreamUtil';
 import { CONTENT_TYPE } from '../../src/util/UriConstants';
 
 describe('A ChainedConverter', (): void => {
@@ -18,7 +17,9 @@ describe('A ChainedConverter', (): void => {
     const metadata = new RepresentationMetadata({ [CONTENT_TYPE]: 'application/ld+json' });
     const representation: Representation = {
       binary: true,
-      data: streamifyArray([ '{"@id": "http://test.com/s", "http://test.com/p": { "@id": "http://test.com/o" }}' ]),
+      data: guardedStreamFrom(
+        [ '{"@id": "http://test.com/s", "http://test.com/p": { "@id": "http://test.com/o" }}' ],
+      ),
       metadata,
     };
 
@@ -36,7 +37,7 @@ describe('A ChainedConverter', (): void => {
     const metadata = new RepresentationMetadata({ [CONTENT_TYPE]: 'text/turtle' });
     const representation: Representation = {
       binary: true,
-      data: streamifyArray([ '<http://test.com/s> <http://test.com/p> <http://test.com/o>.' ]),
+      data: guardedStreamFrom([ '<http://test.com/s> <http://test.com/p> <http://test.com/o>.' ]),
       metadata,
     };
 

--- a/test/unit/ldp/http/BasicResponseWriter.test.ts
+++ b/test/unit/ldp/http/BasicResponseWriter.test.ts
@@ -2,13 +2,13 @@ import { EventEmitter } from 'events';
 import { PassThrough } from 'stream';
 import type { MockResponse } from 'node-mocks-http';
 import { createResponse } from 'node-mocks-http';
-import streamifyArray from 'streamify-array';
 import { BasicResponseWriter } from '../../../../src/ldp/http/BasicResponseWriter';
 import type { MetadataWriter } from '../../../../src/ldp/http/metadata/MetadataWriter';
 import type { ResponseDescription } from '../../../../src/ldp/http/response/ResponseDescription';
 import { RepresentationMetadata } from '../../../../src/ldp/representation/RepresentationMetadata';
 import { INTERNAL_QUADS } from '../../../../src/util/ContentTypes';
 import { UnsupportedHttpError } from '../../../../src/util/errors/UnsupportedHttpError';
+import { guardedStreamFrom } from '../../../../src/util/StreamUtil';
 import { CONTENT_TYPE } from '../../../../src/util/UriConstants';
 import { StaticAsyncHandler } from '../../../util/StaticAsyncHandler';
 
@@ -42,7 +42,7 @@ describe('A BasicResponseWriter', (): void => {
   });
 
   it('responds with a body if the description has a body.', async(): Promise<void> => {
-    const data = streamifyArray([ '<http://test.com/s> <http://test.com/p> <http://test.com/o>.' ]);
+    const data = guardedStreamFrom([ '<http://test.com/s> <http://test.com/p> <http://test.com/o>.' ]);
     result = { statusCode: 201, data };
 
     const end = new Promise((resolve): void => {
@@ -69,7 +69,7 @@ describe('A BasicResponseWriter', (): void => {
   });
 
   it('can handle the data stream erroring.', async(): Promise<void> => {
-    const data = new PassThrough();
+    const data = guardedStreamFrom([]);
     data.read = (): any => {
       data.emit('error', new Error('bad data!'));
       return null;

--- a/test/unit/storage/accessors/InMemoryDataAccessor.test.ts
+++ b/test/unit/storage/accessors/InMemoryDataAccessor.test.ts
@@ -1,9 +1,10 @@
-import streamifyArray from 'streamify-array';
+import type { Readable } from 'stream';
 import { RepresentationMetadata } from '../../../../src/ldp/representation/RepresentationMetadata';
 import { InMemoryDataAccessor } from '../../../../src/storage/accessors/InMemoryDataAccessor';
 import { APPLICATION_OCTET_STREAM } from '../../../../src/util/ContentTypes';
 import { NotFoundHttpError } from '../../../../src/util/errors/NotFoundHttpError';
-import { readableToString } from '../../../../src/util/StreamUtil';
+import type { Guarded } from '../../../../src/util/GuardedStream';
+import { guardedStreamFrom, readableToString } from '../../../../src/util/StreamUtil';
 import { CONTENT_TYPE, LDP, RDF } from '../../../../src/util/UriConstants';
 import { toNamedNode } from '../../../../src/util/UriUtil';
 
@@ -11,11 +12,14 @@ describe('An InMemoryDataAccessor', (): void => {
   const base = 'http://test.com/';
   let accessor: InMemoryDataAccessor;
   let metadata: RepresentationMetadata;
+  let data: Guarded<Readable>;
 
   beforeEach(async(): Promise<void> => {
     accessor = new InMemoryDataAccessor(base);
 
     metadata = new RepresentationMetadata({ [CONTENT_TYPE]: APPLICATION_OCTET_STREAM });
+
+    data = guardedStreamFrom([ 'data' ]);
   });
 
   it('can only handle all data.', async(): Promise<void> => {
@@ -33,12 +37,11 @@ describe('An InMemoryDataAccessor', (): void => {
     });
 
     it('throws an error if part of the path matches a document.', async(): Promise<void> => {
-      await accessor.writeDocument({ path: `${base}resource` }, streamifyArray([ 'data' ]), metadata);
+      await accessor.writeDocument({ path: `${base}resource` }, data, metadata);
       await expect(accessor.getData({ path: `${base}resource/resource2` })).rejects.toThrow(new Error('Invalid path.'));
     });
 
     it('returns the corresponding data every time.', async(): Promise<void> => {
-      const data = streamifyArray([ 'data' ]);
       await accessor.writeDocument({ path: `${base}resource` }, data, metadata);
 
       // Run twice to make sure the data is stored correctly
@@ -53,12 +56,12 @@ describe('An InMemoryDataAccessor', (): void => {
     });
 
     it('errors when trying to access the parent of root.', async(): Promise<void> => {
-      await expect(accessor.writeDocument({ path: `${base}` }, streamifyArray([ 'data' ]), metadata))
+      await expect(accessor.writeDocument({ path: `${base}` }, data, metadata))
         .rejects.toThrow(new Error('Root container has no parent.'));
     });
 
     it('throws a 404 if the trailing slash does not match its type.', async(): Promise<void> => {
-      await accessor.writeDocument({ path: `${base}resource` }, streamifyArray([ 'data' ]), metadata);
+      await accessor.writeDocument({ path: `${base}resource` }, data, metadata);
       await expect(accessor.getMetadata({ path: `${base}resource/` })).rejects.toThrow(NotFoundHttpError);
       await accessor.writeContainer({ path: `${base}container/` }, metadata);
       await expect(accessor.getMetadata({ path: `${base}container` })).rejects.toThrow(NotFoundHttpError);
@@ -66,14 +69,14 @@ describe('An InMemoryDataAccessor', (): void => {
 
     it('returns empty metadata if there was none stored.', async(): Promise<void> => {
       metadata = new RepresentationMetadata();
-      await accessor.writeDocument({ path: `${base}resource` }, streamifyArray([ 'data' ]), metadata);
+      await accessor.writeDocument({ path: `${base}resource` }, data, metadata);
       metadata = await accessor.getMetadata({ path: `${base}resource` });
       expect(metadata.quads()).toHaveLength(0);
     });
 
     it('generates the containment metadata for a container.', async(): Promise<void> => {
       await accessor.writeContainer({ path: `${base}container/` }, metadata);
-      await accessor.writeDocument({ path: `${base}container/resource` }, streamifyArray([ 'data' ]), metadata);
+      await accessor.writeDocument({ path: `${base}container/resource` }, data, metadata);
       await accessor.writeContainer({ path: `${base}container/container2` }, metadata);
       metadata = await accessor.getMetadata({ path: `${base}container/` });
       expect(metadata.getAll(LDP.contains)).toEqualRdfTermArray(
@@ -83,7 +86,7 @@ describe('An InMemoryDataAccessor', (): void => {
 
     it('adds stored metadata when requesting document metadata.', async(): Promise<void> => {
       const inputMetadata = new RepresentationMetadata(`${base}resource`, { [RDF.type]: toNamedNode(LDP.Resource) });
-      await accessor.writeDocument({ path: `${base}resource` }, streamifyArray([ 'data' ]), inputMetadata);
+      await accessor.writeDocument({ path: `${base}resource` }, data, inputMetadata);
       metadata = await accessor.getMetadata({ path: `${base}resource` });
       expect(metadata.identifier.value).toBe(`${base}resource`);
       const quads = metadata.quads();
@@ -107,7 +110,7 @@ describe('An InMemoryDataAccessor', (): void => {
       await accessor.writeContainer({ path: `${base}container/` }, inputMetadata);
       const resourceMetadata = new RepresentationMetadata();
       await accessor.writeDocument(
-        { path: `${base}container/resource` }, streamifyArray([ 'data' ]), resourceMetadata,
+        { path: `${base}container/resource` }, data, resourceMetadata,
       );
 
       const newMetadata = new RepresentationMetadata(inputMetadata);
@@ -128,7 +131,7 @@ describe('An InMemoryDataAccessor', (): void => {
     });
 
     it('errors when writing to an invalid container path..', async(): Promise<void> => {
-      await accessor.writeDocument({ path: `${base}resource` }, streamifyArray([ 'data' ]), metadata);
+      await accessor.writeDocument({ path: `${base}resource` }, data, metadata);
 
       await expect(accessor.writeContainer({ path: `${base}resource/container` }, metadata))
         .rejects.toThrow(new Error('Invalid path.'));
@@ -141,7 +144,7 @@ describe('An InMemoryDataAccessor', (): void => {
     });
 
     it('removes the corresponding resource.', async(): Promise<void> => {
-      await accessor.writeDocument({ path: `${base}resource` }, streamifyArray([ 'data' ]), metadata);
+      await accessor.writeDocument({ path: `${base}resource` }, data, metadata);
       await accessor.writeContainer({ path: `${base}container/` }, metadata);
       await expect(accessor.deleteResource({ path: `${base}resource` })).resolves.toBeUndefined();
       await expect(accessor.deleteResource({ path: `${base}container/` })).resolves.toBeUndefined();

--- a/test/unit/util/GuardedStream.test.ts
+++ b/test/unit/util/GuardedStream.test.ts
@@ -1,0 +1,101 @@
+import { Readable } from 'stream';
+import { guardStream } from '../../../src/util/GuardedStream';
+import { readableToString } from '../../../src/util/StreamUtil';
+
+describe('GuardedStream', (): void => {
+  describe('#guardStream', (): void => {
+    it('has no effect if no error is thrown.', async(): Promise<void> => {
+      const stream = guardStream(Readable.from([ 'data' ]));
+      const listen = new Promise((resolve, reject): void => {
+        stream.on('end', resolve);
+        stream.on('error', reject);
+      });
+      await expect(readableToString(stream)).resolves.toBe('data');
+      await expect(listen).resolves.toBeUndefined();
+    });
+
+    it('returns the stream if it is already guarded.', async(): Promise<void> => {
+      const stream = guardStream(guardStream(Readable.from([ 'data' ])));
+      expect(stream.listenerCount('error')).toBe(1);
+      expect(stream.listenerCount('newListener')).toBe(1);
+      expect(stream.listenerCount('removeListener')).toBe(0);
+
+      const listen = new Promise((resolve, reject): void => {
+        stream.on('end', resolve);
+        stream.on('error', reject);
+      });
+      await expect(readableToString(stream)).resolves.toBe('data');
+      await expect(listen).resolves.toBeUndefined();
+    });
+
+    it('still emits errors when they happen.', async(): Promise<void> => {
+      let stream = Readable.from([ 'data' ]);
+      stream = guardStream(stream);
+      const listen = new Promise((resolve, reject): void => {
+        stream.on('end', resolve);
+        stream.on('error', reject);
+      });
+      stream.emit('error', new Error('error'));
+      await expect(listen).rejects.toThrow(new Error('error'));
+    });
+
+    it('emits old errors when new listeners are attached.', async(): Promise<void> => {
+      let stream = Readable.from([ 'data' ]);
+      stream = guardStream(stream);
+      stream.emit('error', new Error('error'));
+      const listen = new Promise((resolve, reject): void => {
+        stream.on('end', resolve);
+        stream.on('error', reject);
+      });
+      await expect(listen).rejects.toThrow(new Error('error'));
+    });
+
+    it('still works if error listeners get removed and added again.', async(): Promise<void> => {
+      let stream = Readable.from([ 'data' ]);
+      stream = guardStream(stream);
+
+      // Make sure no unneeded listeners stay attached
+      const errorCb = jest.fn();
+      const errorCb2 = jest.fn();
+      stream.on('error', errorCb);
+      stream.on('error', errorCb2);
+      expect(stream.listenerCount('error')).toBe(2);
+      expect(stream.listenerCount('newListener')).toBe(0);
+      expect(stream.listenerCount('removeListener')).toBe(1);
+      stream.removeListener('error', errorCb2);
+      expect(stream.listenerCount('error')).toBe(1);
+      expect(stream.listenerCount('newListener')).toBe(0);
+      expect(stream.listenerCount('removeListener')).toBe(1);
+      stream.removeListener('error', errorCb);
+      expect(stream.listenerCount('error')).toBe(1);
+      expect(stream.listenerCount('newListener')).toBe(1);
+      expect(stream.listenerCount('removeListener')).toBe(0);
+
+      stream.emit('error', new Error('error'));
+
+      const listen = new Promise((resolve, reject): void => {
+        stream.on('end', resolve);
+        stream.on('error', reject);
+      });
+      await expect(listen).rejects.toThrow(new Error('error'));
+    });
+
+    it('logs a warning if nobody listens to the error.', async(): Promise<void> => {
+      jest.useFakeTimers();
+
+      let stream = Readable.from([ 'data' ]);
+      stream = guardStream(stream);
+      stream.emit('error', new Error('error'));
+
+      jest.advanceTimersByTime(1000);
+
+      const listen = new Promise((resolve, reject): void => {
+        stream.on('end', resolve);
+        stream.on('error', reject);
+      });
+      await expect(listen).rejects.toThrow(new Error('error'));
+
+      // No idea how to access the logger with mocks unfortunately
+    });
+  });
+});

--- a/test/unit/util/StreamUtil.test.ts
+++ b/test/unit/util/StreamUtil.test.ts
@@ -1,6 +1,6 @@
 import { PassThrough } from 'stream';
 import streamifyArray from 'streamify-array';
-import { pipeSafely, readableToString } from '../../../src/util/StreamUtil';
+import { guardedStreamFrom, pipeSafely, readableToString } from '../../../src/util/StreamUtil';
 
 describe('StreamUtil', (): void => {
   describe('#readableToString', (): void => {
@@ -38,6 +38,13 @@ describe('StreamUtil', (): void => {
       const output = new PassThrough();
       const piped = pipeSafely(input, output, (): any => new Error('other error'));
       await expect(readableToString(piped)).rejects.toThrow(new Error('other error'));
+    });
+  });
+
+  describe('#guardedStreamFrom', (): void => {
+    it('converts data to a guarded stream.', async(): Promise<void> => {
+      const data = [ 'a', 'b' ];
+      await expect(readableToString(guardedStreamFrom(data))).resolves.toBe('ab');
     });
   });
 });

--- a/test/util/TestHelpers.ts
+++ b/test/util/TestHelpers.ts
@@ -2,12 +2,12 @@ import { EventEmitter } from 'events';
 import { promises as fs } from 'fs';
 import type { IncomingHttpHeaders } from 'http';
 import { join } from 'path';
+import { Readable } from 'stream';
 import * as url from 'url';
 import type { MockResponse } from 'node-mocks-http';
 import { createResponse } from 'node-mocks-http';
-import streamifyArray from 'streamify-array';
 import type { ResourceStore } from '../../index';
-import { RepresentationMetadata } from '../../index';
+import { guardedStreamFrom, RepresentationMetadata } from '../../index';
 import type { PermissionSet } from '../../src/ldp/permissions/PermissionSet';
 import type { HttpHandler } from '../../src/server/HttpHandler';
 import type { HttpRequest } from '../../src/server/HttpRequest';
@@ -52,7 +52,7 @@ export class AclTestHelper {
 
     const representation = {
       binary: true,
-      data: streamifyArray(acl),
+      data: guardedStreamFrom(acl),
       metadata: new RepresentationMetadata({ [CONTENT_TYPE]: 'text/turtle' }),
     };
 
@@ -86,7 +86,7 @@ export class FileTestHelper {
     headers: IncomingHttpHeaders,
     data: Buffer,
   ): Promise<MockResponse<any>> {
-    const request = streamifyArray([ data ]) as HttpRequest;
+    const request = Readable.from([ data ]) as HttpRequest;
 
     request.url = requestUrl.pathname;
     request.method = method;


### PR DESCRIPTION
This closes #317.

This is the other solution as mentioned in #326  (read that one first).

In this case a new utility function gets created which adds an error event listener to a stream to store that event. Then, if any new event listeners get added at a later point in time that stored event will be sent to the listener callback function just as if it happened at that point in time. This way Node.js buffering a stream and throwing an error before we attach a listener is not an issue. Buffering does not cause an "end" event to be fired early so we don't have to listen to that one in advance.

Similar to the monitor, a warning will be logged if an error event gets triggered but no listener gets added within a certain time.

This function should be called every time a new stream gets created to wrap it. From that point on that stream is "safe". I might have missed some basic streams such as `streamifyArray([ 'data' ])` since those should always be safe anyway. 

After spending way too much time to test if the logger actually emitted the warning I gave up on that as I have no idea how to correctly mock there to handle that.