### PR TITLE
Separate middleware from Express

### DIFF
--- a/config/config-default.json
+++ b/config/config-default.json
@@ -12,6 +12,7 @@
     "files-scs:config/presets/ldp/request-parser.json",
     "files-scs:config/presets/ldp/websockets.json",
     "files-scs:config/presets/logging.json",
+    "files-scs:config/presets/middleware.json",
     "files-scs:config/presets/representation-conversion.json",
     "files-scs:config/presets/setup.json",
     "files-scs:config/presets/storage/backend/storage-memory.json",

--- a/config/config-file.json
+++ b/config/config-file.json
@@ -12,6 +12,7 @@
     "files-scs:config/presets/ldp/request-parser.json",
     "files-scs:config/presets/ldp/websockets.json",
     "files-scs:config/presets/logging.json",
+    "files-scs:config/presets/middleware.json",
     "files-scs:config/presets/representation-conversion.json",
     "files-scs:config/presets/setup.json",
     "files-scs:config/presets/storage/backend/storage-filesystem.json",

--- a/config/config-path-routing.json
+++ b/config/config-path-routing.json
@@ -12,6 +12,7 @@
     "files-scs:config/presets/ldp/request-parser.json",
     "files-scs:config/presets/ldp/websockets.json",
     "files-scs:config/presets/logging.json",
+    "files-scs:config/presets/middleware.json",
     "files-scs:config/presets/representation-conversion.json",
     "files-scs:config/presets/setup.json",
     "files-scs:config/presets/storage/backend/storage-filesystem.json",

--- a/config/config-rdf-to-sparql-endpoint.json
+++ b/config/config-rdf-to-sparql-endpoint.json
@@ -12,6 +12,7 @@
     "files-scs:config/presets/ldp/request-parser.json",
     "files-scs:config/presets/ldp/websockets.json",
     "files-scs:config/presets/logging.json",
+    "files-scs:config/presets/middleware.json",
     "files-scs:config/presets/representation-conversion.json",
     "files-scs:config/presets/setup.json",
     "files-scs:config/presets/storage/backend/storage-filesystem.json",

--- a/config/config-sparql-endpoint.json
+++ b/config/config-sparql-endpoint.json
@@ -12,6 +12,7 @@
     "files-scs:config/presets/ldp/request-parser.json",
     "files-scs:config/presets/ldp/websockets.json",
     "files-scs:config/presets/logging.json",
+    "files-scs:config/presets/middleware.json",
     "files-scs:config/presets/representation-conversion.json",
     "files-scs:config/presets/setup.json",
     "files-scs:config/presets/storage/backend/storage-sparql-endpoint.json",

--- a/config/presets/http.json
+++ b/config/presets/http.json
@@ -17,6 +17,18 @@
       "ExpressHttpServerFactory:_handler": {
         "@id": "urn:solid-server:default:HttpHandler"
       }
+    },
+    {
+      "@id": "urn:solid-server:default:HttpHandler",
+      "@type": "AllVoidCompositeHandler",
+      "AllVoidCompositeHandler:_handlers": [
+        {
+          "@id": "urn:solid-server:default:Middleware"
+        },
+        {
+          "@id": "urn:solid-server:default:LdpHandler"
+        }
+      ]
     }
   ]
 }

--- a/config/presets/ldp.json
+++ b/config/presets/ldp.json
@@ -2,7 +2,7 @@
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
   "@graph": [
     {
-      "@id": "urn:solid-server:default:HttpHandler",
+      "@id": "urn:solid-server:default:LdpHandler",
       "@type": "AuthenticatedLdpHandler",
       "AuthenticatedLdpHandler:_args_requestParser": {
         "@id": "urn:solid-server:default:RequestParser"

--- a/config/presets/ldp/response-writer.json
+++ b/config/presets/ldp/response-writer.json
@@ -26,12 +26,6 @@
               "LinkRelMetadataWriter:_headerMap_value": "type"
             }
           ]
-        },
-        {
-          "@type": "WebSocketMetadataWriter",
-          "WebSocketMetadataWriter:_settings_port": {
-            "@id": "urn:solid-server:default:variable:port"
-          }
         }
       ]
     },

--- a/config/presets/middleware.json
+++ b/config/presets/middleware.json
@@ -6,7 +6,16 @@
       "@type": "AllVoidCompositeHandler",
       "AllVoidCompositeHandler:_handlers": [
         {
-          "@type": "CorsHandler"
+          "@type": "CorsHandler",
+          "CorsHandler:_options_methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE"
+          ]
         },
         {
           "@type": "HeaderHandler",

--- a/config/presets/middleware.json
+++ b/config/presets/middleware.json
@@ -15,6 +15,9 @@
             "PUT",
             "PATCH",
             "DELETE"
+          ],
+          "CorsHandler:_options_exposedHeaders": [
+            "Updates-Via"
           ]
         },
         {

--- a/config/presets/middleware.json
+++ b/config/presets/middleware.json
@@ -1,0 +1,17 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "@id": "urn:solid-server:default:Middleware",
+      "@type": "AllVoidCompositeHandler",
+      "AllVoidCompositeHandler:_handlers": [
+        {
+          "@type": "CorsHandler"
+        },
+        {
+          "@type": "HeaderHandler"
+        }
+      ]
+    }
+  ]
+}

--- a/config/presets/middleware.json
+++ b/config/presets/middleware.json
@@ -28,6 +28,12 @@
               "HeaderHandler:_headers_value": "Community Solid Server"
             }
           ]
+        },
+        {
+          "@type": "WebSocketAdvertiser",
+          "WebSocketAdvertiser:_settings_port": {
+            "@id": "urn:solid-server:default:variable:port"
+          }
         }
       ]
     }

--- a/config/presets/middleware.json
+++ b/config/presets/middleware.json
@@ -9,7 +9,13 @@
           "@type": "CorsHandler"
         },
         {
-          "@type": "HeaderHandler"
+          "@type": "HeaderHandler",
+          "HeaderHandler:_headers": [
+            {
+              "HeaderHandler:_headers_key": "X-Powered-By",
+              "HeaderHandler:_headers_value": "Community Solid Server"
+            }
+          ]
         }
       ]
     }

--- a/index.ts
+++ b/index.ts
@@ -26,7 +26,6 @@ export * from './src/ldp/http/metadata/MetadataExtractor';
 export * from './src/ldp/http/metadata/MetadataParser';
 export * from './src/ldp/http/metadata/MetadataWriter';
 export * from './src/ldp/http/metadata/SlugParser';
-export * from './src/ldp/http/metadata/WebSocketMetadataWriter';
 
 // LDP/HTTP/Response
 export * from './src/ldp/http/response/CreatedResponseDescription';
@@ -98,6 +97,7 @@ export * from './src/server/WebSocketHandler';
 // Server/Middleware
 export * from './src/server/middleware/CorsHandler';
 export * from './src/server/middleware/HeaderHandler';
+export * from './src/server/middleware/WebSocketAdvertiser';
 
 // Storage/Accessors
 export * from './src/storage/accessors/DataAccessor';

--- a/index.ts
+++ b/index.ts
@@ -95,6 +95,10 @@ export * from './src/server/HttpResponse';
 export * from './src/server/WebSocketServerFactory';
 export * from './src/server/WebSocketHandler';
 
+// Server/Middleware
+export * from './src/server/middleware/CorsHandler';
+export * from './src/server/middleware/HeaderHandler';
+
 // Storage/Accessors
 export * from './src/storage/accessors/DataAccessor';
 export * from './src/storage/accessors/FileDataAccessor';

--- a/src/ldp/http/metadata/LinkRelMetadataWriter.ts
+++ b/src/ldp/http/metadata/LinkRelMetadataWriter.ts
@@ -10,9 +10,7 @@ import { MetadataWriter } from './MetadataWriter';
 export class LinkRelMetadataWriter extends MetadataWriter {
   private readonly linkRelMap: Record<string, string>;
 
-  // Not supported by Components.js yet
-  // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
-  public constructor(linkRelMap: { [predicate: string]: string }) {
+  public constructor(linkRelMap: Record<string, string>) {
     super();
     this.linkRelMap = linkRelMap;
   }

--- a/src/ldp/http/metadata/MappedMetadataWriter.ts
+++ b/src/ldp/http/metadata/MappedMetadataWriter.ts
@@ -10,9 +10,7 @@ import { MetadataWriter } from './MetadataWriter';
 export class MappedMetadataWriter extends MetadataWriter {
   private readonly headerMap: Record<string, string>;
 
-  // Not supported by Components.js yet
-  // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
-  public constructor(headerMap: { [predicate: string]: string }) {
+  public constructor(headerMap: Record<string, string>) {
     super();
     this.headerMap = headerMap;
   }

--- a/src/server/middleware/CorsHandler.ts
+++ b/src/server/middleware/CorsHandler.ts
@@ -1,0 +1,26 @@
+import cors from 'cors';
+import type { RequestHandler } from 'express';
+import { HttpHandler } from '../HttpHandler';
+import type { HttpRequest } from '../HttpRequest';
+import type { HttpResponse } from '../HttpResponse';
+
+/**
+ * Handler that sets CORS options on the response.
+ */
+export class CorsHandler extends HttpHandler {
+  private readonly corsHandler: RequestHandler;
+
+  public constructor() {
+    super();
+    this.corsHandler = cors({
+      origin: (origin, callback): void => callback(null, (origin ?? '*') as any),
+      methods: [ 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE' ],
+    });
+  }
+
+  public async handle(input: { request: HttpRequest; response: HttpResponse }): Promise<void> {
+    return new Promise((resolve): void => {
+      this.corsHandler(input.request as any, input.response as any, (): void => resolve());
+    });
+  }
+}

--- a/src/server/middleware/CorsHandler.ts
+++ b/src/server/middleware/CorsHandler.ts
@@ -1,8 +1,25 @@
 import cors from 'cors';
+import type { CorsOptions } from 'cors';
 import type { RequestHandler } from 'express';
 import { HttpHandler } from '../HttpHandler';
 import type { HttpRequest } from '../HttpRequest';
 import type { HttpResponse } from '../HttpResponse';
+
+const defaultOptions: CorsOptions = {
+  origin: (origin: any, callback: any): void => callback(null, origin ?? '*'),
+};
+
+// Components.js does not support the full CorsOptions yet
+interface SimpleCorsOptions {
+  origin?: string;
+  methods?: string[];
+  allowedHeaders?: string[];
+  exposedHeaders?: string[];
+  credentials?: boolean;
+  maxAge?: number;
+  preflightContinue?: boolean;
+  optionsSuccessStatus?: number;
+}
 
 /**
  * Handler that sets CORS options on the response.
@@ -10,12 +27,9 @@ import type { HttpResponse } from '../HttpResponse';
 export class CorsHandler extends HttpHandler {
   private readonly corsHandler: RequestHandler;
 
-  public constructor() {
+  public constructor(options: SimpleCorsOptions = {}) {
     super();
-    this.corsHandler = cors({
-      origin: (origin, callback): void => callback(null, (origin ?? '*') as any),
-      methods: [ 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE' ],
-    });
+    this.corsHandler = cors({ ...defaultOptions, ...options });
   }
 
   public async handle(input: { request: HttpRequest; response: HttpResponse }): Promise<void> {

--- a/src/server/middleware/HeaderHandler.ts
+++ b/src/server/middleware/HeaderHandler.ts
@@ -7,9 +7,7 @@ import type { HttpResponse } from '../HttpResponse';
 export class HeaderHandler extends HttpHandler {
   private readonly headers: Record<string, string>;
 
-  // Not supported by Components.js yet
-  // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
-  public constructor(headers: { [header: string]: string } = {}) {
+  public constructor(headers: Record<string, string>) {
     super();
     this.headers = { ...headers };
   }

--- a/src/server/middleware/HeaderHandler.ts
+++ b/src/server/middleware/HeaderHandler.ts
@@ -7,11 +7,11 @@ import type { HttpResponse } from '../HttpResponse';
 export class HeaderHandler extends HttpHandler {
   private readonly headers: Record<string, string>;
 
-  public constructor() {
+  // Not supported by Components.js yet
+  // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
+  public constructor(headers: { [header: string]: string } = {}) {
     super();
-    this.headers = {
-      'x-powered-by': 'Community Solid Server',
-    };
+    this.headers = { ...headers };
   }
 
   public async handle({ response }: { response: HttpResponse }): Promise<void> {

--- a/src/server/middleware/HeaderHandler.ts
+++ b/src/server/middleware/HeaderHandler.ts
@@ -1,0 +1,22 @@
+import { HttpHandler } from '../HttpHandler';
+import type { HttpResponse } from '../HttpResponse';
+
+/**
+ * Handler that sets custom headers on the response.
+ */
+export class HeaderHandler extends HttpHandler {
+  private readonly headers: Record<string, string>;
+
+  public constructor() {
+    super();
+    this.headers = {
+      'x-powered-by': 'Community Solid Server',
+    };
+  }
+
+  public async handle({ response }: { response: HttpResponse }): Promise<void> {
+    for (const header of Object.keys(this.headers)) {
+      response.setHeader(header, this.headers[header]);
+    }
+  }
+}

--- a/src/server/middleware/WebSocketAdvertiser.ts
+++ b/src/server/middleware/WebSocketAdvertiser.ts
@@ -22,7 +22,7 @@ export class WebSocketAdvertiser extends HttpHandler {
     if (socketUrl.hostname !== hostname) {
       throw new Error(`Invalid hostname: ${hostname}`);
     }
-    this.socketUrl = socketUrl.href.slice(0, -1);
+    this.socketUrl = socketUrl.href;
   }
 
   public async handle({ response }: { response: HttpResponse }): Promise<void> {

--- a/src/server/middleware/WebSocketAdvertiser.ts
+++ b/src/server/middleware/WebSocketAdvertiser.ts
@@ -1,6 +1,6 @@
-import type { HttpResponse } from '../../../server/HttpResponse';
-import { addHeader } from '../../../util/HeaderUtil';
-import { MetadataWriter } from './MetadataWriter';
+import { addHeader } from '../../util/HeaderUtil';
+import { HttpHandler } from '../HttpHandler';
+import type { HttpResponse } from '../HttpResponse';
 
 interface WebSocketSettings {
   hostname?: string;
@@ -9,9 +9,9 @@ interface WebSocketSettings {
 }
 
 /**
- * A {@link MetadataWriter} that advertises a WebSocket through the Updates-Via header.
+ * Handler that advertises a WebSocket through the Updates-Via header.
  */
-export class WebSocketMetadataWriter extends MetadataWriter {
+export class WebSocketAdvertiser extends HttpHandler {
   private readonly socketUrl: string;
 
   public constructor(settings: WebSocketSettings = {}) {

--- a/src/storage/routing/RegexRouterRule.ts
+++ b/src/storage/routing/RegexRouterRule.ts
@@ -21,8 +21,7 @@ export class RegexRouterRule extends RouterRule {
   /**
    * The keys of the `storeMap` will be converted into actual RegExp objects that will be used for testing.
    */
-  // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
-  public constructor(base: string, storeMap: { [ regex: string ]: ResourceStore }) {
+  public constructor(base: string, storeMap: Record<string, ResourceStore>) {
     super();
     this.base = trimTrailingSlashes(base);
     this.regexes = new Map(Object.keys(storeMap).map((regex): [ RegExp, ResourceStore ] =>

--- a/test/configs/middleware.json
+++ b/test/configs/middleware.json
@@ -2,7 +2,8 @@
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
   "import": [
     "files-scs:config/presets/http.json",
-    "files-scs:config/presets/middleware.json"
+    "files-scs:config/presets/middleware.json",
+    "files-scs:config/presets/cli-params.json"
   ],
   "@graph": [
     {

--- a/test/configs/middleware.json
+++ b/test/configs/middleware.json
@@ -1,0 +1,13 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
+  "import": [
+    "files-scs:config/presets/http.json",
+    "files-scs:config/presets/middleware.json"
+  ],
+  "@graph": [
+    {
+      "@id": "urn:solid-server:default:LdpHandler",
+      "@type": "Variable"
+    }
+  ]
+}

--- a/test/configs/websockets.json
+++ b/test/configs/websockets.json
@@ -9,6 +9,7 @@
     "files-scs:config/presets/ldp/response-writer.json",
     "files-scs:config/presets/ldp/request-parser.json",
     "files-scs:config/presets/ldp/websockets.json",
+    "files-scs:config/presets/middleware.json",
     "files-scs:config/presets/representation-conversion.json",
     "files-scs:config/presets/storage/backend/storage-memory.json",
     "files-scs:config/presets/storage/routing/no-routing.json",
@@ -17,7 +18,7 @@
   ],
   "@graph": [
     {
-      "@id": "urn:solid-server:default:HttpHandler",
+      "@id": "urn:solid-server:default:LdpHandler",
       "@type": "AuthenticatedLdpHandler",
       "AuthenticatedLdpHandler:_args_requestParser": {
         "@id": "urn:solid-server:default:RequestParser"

--- a/test/integration/Middleware.test.ts
+++ b/test/integration/Middleware.test.ts
@@ -22,6 +22,7 @@ describe('An Express server with middleware', (): void => {
     const factory = await instantiateFromConfig(
       'urn:solid-server:default:ExpressHttpServerFactory', 'middleware.json', {
         'urn:solid-server:default:LdpHandler': new SimpleHttpHandler(),
+        'urn:solid-server:default:variable:port': port,
       },
     ) as ExpressHttpServerFactory;
     server = factory.startServer(port);

--- a/test/integration/Middleware.test.ts
+++ b/test/integration/Middleware.test.ts
@@ -1,0 +1,69 @@
+import type { Server } from 'http';
+import request from 'supertest';
+import type { ExpressHttpServerFactory } from '../../src/server/ExpressHttpServerFactory';
+import { HttpHandler } from '../../src/server/HttpHandler';
+import type { HttpRequest } from '../../src/server/HttpRequest';
+import type { HttpResponse } from '../../src/server/HttpResponse';
+import { instantiateFromConfig } from '../configs/Util';
+
+const port = 6002;
+
+class SimpleHttpHandler extends HttpHandler {
+  public async handle(input: { request: HttpRequest; response: HttpResponse }): Promise<void> {
+    input.response.writeHead(200);
+    input.response.end('Hello World');
+  }
+}
+
+describe('An Express server with middleware', (): void => {
+  let server: Server;
+
+  beforeAll(async(): Promise<void> => {
+    const factory = await instantiateFromConfig(
+      'urn:solid-server:default:ExpressHttpServerFactory', 'middleware.json', {
+        'urn:solid-server:default:LdpHandler': new SimpleHttpHandler(),
+      },
+    ) as ExpressHttpServerFactory;
+    server = factory.startServer(port);
+  });
+
+  afterEach(async(): Promise<void> => {
+    server.close();
+  });
+
+  it('sends server identification in the X-Powered-By header.', async(): Promise<void> => {
+    const res = await request(server).get('/');
+    expect(res.header).toEqual(expect.objectContaining({
+      'x-powered-by': 'Community Solid Server',
+    }));
+  });
+
+  it('returns CORS headers for an OPTIONS request.', async(): Promise<void> => {
+    const res = await request(server)
+      .options('/')
+      .set('Access-Control-Request-Headers', 'content-type')
+      .set('Access-Control-Request-Method', 'POST')
+      .set('Host', 'test.com')
+      .expect(204);
+    expect(res.header).toEqual(expect.objectContaining({
+      'access-control-allow-origin': '*',
+      'access-control-allow-headers': 'content-type',
+    }));
+    const corsMethods = res.header['access-control-allow-methods'].split(',')
+      .map((method: string): string => method.trim());
+    const allowedMethods = [ 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE' ];
+    expect(corsMethods).toEqual(expect.arrayContaining(allowedMethods));
+    expect(corsMethods).toHaveLength(allowedMethods.length);
+  });
+
+  it('specifies CORS origin header if an origin was supplied.', async(): Promise<void> => {
+    const res = await request(server).get('/').set('origin', 'test.com').expect(200);
+    expect(res.header).toEqual(expect.objectContaining({ 'access-control-allow-origin': 'test.com' }));
+  });
+
+  it('sends incoming requests to the handler.', async(): Promise<void> => {
+    const response = request(server).get('/').set('Host', 'test.com');
+    expect(response).toBeDefined();
+    await response.expect(200).expect('Hello World');
+  });
+});

--- a/test/integration/WebSocketsProtocol.test.ts
+++ b/test/integration/WebSocketsProtocol.test.ts
@@ -33,7 +33,7 @@ describe('A server with the Solid WebSockets API', (): void => {
 
   it('sets the Updates-Via header.', async(): Promise<void> => {
     const response = await fetch(baseUrl);
-    expect(response.headers.get('Updates-Via')).toBe(`ws://localhost:${port}`);
+    expect(response.headers.get('Updates-Via')).toBe(`ws://localhost:${port}/`);
   });
 
   it('exposes the Updates-Via header via CORS.', async(): Promise<void> => {

--- a/test/integration/WebSocketsProtocol.test.ts
+++ b/test/integration/WebSocketsProtocol.test.ts
@@ -36,6 +36,12 @@ describe('A server with the Solid WebSockets API', (): void => {
     expect(response.headers.get('Updates-Via')).toBe(`ws://localhost:${port}`);
   });
 
+  it('exposes the Updates-Via header via CORS.', async(): Promise<void> => {
+    const response = await fetch(baseUrl);
+    expect(response.headers.get('Access-Control-Expose-Headers')!.split(','))
+      .toContain('Updates-Via');
+  });
+
   describe('when a WebSocket client connects', (): void => {
     let client: WebSocket;
     const messages = new Array<string>();

--- a/test/unit/server/ExpressHttpServerFactory.test.ts
+++ b/test/unit/server/ExpressHttpServerFactory.test.ts
@@ -42,42 +42,11 @@ describe('ExpressHttpServerFactory', (): void => {
   });
 
   afterEach(async(): Promise<void> => {
-    // Close server
     server.close();
   });
 
   afterAll(async(): Promise<void> => {
     mock.mockReset();
-  });
-
-  it('sends server identification in the X-Powered-By header.', async(): Promise<void> => {
-    const res = await request(server).get('/');
-    expect(res.header).toEqual(expect.objectContaining({
-      'x-powered-by': 'Community Solid Server',
-    }));
-  });
-
-  it('returns CORS headers for an OPTIONS request.', async(): Promise<void> => {
-    const res = await request(server)
-      .options('/')
-      .set('Access-Control-Request-Headers', 'content-type')
-      .set('Access-Control-Request-Method', 'POST')
-      .set('Host', 'test.com')
-      .expect(204);
-    expect(res.header).toEqual(expect.objectContaining({
-      'access-control-allow-origin': '*',
-      'access-control-allow-headers': 'content-type',
-    }));
-    const corsMethods = res.header['access-control-allow-methods'].split(',')
-      .map((method: string): string => method.trim());
-    const allowedMethods = [ 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE' ];
-    expect(corsMethods).toEqual(expect.arrayContaining(allowedMethods));
-    expect(corsMethods).toHaveLength(allowedMethods.length);
-  });
-
-  it('specifies CORS origin header if an origin was supplied.', async(): Promise<void> => {
-    const res = await request(server).get('/').set('origin', 'test.com').expect(200);
-    expect(res.header).toEqual(expect.objectContaining({ 'access-control-allow-origin': 'test.com' }));
   });
 
   it('sends incoming requests to the handler.', async(): Promise<void> => {

--- a/test/unit/server/middleware/CorsHandler.test.ts
+++ b/test/unit/server/middleware/CorsHandler.test.ts
@@ -1,0 +1,33 @@
+import { createRequest, createResponse } from 'node-mocks-http';
+import { CorsHandler } from '../../../../src/server/middleware/CorsHandler';
+import { guardStream } from '../../../../src/util/GuardedStream';
+
+describe('a CorsHandler', (): void => {
+  let handler: CorsHandler;
+
+  beforeAll(async(): Promise<void> => {
+    handler = new CorsHandler();
+  });
+
+  it('returns CORS headers.', async(): Promise<void> => {
+    const request = guardStream(createRequest());
+    const response = createResponse();
+    await handler.handleSafe({ request, response });
+    expect(response.getHeaders()).toEqual(expect.objectContaining({
+      'access-control-allow-origin': '*',
+    }));
+  });
+
+  it('echoes the origin when specified.', async(): Promise<void> => {
+    const request = guardStream(createRequest({
+      headers: {
+        origin: 'example.org',
+      },
+    }));
+    const response = createResponse();
+    await handler.handleSafe({ request, response });
+    expect(response.getHeaders()).toEqual(expect.objectContaining({
+      'access-control-allow-origin': 'example.org',
+    }));
+  });
+});

--- a/test/unit/server/middleware/CorsHandler.test.ts
+++ b/test/unit/server/middleware/CorsHandler.test.ts
@@ -3,22 +3,21 @@ import { CorsHandler } from '../../../../src/server/middleware/CorsHandler';
 import { guardStream } from '../../../../src/util/GuardedStream';
 
 describe('a CorsHandler', (): void => {
-  let handler: CorsHandler;
+  it('sets regular CORS headers.', async(): Promise<void> => {
+    const handler = new CorsHandler();
 
-  beforeAll(async(): Promise<void> => {
-    handler = new CorsHandler();
-  });
-
-  it('returns CORS headers.', async(): Promise<void> => {
     const request = guardStream(createRequest());
     const response = createResponse();
     await handler.handleSafe({ request, response });
+
     expect(response.getHeaders()).toEqual(expect.objectContaining({
       'access-control-allow-origin': '*',
     }));
   });
 
   it('echoes the origin when specified.', async(): Promise<void> => {
+    const handler = new CorsHandler();
+
     const request = guardStream(createRequest({
       headers: {
         origin: 'example.org',
@@ -26,8 +25,23 @@ describe('a CorsHandler', (): void => {
     }));
     const response = createResponse();
     await handler.handleSafe({ request, response });
+
     expect(response.getHeaders()).toEqual(expect.objectContaining({
       'access-control-allow-origin': 'example.org',
+    }));
+  });
+
+  it('supports customizations.', async(): Promise<void> => {
+    const handler = new CorsHandler({
+      exposedHeaders: [ 'Custom-Header' ],
+    });
+
+    const request = guardStream(createRequest());
+    const response = createResponse();
+    await handler.handleSafe({ request, response });
+
+    expect(response.getHeaders()).toEqual(expect.objectContaining({
+      'access-control-expose-headers': 'Custom-Header',
     }));
   });
 });

--- a/test/unit/server/middleware/HeaderHandler.test.ts
+++ b/test/unit/server/middleware/HeaderHandler.test.ts
@@ -3,18 +3,24 @@ import { HeaderHandler } from '../../../../src/server/middleware/HeaderHandler';
 import { guardStream } from '../../../../src/util/GuardedStream';
 
 describe('a HeaderHandler', (): void => {
-  let handler: HeaderHandler;
+  it('adds no headers when none are configured.', async(): Promise<void> => {
+    const handler = new HeaderHandler();
 
-  beforeAll(async(): Promise<void> => {
-    handler = new HeaderHandler();
-  });
-
-  it('returns an X-Powered-By header.', async(): Promise<void> => {
     const request = guardStream(createRequest());
     const response = createResponse();
     await handler.handleSafe({ request, response });
-    expect(response.getHeaders()).toEqual(expect.objectContaining({
-      'x-powered-by': 'Community Solid Server',
-    }));
+
+    expect(response.getHeaders()).toEqual({});
+  });
+
+  it('adds all configured headers.', async(): Promise<void> => {
+    const headers = { custom: 'Custom', other: 'Other' };
+    const handler = new HeaderHandler(headers);
+
+    const request = guardStream(createRequest());
+    const response = createResponse();
+    await handler.handleSafe({ request, response });
+
+    expect(response.getHeaders()).toEqual(expect.objectContaining(headers));
   });
 });

--- a/test/unit/server/middleware/HeaderHandler.test.ts
+++ b/test/unit/server/middleware/HeaderHandler.test.ts
@@ -3,16 +3,6 @@ import { HeaderHandler } from '../../../../src/server/middleware/HeaderHandler';
 import { guardStream } from '../../../../src/util/GuardedStream';
 
 describe('a HeaderHandler', (): void => {
-  it('adds no headers when none are configured.', async(): Promise<void> => {
-    const handler = new HeaderHandler();
-
-    const request = guardStream(createRequest());
-    const response = createResponse();
-    await handler.handleSafe({ request, response });
-
-    expect(response.getHeaders()).toEqual({});
-  });
-
   it('adds all configured headers.', async(): Promise<void> => {
     const headers = { custom: 'Custom', other: 'Other' };
     const handler = new HeaderHandler(headers);

--- a/test/unit/server/middleware/HeaderHandler.test.ts
+++ b/test/unit/server/middleware/HeaderHandler.test.ts
@@ -1,0 +1,20 @@
+import { createRequest, createResponse } from 'node-mocks-http';
+import { HeaderHandler } from '../../../../src/server/middleware/HeaderHandler';
+import { guardStream } from '../../../../src/util/GuardedStream';
+
+describe('a HeaderHandler', (): void => {
+  let handler: HeaderHandler;
+
+  beforeAll(async(): Promise<void> => {
+    handler = new HeaderHandler();
+  });
+
+  it('returns an X-Powered-By header.', async(): Promise<void> => {
+    const request = guardStream(createRequest());
+    const response = createResponse();
+    await handler.handleSafe({ request, response });
+    expect(response.getHeaders()).toEqual(expect.objectContaining({
+      'x-powered-by': 'Community Solid Server',
+    }));
+  });
+});

--- a/test/unit/server/middleware/WebSocketAdvertiser.test.ts
+++ b/test/unit/server/middleware/WebSocketAdvertiser.test.ts
@@ -6,28 +6,28 @@ describe('A WebSocketAdvertiser', (): void => {
     const writer = new WebSocketAdvertiser();
     const response = createResponse();
     await writer.handle({ response } as any);
-    expect(response.getHeaders()).toEqual({ 'updates-via': 'ws://localhost' });
+    expect(response.getHeaders()).toEqual({ 'updates-via': 'ws://localhost/' });
   });
 
   it('writes an HTTP WebSocket with port 80.', async(): Promise<void> => {
     const writer = new WebSocketAdvertiser({ hostname: 'test.example', port: 80, protocol: 'http' });
     const response = createResponse();
     await writer.handle({ response } as any);
-    expect(response.getHeaders()).toEqual({ 'updates-via': 'ws://test.example' });
+    expect(response.getHeaders()).toEqual({ 'updates-via': 'ws://test.example/' });
   });
 
   it('writes an HTTP WebSocket with port 3000.', async(): Promise<void> => {
     const writer = new WebSocketAdvertiser({ hostname: 'test.example', port: 3000, protocol: 'http' });
     const response = createResponse();
     await writer.handle({ response } as any);
-    expect(response.getHeaders()).toEqual({ 'updates-via': 'ws://test.example:3000' });
+    expect(response.getHeaders()).toEqual({ 'updates-via': 'ws://test.example:3000/' });
   });
 
   it('writes an HTTPS WebSocket with port 443.', async(): Promise<void> => {
     const writer = new WebSocketAdvertiser({ hostname: 'test.example', port: 443, protocol: 'https' });
     const response = createResponse();
     await writer.handle({ response } as any);
-    expect(response.getHeaders()).toEqual({ 'updates-via': 'wss://test.example' });
+    expect(response.getHeaders()).toEqual({ 'updates-via': 'wss://test.example/' });
   });
 
   it('rejects an invalid hostname.', (): void => {

--- a/test/unit/server/middleware/WebSocketAdvertiser.test.ts
+++ b/test/unit/server/middleware/WebSocketAdvertiser.test.ts
@@ -1,37 +1,37 @@
 import { createResponse } from 'node-mocks-http';
-import { WebSocketMetadataWriter } from '../../../../../src/ldp/http/metadata/WebSocketMetadataWriter';
+import { WebSocketAdvertiser } from '../../../../src/server/middleware/WebSocketAdvertiser';
 
-describe('A WebSocketMetadataWriter', (): void => {
+describe('A WebSocketAdvertiser', (): void => {
   it('writes a default HTTP WebSocket.', async(): Promise<void> => {
-    const writer = new WebSocketMetadataWriter();
+    const writer = new WebSocketAdvertiser();
     const response = createResponse();
     await writer.handle({ response } as any);
     expect(response.getHeaders()).toEqual({ 'updates-via': 'ws://localhost' });
   });
 
   it('writes an HTTP WebSocket with port 80.', async(): Promise<void> => {
-    const writer = new WebSocketMetadataWriter({ hostname: 'test.example', port: 80, protocol: 'http' });
+    const writer = new WebSocketAdvertiser({ hostname: 'test.example', port: 80, protocol: 'http' });
     const response = createResponse();
     await writer.handle({ response } as any);
     expect(response.getHeaders()).toEqual({ 'updates-via': 'ws://test.example' });
   });
 
   it('writes an HTTP WebSocket with port 3000.', async(): Promise<void> => {
-    const writer = new WebSocketMetadataWriter({ hostname: 'test.example', port: 3000, protocol: 'http' });
+    const writer = new WebSocketAdvertiser({ hostname: 'test.example', port: 3000, protocol: 'http' });
     const response = createResponse();
     await writer.handle({ response } as any);
     expect(response.getHeaders()).toEqual({ 'updates-via': 'ws://test.example:3000' });
   });
 
   it('writes an HTTPS WebSocket with port 443.', async(): Promise<void> => {
-    const writer = new WebSocketMetadataWriter({ hostname: 'test.example', port: 443, protocol: 'https' });
+    const writer = new WebSocketAdvertiser({ hostname: 'test.example', port: 443, protocol: 'https' });
     const response = createResponse();
     await writer.handle({ response } as any);
     expect(response.getHeaders()).toEqual({ 'updates-via': 'wss://test.example' });
   });
 
   it('rejects an invalid hostname.', (): void => {
-    expect((): any => new WebSocketMetadataWriter({ hostname: 'test.example/invalid' }))
+    expect((): any => new WebSocketAdvertiser({ hostname: 'test.example/invalid' }))
       .toThrow('Invalid hostname: test.example/invalid');
   });
 });


### PR DESCRIPTION
CORS and other middleware is currently hardwired inside of the Express server.
This makes it hard to configure them.

This PR makes each piece of middleware a separate component that can be configured with Components.js.

Additionally, this PR adjusts some of that configuration.

Closes https://github.com/solid/community-server/issues/27