### PR TITLE
Drop Node 10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10.x
           - 12.x
           - 14.x
     env:

--- a/src/ldp/http/SparqlUpdateBodyParser.ts
+++ b/src/ldp/http/SparqlUpdateBodyParser.ts
@@ -26,8 +26,6 @@ export class SparqlUpdateBodyParser extends BodyParser {
   }
 
   public async handle({ request, metadata }: BodyParserArgs): Promise<SparqlUpdatePatch> {
-    // Note that readableObjectMode is only defined starting from Node 12
-    // It is impossible to check if object mode is enabled in Node 10 (without accessing private variables)
     const options = { objectMode: request.readableObjectMode };
     const toAlgebraStream = pipeSafely(request, new PassThrough(options));
     const dataCopy = pipeSafely(request, new PassThrough(options));

--- a/src/storage/conversion/RdfToQuadConverter.ts
+++ b/src/storage/conversion/RdfToQuadConverter.ts
@@ -37,9 +37,7 @@ export class RdfToQuadConverter extends TypedRepresentationConverter {
       baseIRI,
     });
 
-    // Wrap the stream such that errors are transformed
-    // (Node 10 requires both writableObjectMode and readableObjectMode)
-    const pass = new PassThrough({ writableObjectMode: true, readableObjectMode: true });
+    const pass = new PassThrough({ objectMode: true });
     const data = pipeSafely(rawQuads, pass, (error): Error => new UnsupportedHttpError(error.message));
 
     return {

--- a/test/unit/ldp/http/SparqlUpdateBodyParser.test.ts
+++ b/test/unit/ldp/http/SparqlUpdateBodyParser.test.ts
@@ -1,4 +1,5 @@
 import { namedNode, quad } from '@rdfjs/data-model';
+import arrayifyStream from 'arrayify-stream';
 import { Algebra } from 'sparqlalgebrajs';
 import * as algebra from 'sparqlalgebrajs';
 import streamifyArray from 'streamify-array';
@@ -8,7 +9,6 @@ import { RepresentationMetadata } from '../../../../src/ldp/representation/Repre
 import type { HttpRequest } from '../../../../src/server/HttpRequest';
 import { UnsupportedHttpError } from '../../../../src/util/errors/UnsupportedHttpError';
 import { UnsupportedMediaTypeHttpError } from '../../../../src/util/errors/UnsupportedMediaTypeHttpError';
-import { readableToString } from '../../../../src/util/StreamUtil';
 
 describe('A SparqlUpdateBodyParser', (): void => {
   const bodyParser = new SparqlUpdateBodyParser();
@@ -56,9 +56,8 @@ describe('A SparqlUpdateBodyParser', (): void => {
     expect(result.binary).toBe(true);
     expect(result.metadata).toBe(input.metadata);
 
-    // Workaround for Node 10 not exposing objectMode
-    expect(await readableToString(result.data)).toEqual(
-      'DELETE DATA { <http://test.com/s> <http://test.com/p> <http://test.com/o> }',
+    expect(await arrayifyStream(result.data)).toEqual(
+      [ 'DELETE DATA { <http://test.com/s> <http://test.com/p> <http://test.com/o> }' ],
     );
   });
 });


### PR DESCRIPTION
We will need to drop Node 10, given that the crucial functionality of #358 transitively depends on `@panva/jose`, which only works on 12 and up.

Since Node 10 goes out of maintenance in April 2021, this seems acceptable.