### PR TITLE
Update componentsjs-generator to v1.5.0

### DIFF
--- a/componentsjs-generator-ignore-classes.json
+++ b/componentsjs-generator-ignore-classes.json
@@ -1,0 +1,4 @@
+[
+  "Error",
+  "EventEmitter"
+]

--- a/config/presets/ldp.json
+++ b/config/presets/ldp.json
@@ -4,22 +4,22 @@
     {
       "@id": "urn:solid-server:default:HttpHandler",
       "@type": "AuthenticatedLdpHandler",
-      "AuthenticatedLdpHandler:_requestParser": {
+      "AuthenticatedLdpHandler:_args_requestParser": {
         "@id": "urn:solid-server:default:RequestParser"
       },
-      "AuthenticatedLdpHandler:_credentialsExtractor": {
+      "AuthenticatedLdpHandler:_args_credentialsExtractor": {
         "@id": "urn:solid-server:default:CredentialsExtractor"
       },
-      "AuthenticatedLdpHandler:_permissionsExtractor": {
+      "AuthenticatedLdpHandler:_args_permissionsExtractor": {
         "@id": "urn:solid-server:default:PermissionsExtractor"
       },
-      "AuthenticatedLdpHandler:_authorizer": {
+      "AuthenticatedLdpHandler:_args_authorizer": {
         "@id": "urn:solid-server:default:AclAuthorizer"
       },
-      "AuthenticatedLdpHandler:_operationHandler": {
+      "AuthenticatedLdpHandler:_args_operationHandler": {
         "@id": "urn:solid-server:default:OperationHandler"
       },
-      "AuthenticatedLdpHandler:_responseWriter": {
+      "AuthenticatedLdpHandler:_args_responseWriter": {
         "@id": "urn:solid-server:default:ResponseWriter"
       }
     }

--- a/config/presets/ldp/request-parser.json
+++ b/config/presets/ldp/request-parser.json
@@ -4,16 +4,16 @@
     {
       "@id": "urn:solid-server:default:RequestParser",
       "@type": "BasicRequestParser",
-      "BasicRequestParser:_targetExtractor": {
+      "BasicRequestParser:_args_targetExtractor": {
         "@type": "BasicTargetExtractor"
       },
-      "BasicRequestParser:_preferenceParser": {
+      "BasicRequestParser:_args_preferenceParser": {
         "@type": "AcceptPreferenceParser"
       },
-      "BasicRequestParser:_metadataExtractor": {
+      "BasicRequestParser:_args_metadataExtractor": {
         "@id": "urn:solid-server:default:MetadataExtractor"
       },
-      "BasicRequestParser:_bodyParser": {
+      "BasicRequestParser:_args_bodyParser": {
         "@type": "FirstCompositeHandler",
         "FirstCompositeHandler:_handlers": [
           {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2469,20 +2469,6 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
-    "componentjs-generator": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/componentjs-generator/-/componentjs-generator-1.2.0.tgz",
-      "integrity": "sha512-WW0Z6NbL4S4Ue1ZFX4qYjlvsddvTx43sORnPj2TyvZ3o09nSwJVSZnv9pAupEBrlDUieM3DcIbl+EXwY5t+y/A==",
-      "dev": true,
-      "requires": {
-        "@types/lru-cache": "^5.1.0",
-        "@typescript-eslint/typescript-estree": "^4.0.0",
-        "comment-parser": "^0.7.6",
-        "jsonld-context-parser": "^2.0.2",
-        "lru-cache": "^6.0.0",
-        "minimist": "^1.2.5"
-      }
-    },
     "componentsjs": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-3.6.0.tgz",
@@ -2517,6 +2503,69 @@
           "version": "0.9.1",
           "resolved": "https://registry.npmjs.org/n3/-/n3-0.9.1.tgz",
           "integrity": "sha1-QwtUfVjcc4FAjEV4TdgFgXGQOTI="
+        }
+      }
+    },
+    "componentsjs-generator": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/componentsjs-generator/-/componentsjs-generator-1.5.0.tgz",
+      "integrity": "sha512-TDhf94YhnabfVE1ZfDFwUpE/lQOXOmAHNKNVQRohgs8euY+IhMtWtsDOgrJK0uknFMyMwzlXSqJqZ/2G9doVXw==",
+      "dev": true,
+      "requires": {
+        "@types/lru-cache": "^5.1.0",
+        "@typescript-eslint/typescript-estree": "^4.6.1",
+        "comment-parser": "^0.7.6",
+        "jsonld-context-parser": "^2.0.2",
+        "lru-cache": "^6.0.0",
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "@typescript-eslint/types": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.8.1.tgz",
+          "integrity": "sha512-ave2a18x2Y25q5K05K/U3JQIe2Av4+TNi/2YuzyaXLAsDx6UZkz1boZ7nR/N6Wwae2PpudTZmHFXqu7faXfHmA==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.8.1.tgz",
+          "integrity": "sha512-bJ6Fn/6tW2g7WIkCWh3QRlaSU7CdUUK52shx36/J7T5oTQzANvi6raoTsbwGM11+7eBbeem8hCCKbyvAc0X3sQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.8.1",
+            "@typescript-eslint/visitor-keys": "4.8.1",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-glob": "^4.0.1",
+            "lodash": "^4.17.15",
+            "semver": "^7.3.2",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.8.1.tgz",
+          "integrity": "sha512-3nrwXFdEYALQh/zW8rFwP4QltqsanCDz4CwWMPiIZmwlk9GlvBeueEIbq05SEq4ganqM0g9nh02xXgv5XI3PeQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.8.1",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/solid/community-server#readme",
   "scripts": {
     "build": "npm run build:ts && npm run build:components",
-    "build:components": "componentsjs-generator -s src",
+    "build:components": "componentsjs-generator -s src -i componentsjs-generator-ignore-classes.json",
     "build:ts": "tsc",
     "docker": "npm run docker:setup && npm run docker:start",
     "docker:clean": "./test/docker/docker-clean.sh",
@@ -112,7 +112,7 @@
     "@types/supertest": "^2.0.10",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
-    "componentjs-generator": "^1.2.0",
+    "componentsjs-generator": "^1.5.0",
     "eslint": "^7.9.0",
     "eslint-config-es": "^3.20.3",
     "eslint-import-resolver-typescript": "^2.3.0",


### PR DESCRIPTION
I upgraded but am now getting:

```
> @solid/community-server@0.2.0 build:components /Users/ruben/Documents/UGent/Solid/solid-community-server
> componentsjs-generator -s src

Failed to load super class HttpError of ConflictHttpError in /Users/ruben/Documents/UGent/Solid/solid-community-server/src/util/errors/ConflictHttpError:
Failed to load super class Error of HttpError in /Users/ruben/Documents/UGent/Solid/solid-community-server/src/util/errors/ConflictHttpError:
Could not load class Error from /Users/ruben/Documents/UGent/Solid/solid-community-server/src/util/errors/HttpError
```

So there seems to be a problem with built-in JavaScript classes.