### PR TITLE
Support the Forwarded header

### DIFF
--- a/src/ldp/http/BasicTargetExtractor.ts
+++ b/src/ldp/http/BasicTargetExtractor.ts
@@ -1,6 +1,6 @@
 import type { TLSSocket } from 'tls';
-import { getLoggerFor } from '../../logging/LogUtil';
 import type { HttpRequest } from '../../server/HttpRequest';
+import { parseForwarded } from '../../util/HeaderUtil';
 import { toCanonicalUriPath } from '../../util/PathUtil';
 import type { ResourceIdentifier } from '../representation/ResourceIdentifier';
 import { TargetExtractor } from './TargetExtractor';
@@ -11,28 +11,35 @@ import { TargetExtractor } from './TargetExtractor';
  * TODO: input requires more extensive cleaning/parsing based on headers (see #22).
  */
 export class BasicTargetExtractor extends TargetExtractor {
-  protected readonly logger = getLoggerFor(this);
-
-  public async handle({ url, headers: { host }, connection }: HttpRequest): Promise<ResourceIdentifier> {
+  public async handle({ url, connection, headers }: HttpRequest): Promise<ResourceIdentifier> {
     if (!url) {
-      this.logger.error('The request has no URL');
       throw new Error('Missing URL');
     }
+
+    // Extract host and protocol (possibly overridden by the Forwarded header)
+    let { host } = headers;
+    let protocol = (connection as TLSSocket)?.encrypted ? 'https' : 'http';
+    if (headers.forwarded) {
+      const forwarded = parseForwarded(headers.forwarded);
+      if (forwarded.host) {
+        ({ host } = forwarded);
+      }
+      if (forwarded.proto) {
+        ({ proto: protocol } = forwarded);
+      }
+    }
+
+    // Perform a sanity check on the host
     if (!host) {
-      this.logger.error('The request has no Host header');
       throw new Error('Missing Host header');
     }
     if (/[/\\*]/u.test(host)) {
       throw new Error(`The request has an invalid Host header: ${host}`);
     }
 
-    const isHttps = (connection as TLSSocket)?.encrypted;
-    this.logger.debug(`Request is using HTTPS: ${isHttps}`);
-
     // URL object applies punycode encoding to domain
-    const base = `http${isHttps ? 's' : ''}://${host}`;
+    const base = `${protocol}://${host}`;
     const path = new URL(toCanonicalUriPath(url), base).href;
-
     return { path };
   }
 }

--- a/src/util/HeaderUtil.ts
+++ b/src/util/HeaderUtil.ts
@@ -378,3 +378,37 @@ export const addHeader = (response: HttpResponse, name: string, value: string | 
   }
   response.setHeader(name, allValues.length === 1 ? allValues[0] : allValues);
 };
+
+/**
+ * The Forwarded header from RFC7239
+ */
+export interface Forwarded {
+  /** The user-agent facing interface of the proxy */
+  by?: string;
+  /** The node making the request to the proxy */
+  for?: string;
+  /** The host request header field as received by the proxy */
+  host?: string;
+  /** The protocol used to make the request */
+  proto?: string;
+}
+
+/**
+ * Parses a Forwarded header value.
+ *
+ * @param value - The Forwarded header value.
+ *
+ * @returns The parsed Forwarded header.
+ */
+export const parseForwarded = (value = ''): Forwarded => {
+  const forwarded: Record<string, string> = {};
+  if (value) {
+    for (const pair of value.replace(/\s*,.*$/u, '').split(';')) {
+      const components = /^(by|for|host|proto)=(.+)$/u.exec(pair);
+      if (components) {
+        forwarded[components[1]] = components[2];
+      }
+    }
+  }
+  return forwarded;
+};

--- a/test/unit/ldp/http/BasicTargetExtractor.test.ts
+++ b/test/unit/ldp/http/BasicTargetExtractor.test.ts
@@ -51,4 +51,22 @@ describe('A BasicTargetExtractor', (): void => {
     await expect(extractor.handle({ url: '/', headers: { host: '點看' }} as any))
       .resolves.toEqual({ path: 'http://xn--c1yn36f/' });
   });
+
+  it('ignores an irrelevant Forwarded header.', async(): Promise<void> => {
+    const headers = {
+      host: 'test.com',
+      forwarded: 'by=203.0.113.60',
+    };
+    await expect(extractor.handle({ url: '/foo/bar', headers } as any))
+      .resolves.toEqual({ path: 'http://test.com/foo/bar' });
+  });
+
+  it('takes the Forwarded header into account.', async(): Promise<void> => {
+    const headers = {
+      host: 'test.com',
+      forwarded: 'proto=https;host=pod.example',
+    };
+    await expect(extractor.handle({ url: '/foo/bar', headers } as any))
+      .resolves.toEqual({ path: 'https://pod.example/foo/bar' });
+  });
 });

--- a/test/unit/util/HeaderUtil.test.ts
+++ b/test/unit/util/HeaderUtil.test.ts
@@ -5,6 +5,7 @@ import {
   parseAcceptCharset,
   parseAcceptEncoding,
   parseAcceptLanguage,
+  parseForwarded,
 } from '../../../src/util/HeaderUtil';
 
 describe('HeaderUtil', (): void => {
@@ -164,6 +165,37 @@ describe('HeaderUtil', (): void => {
       response.setHeader('names', [ 'oldValue1', 'oldValue2' ]);
       expect(addHeader(response, 'names', [ 'value1', 'values2' ])).toBeUndefined();
       expect(response.getHeader('names')).toEqual([ 'oldValue1', 'oldValue2', 'value1', 'values2' ]);
+    });
+  });
+
+  describe('parseForwarded', (): void => {
+    it('parses an undefined value.', (): void => {
+      expect(parseForwarded()).toEqual({});
+    });
+
+    it('parses an empty string.', (): void => {
+      expect(parseForwarded('')).toEqual({});
+    });
+
+    it('parses a Forwarded header value.', (): void => {
+      expect(parseForwarded('for=192.0.2.60;proto=http;by=203.0.113.43;host=example.org')).toEqual({
+        by: '203.0.113.43',
+        for: '192.0.2.60',
+        host: 'example.org',
+        proto: 'http',
+      });
+    });
+
+    it('skips empty fields.', (): void => {
+      expect(parseForwarded('for=192.0.2.60;proto=;by=;host=')).toEqual({
+        for: '192.0.2.60',
+      });
+    });
+
+    it('takes only the first value into account.', (): void => {
+      expect(parseForwarded('host=pod.example, for=192.0.2.43, host=other')).toEqual({
+        host: 'pod.example',
+      });
     });
   });
 });


### PR DESCRIPTION
Required when servers are behind a reverse proxy.

Closes https://github.com/solid/community-server/issues/22