### PR TITLE
Re-introduce ContainerManager

### DIFF
--- a/config/presets/acl.json
+++ b/config/presets/acl.json
@@ -13,6 +13,9 @@
       },
       "WebAclAuthorizer:_resourceStore": {
         "@id": "urn:solid-server:default:ResourceStore"
+      },
+      "WebAclAuthorizer:_identifierStrategy": {
+        "@id": "urn:solid-server:default:IdentifierStrategy"
       }
     }
   ]

--- a/config/presets/storage-wrapper.json
+++ b/config/presets/storage-wrapper.json
@@ -6,6 +6,17 @@
       "@type": "MonitoringStore",
       "MonitoringStore:_source": {
         "@id": "urn:solid-server:default:ResourceStore_Patching"
+      },
+      "MonitoringStore:_identifierStrategy": {
+        "@id": "urn:solid-server:default:IdentifierStrategy"
+      }
+    },
+
+    {
+      "@id": "urn:solid-server:default:IdentifierStrategy",
+      "@type": "SingleRootIdentifierStrategy",
+      "SingleRootIdentifierStrategy:_baseUrl": {
+        "@id": "urn:solid-server:default:variable:baseUrl"
       }
     },
 

--- a/config/presets/storage/backend/storage-filesystem.json
+++ b/config/presets/storage/backend/storage-filesystem.json
@@ -26,9 +26,6 @@
       "DataAccessorBasedStore:_accessor": {
         "@id": "urn:solid-server:default:FileDataAccessor"
       },
-      "DataAccessorBasedStore:_base": {
-        "@id": "urn:solid-server:default:variable:baseUrl"
-      },
       "DataAccessorBasedStore:_identifierStrategy": {
         "@id": "urn:solid-server:default:IdentifierStrategy"
       }

--- a/config/presets/storage/backend/storage-filesystem.json
+++ b/config/presets/storage/backend/storage-filesystem.json
@@ -28,6 +28,9 @@
       },
       "DataAccessorBasedStore:_base": {
         "@id": "urn:solid-server:default:variable:baseUrl"
+      },
+      "DataAccessorBasedStore:_identifierStrategy": {
+        "@id": "urn:solid-server:default:IdentifierStrategy"
       }
     }
   ]

--- a/config/presets/storage/backend/storage-memory.json
+++ b/config/presets/storage/backend/storage-memory.json
@@ -14,9 +14,6 @@
       "DataAccessorBasedStore:_accessor": {
         "@id": "urn:solid-server:default:MemoryDataAccessor"
       },
-      "DataAccessorBasedStore:_base": {
-        "@id": "urn:solid-server:default:variable:baseUrl"
-      },
       "DataAccessorBasedStore:_identifierStrategy": {
         "@id": "urn:solid-server:default:IdentifierStrategy"
       }

--- a/config/presets/storage/backend/storage-memory.json
+++ b/config/presets/storage/backend/storage-memory.json
@@ -16,6 +16,9 @@
       },
       "DataAccessorBasedStore:_base": {
         "@id": "urn:solid-server:default:variable:baseUrl"
+      },
+      "DataAccessorBasedStore:_identifierStrategy": {
+        "@id": "urn:solid-server:default:IdentifierStrategy"
       }
     }
   ]

--- a/config/presets/storage/backend/storage-sparql-endpoint.json
+++ b/config/presets/storage/backend/storage-sparql-endpoint.json
@@ -9,6 +9,9 @@
       },
       "SparqlDataAccessor:_base": {
         "@id": "urn:solid-server:default:variable:baseUrl"
+      },
+      "SparqlDataAccessor:_identifierStrategy": {
+        "@id": "urn:solid-server:default:IdentifierStrategy"
       }
     },
 
@@ -20,6 +23,9 @@
       },
       "DataAccessorBasedStore:_base": {
         "@id": "urn:solid-server:default:variable:baseUrl"
+      },
+      "DataAccessorBasedStore:_identifierStrategy": {
+        "@id": "urn:solid-server:default:IdentifierStrategy"
       }
     },
 

--- a/config/presets/storage/backend/storage-sparql-endpoint.json
+++ b/config/presets/storage/backend/storage-sparql-endpoint.json
@@ -7,9 +7,6 @@
       "SparqlDataAccessor:_endpoint": {
         "@id": "urn:solid-server:default:variable:sparqlEndpoint"
       },
-      "SparqlDataAccessor:_base": {
-        "@id": "urn:solid-server:default:variable:baseUrl"
-      },
       "SparqlDataAccessor:_identifierStrategy": {
         "@id": "urn:solid-server:default:IdentifierStrategy"
       }
@@ -20,9 +17,6 @@
       "@type": "DataAccessorBasedStore",
       "DataAccessorBasedStore:_accessor": {
         "@id": "urn:solid-server:default:SparqlDataAccessor"
-      },
-      "DataAccessorBasedStore:_base": {
-        "@id": "urn:solid-server:default:variable:baseUrl"
       },
       "DataAccessorBasedStore:_identifierStrategy": {
         "@id": "urn:solid-server:default:IdentifierStrategy"

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,10 @@ export * from './util/errors/SystemError';
 export * from './util/errors/UnauthorizedHttpError';
 export * from './util/errors/UnsupportedMediaTypeHttpError';
 
+// Util/Identifiers
+export * from './util/identifiers/IdentifierStrategy';
+export * from './util/identifiers/SingleRootIdentifierStrategy';
+
 // Util/Locking
 export * from './util/locking/ExpiringLock';
 export * from './util/locking/ExpiringResourceLocker';

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -50,12 +50,10 @@ import type { ResourceStore } from './ResourceStore';
  */
 export class DataAccessorBasedStore implements ResourceStore {
   private readonly accessor: DataAccessor;
-  private readonly base: string;
   private readonly identifierStrategy: IdentifierStrategy;
 
-  public constructor(accessor: DataAccessor, base: string, identifierStrategy: IdentifierStrategy) {
+  public constructor(accessor: DataAccessor, identifierStrategy: IdentifierStrategy) {
     this.accessor = accessor;
-    this.base = ensureTrailingSlash(base);
     this.identifierStrategy = identifierStrategy;
   }
 
@@ -149,7 +147,7 @@ export class DataAccessorBasedStore implements ResourceStore {
 
   public async deleteResource(identifier: ResourceIdentifier): Promise<void> {
     this.validateIdentifier(identifier);
-    if (ensureTrailingSlash(identifier.path) === this.base) {
+    if (this.identifierStrategy.isRootContainer(identifier)) {
       throw new MethodNotAllowedHttpError('Cannot delete root container.');
     }
     const metadata = await this.accessor.getMetadata(identifier);
@@ -163,7 +161,7 @@ export class DataAccessorBasedStore implements ResourceStore {
    * Verify if the given identifier matches the stored base.
    */
   protected validateIdentifier(identifier: ResourceIdentifier): void {
-    if (!identifier.path.startsWith(this.base)) {
+    if (!this.identifierStrategy.supportsIdentifier(identifier)) {
       throw new NotFoundHttpError();
     }
   }

--- a/src/storage/accessors/SparqlDataAccessor.ts
+++ b/src/storage/accessors/SparqlDataAccessor.ts
@@ -25,7 +25,8 @@ import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpErr
 import { UnsupportedMediaTypeHttpError } from '../../util/errors/UnsupportedMediaTypeHttpError';
 import { guardStream } from '../../util/GuardedStream';
 import type { Guarded } from '../../util/GuardedStream';
-import { ensureTrailingSlash, getParentContainer, isContainerIdentifier } from '../../util/PathUtil';
+import type { IdentifierStrategy } from '../../util/identifiers/IdentifierStrategy';
+import { ensureTrailingSlash, isContainerIdentifier } from '../../util/PathUtil';
 import { generateResourceQuads } from '../../util/ResourceUtil';
 import { CONTENT_TYPE, LDP } from '../../util/UriConstants';
 import { toNamedNode } from '../../util/UriUtil';
@@ -49,12 +50,14 @@ export class SparqlDataAccessor implements DataAccessor {
   protected readonly logger = getLoggerFor(this);
   private readonly endpoint: string;
   private readonly base: string;
+  private readonly identifierStrategy: IdentifierStrategy;
   private readonly fetcher: SparqlEndpointFetcher;
   private readonly generator: SparqlGenerator;
 
-  public constructor(endpoint: string, base: string) {
+  public constructor(endpoint: string, base: string, identifierStrategy: IdentifierStrategy) {
     this.endpoint = endpoint;
     this.base = ensureTrailingSlash(base);
+    this.identifierStrategy = identifierStrategy;
     this.fetcher = new SparqlEndpointFetcher();
     this.generator = new Generator();
   }
@@ -149,7 +152,7 @@ export class SparqlDataAccessor implements DataAccessor {
    * Helper function to get named nodes corresponding to the identifier and its parent container.
    */
   private getRelatedNames(identifier: ResourceIdentifier): { name: NamedNode; parent: NamedNode } {
-    const parentIdentifier = getParentContainer(identifier);
+    const parentIdentifier = this.identifierStrategy.getParentContainer(identifier);
     const name = namedNode(identifier.path);
     const parent = namedNode(parentIdentifier.path);
     return { name, parent };

--- a/src/util/PathUtil.ts
+++ b/src/util/PathUtil.ts
@@ -1,5 +1,4 @@
 import type { ResourceIdentifier } from '../ldp/representation/ResourceIdentifier';
-import { InternalServerError } from './errors/InternalServerError';
 
 /**
  * Makes sure the input path has exactly 1 slash at the end.
@@ -38,26 +37,6 @@ export const decodeUriPathComponents = (path: string): string => path.split('/')
  * Encodes all (non-slash) special characters in a URI path.
  */
 export const encodeUriPathComponents = (path: string): string => path.split('/').map(encodeURIComponent).join('/');
-
-/**
- * Finds the container containing the given resource.
- * This does not ensure either the container or resource actually exist.
- *
- * @param id - Identifier to find container of.
- *
- * @returns The identifier of the container this resource is in.
- */
-export const getParentContainer = (id: ResourceIdentifier): ResourceIdentifier => {
-  // Trailing slash is necessary for URL library
-  const parentPath = new URL('..', ensureTrailingSlash(id.path)).toString();
-
-  // This probably means there is an issue with the root
-  if (parentPath === id.path) {
-    throw new InternalServerError(`Resource ${id.path} does not have a parent container`);
-  }
-
-  return { path: parentPath };
-};
 
 /**
  * Checks if the path corresponds to a container path (ending in a /).

--- a/src/util/identifiers/IdentifierStrategy.ts
+++ b/src/util/identifiers/IdentifierStrategy.ts
@@ -1,0 +1,26 @@
+import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
+
+/**
+ * Captures the behavior of container identifiers in a certain storage configuration.
+ */
+export interface IdentifierStrategy {
+  /**
+   * Verifies if this identifier is supported.
+   * This does not check if this identifier actually exists,
+   * but checks if the identifier is in scope for this class.
+   */
+  supportsIdentifier: (identifier: ResourceIdentifier) => boolean;
+
+  /**
+   * Generates the identifier of the container this resource would be a member of.
+   * This does not check if that identifier actually exists.
+   * Will throw an error if the input identifier is a root container or is not supported.
+   */
+  getParentContainer: (identifier: ResourceIdentifier) => ResourceIdentifier;
+
+  /**
+   * Checks if the input corresponds to the identifier of a root container.
+   * This does not check if this identifier actually exists.
+   */
+  isRootContainer: (identifier: ResourceIdentifier) => boolean;
+}

--- a/src/util/identifiers/SingleRootIdentifierStrategy.ts
+++ b/src/util/identifiers/SingleRootIdentifierStrategy.ts
@@ -1,0 +1,37 @@
+import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
+import { InternalServerError } from '../errors/InternalServerError';
+import { ensureTrailingSlash } from '../PathUtil';
+import type { IdentifierStrategy } from './IdentifierStrategy';
+
+/**
+ * An IdentifierStrategy that assumes there is only 1 root and all other identifiers are made by appending to that root.
+ */
+export class SingleRootIdentifierStrategy implements IdentifierStrategy {
+  private readonly baseUrl: string;
+
+  public constructor(baseUrl: string) {
+    this.baseUrl = ensureTrailingSlash(baseUrl);
+  }
+
+  public supportsIdentifier(identifier: ResourceIdentifier): boolean {
+    return identifier.path.startsWith(this.baseUrl);
+  }
+
+  public getParentContainer(identifier: ResourceIdentifier): ResourceIdentifier {
+    if (!this.supportsIdentifier(identifier)) {
+      throw new InternalServerError(`${identifier.path} is not supported`);
+    }
+    if (this.isRootContainer(identifier)) {
+      throw new InternalServerError(`${identifier.path} is a root container and has no parent`);
+    }
+
+    // Trailing slash is necessary for URL library
+    const parentPath = new URL('..', ensureTrailingSlash(identifier.path)).href;
+
+    return { path: parentPath };
+  }
+
+  public isRootContainer(identifier: ResourceIdentifier): boolean {
+    return identifier.path === this.baseUrl;
+  }
+}

--- a/test/configs/Util.ts
+++ b/test/configs/Util.ts
@@ -35,6 +35,7 @@ import {
   RawBodyParser,
   RepresentationConvertingStore,
   SequenceHandler,
+  SingleRootIdentifierStrategy,
   SingleThreadedResourceLocker,
   SlugParser,
   SparqlUpdatePatchHandler,
@@ -60,7 +61,7 @@ export const getRootFilePath = (subfolder: string): string => join(__dirname, '.
  * @returns The data accessor based store.
  */
 export const getDataAccessorStore = (base: string, dataAccessor: DataAccessor): DataAccessorBasedStore =>
-  new DataAccessorBasedStore(dataAccessor, base);
+  new DataAccessorBasedStore(dataAccessor, base, new SingleRootIdentifierStrategy(base));
 
 /**
  * Gives an in memory resource store based on (default) base url.
@@ -175,7 +176,7 @@ export const getBasicRequestParser = (bodyParsers: BodyParser[] = []): BasicRequ
  * @returns The acl authorizer.
  */
 export const getWebAclAuthorizer = (store: ResourceStore, aclManager = new UrlBasedAclManager()): WebAclAuthorizer =>
-  new WebAclAuthorizer(aclManager, store);
+  new WebAclAuthorizer(aclManager, store, new SingleRootIdentifierStrategy(BASE));
 
 /**
  * Returns a component instantiated from a Components.js configuration.

--- a/test/configs/Util.ts
+++ b/test/configs/Util.ts
@@ -61,7 +61,7 @@ export const getRootFilePath = (subfolder: string): string => join(__dirname, '.
  * @returns The data accessor based store.
  */
 export const getDataAccessorStore = (base: string, dataAccessor: DataAccessor): DataAccessorBasedStore =>
-  new DataAccessorBasedStore(dataAccessor, base, new SingleRootIdentifierStrategy(base));
+  new DataAccessorBasedStore(dataAccessor, new SingleRootIdentifierStrategy(base));
 
 /**
  * Gives an in memory resource store based on (default) base url.

--- a/test/integration/LockingResourceStore.test.ts
+++ b/test/integration/LockingResourceStore.test.ts
@@ -26,7 +26,7 @@ describe('A LockingResourceStore', (): void => {
 
     const base = 'http://test.com/';
     path = `${base}path`;
-    source = new DataAccessorBasedStore(new InMemoryDataAccessor(base), base, new SingleRootIdentifierStrategy(base));
+    source = new DataAccessorBasedStore(new InMemoryDataAccessor(base), new SingleRootIdentifierStrategy(base));
 
     locker = new SingleThreadedResourceLocker();
     expiringLocker = new WrappedExpiringResourceLocker(locker, 1000);

--- a/test/integration/LockingResourceStore.test.ts
+++ b/test/integration/LockingResourceStore.test.ts
@@ -6,6 +6,7 @@ import { DataAccessorBasedStore } from '../../src/storage/DataAccessorBasedStore
 import { LockingResourceStore } from '../../src/storage/LockingResourceStore';
 import type { ResourceStore } from '../../src/storage/ResourceStore';
 import { APPLICATION_OCTET_STREAM } from '../../src/util/ContentTypes';
+import { SingleRootIdentifierStrategy } from '../../src/util/identifiers/SingleRootIdentifierStrategy';
 import type { ExpiringResourceLocker } from '../../src/util/locking/ExpiringResourceLocker';
 import type { ResourceLocker } from '../../src/util/locking/ResourceLocker';
 import { SingleThreadedResourceLocker } from '../../src/util/locking/SingleThreadedResourceLocker';
@@ -25,7 +26,7 @@ describe('A LockingResourceStore', (): void => {
 
     const base = 'http://test.com/';
     path = `${base}path`;
-    source = new DataAccessorBasedStore(new InMemoryDataAccessor(base), base);
+    source = new DataAccessorBasedStore(new InMemoryDataAccessor(base), base, new SingleRootIdentifierStrategy(base));
 
     locker = new SingleThreadedResourceLocker();
     expiringLocker = new WrappedExpiringResourceLocker(locker, 1000);

--- a/test/integration/SparqlStorage.test.ts
+++ b/test/integration/SparqlStorage.test.ts
@@ -8,7 +8,7 @@ import { describeIf, FileTestHelper } from '../util/TestHelpers';
 describeIf('docker', 'a server with a SPARQL endpoint as storage', (): void => {
   describe('without acl', (): void => {
     const config = new DataAccessorBasedConfig(BASE,
-      new SparqlDataAccessor('http://localhost:4000/sparql', BASE, new SingleRootIdentifierStrategy(BASE)),
+      new SparqlDataAccessor('http://localhost:4000/sparql', new SingleRootIdentifierStrategy(BASE)),
       INTERNAL_QUADS);
     const handler = config.getHttpHandler();
     const fileHelper = new FileTestHelper(handler, new URL(BASE));

--- a/test/integration/SparqlStorage.test.ts
+++ b/test/integration/SparqlStorage.test.ts
@@ -1,5 +1,6 @@
 import { SparqlDataAccessor } from '../../src/storage/accessors/SparqlDataAccessor';
 import { INTERNAL_QUADS } from '../../src/util/ContentTypes';
+import { SingleRootIdentifierStrategy } from '../../src/util/identifiers/SingleRootIdentifierStrategy';
 import { DataAccessorBasedConfig } from '../configs/DataAccessorBasedConfig';
 import { BASE } from '../configs/Util';
 import { describeIf, FileTestHelper } from '../util/TestHelpers';
@@ -7,7 +8,7 @@ import { describeIf, FileTestHelper } from '../util/TestHelpers';
 describeIf('docker', 'a server with a SPARQL endpoint as storage', (): void => {
   describe('without acl', (): void => {
     const config = new DataAccessorBasedConfig(BASE,
-      new SparqlDataAccessor('http://localhost:4000/sparql', BASE),
+      new SparqlDataAccessor('http://localhost:4000/sparql', BASE, new SingleRootIdentifierStrategy(BASE)),
       INTERNAL_QUADS);
     const handler = config.getHttpHandler();
     const fileHelper = new FileTestHelper(handler, new URL(BASE));

--- a/test/unit/authorization/WebAclAuthorizer.test.ts
+++ b/test/unit/authorization/WebAclAuthorizer.test.ts
@@ -8,9 +8,10 @@ import type { Representation } from '../../../src/ldp/representation/Representat
 import type { ResourceIdentifier } from '../../../src/ldp/representation/ResourceIdentifier';
 import type { ResourceStore } from '../../../src/storage/ResourceStore';
 import { ForbiddenHttpError } from '../../../src/util/errors/ForbiddenHttpError';
+import { InternalServerError } from '../../../src/util/errors/InternalServerError';
 import { NotFoundHttpError } from '../../../src/util/errors/NotFoundHttpError';
 import { UnauthorizedHttpError } from '../../../src/util/errors/UnauthorizedHttpError';
-import { getParentContainer } from '../../../src/util/PathUtil';
+import { SingleRootIdentifierStrategy } from '../../../src/util/identifiers/SingleRootIdentifierStrategy';
 
 const nn = namedNode;
 
@@ -25,6 +26,8 @@ describe('A WebAclAuthorizer', (): void => {
     getAclConstrainedResource: async(id: ResourceIdentifier): Promise<ResourceIdentifier> =>
       !id.path.endsWith('.acl') ? id : { path: id.path.slice(0, -4) },
   };
+  let store: ResourceStore;
+  const identifierStrategy = new SingleRootIdentifierStrategy('http://test.com/');
   let permissions: PermissionSet;
   let credentials: Credentials;
   let identifier: ResourceIdentifier;
@@ -37,132 +40,119 @@ describe('A WebAclAuthorizer', (): void => {
     };
     credentials = {};
     identifier = { path: 'http://test.com/foo' };
+
+    store = {
+      getRepresentation: jest.fn(),
+    } as any;
+    authorizer = new WebAclAuthorizer(aclManager, store, identifierStrategy);
   });
 
   it('handles all inputs.', async(): Promise<void> => {
-    authorizer = new WebAclAuthorizer(aclManager, null as any);
+    authorizer = new WebAclAuthorizer(aclManager, null as any, identifierStrategy);
     await expect(authorizer.canHandle({} as any)).resolves.toBeUndefined();
   });
 
   it('allows access if the acl file allows all agents.', async(): Promise<void> => {
-    const store = {
-      getRepresentation: async(): Promise<Representation> => ({ data: streamifyArray([
-        quad(nn('auth'), nn(`${acl}agentClass`), nn('http://xmlns.com/foaf/0.1/Agent')),
-        quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
-        quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
-      ]) } as Representation),
-    } as unknown as ResourceStore;
-    authorizer = new WebAclAuthorizer(aclManager, store);
+    store.getRepresentation = async(): Promise<Representation> => ({ data: streamifyArray([
+      quad(nn('auth'), nn(`${acl}agentClass`), nn('http://xmlns.com/foaf/0.1/Agent')),
+      quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
+      quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
+    ]) } as Representation);
     await expect(authorizer.handle({ identifier, permissions, credentials })).resolves.toBeUndefined();
   });
 
   it('allows access if there is a parent acl file allowing all agents.', async(): Promise<void> => {
-    const store = {
-      async getRepresentation(id: ResourceIdentifier): Promise<Representation> {
-        if (id.path.endsWith('foo.acl')) {
-          throw new NotFoundHttpError();
-        }
-        return {
-          data: streamifyArray([
-            quad(nn('auth'), nn(`${acl}agentClass`), nn('http://xmlns.com/foaf/0.1/Agent')),
-            quad(nn('auth'), nn(`${acl}default`), nn(getParentContainer(identifier).path)),
-            quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
-          ]),
-        } as Representation;
-      },
-    } as unknown as ResourceStore;
-    authorizer = new WebAclAuthorizer(aclManager, store);
+    store.getRepresentation = async(id: ResourceIdentifier): Promise<Representation> => {
+      if (id.path.endsWith('foo.acl')) {
+        throw new NotFoundHttpError();
+      }
+      return {
+        data: streamifyArray([
+          quad(nn('auth'), nn(`${acl}agentClass`), nn('http://xmlns.com/foaf/0.1/Agent')),
+          quad(nn('auth'), nn(`${acl}default`), nn(identifierStrategy.getParentContainer(identifier).path)),
+          quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
+        ]),
+      } as Representation;
+    };
     await expect(authorizer.handle({ identifier, permissions, credentials })).resolves.toBeUndefined();
   });
 
   it('allows access to authorized agents if the acl files allows all authorized users.', async(): Promise<void> => {
-    const store = {
-      getRepresentation: async(): Promise<Representation> => ({ data: streamifyArray([
-        quad(nn('auth'), nn(`${acl}agentClass`), nn('http://xmlns.com/foaf/0.1/AuthenticatedAgent')),
-        quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
-        quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
-      ]) } as Representation),
-    } as unknown as ResourceStore;
-    authorizer = new WebAclAuthorizer(aclManager, store);
+    store.getRepresentation = async(): Promise<Representation> => ({ data: streamifyArray([
+      quad(nn('auth'), nn(`${acl}agentClass`), nn('http://xmlns.com/foaf/0.1/AuthenticatedAgent')),
+      quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
+      quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
+    ]) } as Representation);
     credentials.webId = 'http://test.com/user';
     await expect(authorizer.handle({ identifier, permissions, credentials })).resolves.toBeUndefined();
   });
 
   it('errors if authorization is required but the agent is not authorized.', async(): Promise<void> => {
-    const store = {
-      getRepresentation: async(): Promise<Representation> => ({ data: streamifyArray([
-        quad(nn('auth'), nn(`${acl}agentClass`), nn('http://xmlns.com/foaf/0.1/AuthenticatedAgent')),
-        quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
-        quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
-      ]) } as Representation),
-    } as unknown as ResourceStore;
-    authorizer = new WebAclAuthorizer(aclManager, store);
+    store.getRepresentation = async(): Promise<Representation> => ({ data: streamifyArray([
+      quad(nn('auth'), nn(`${acl}agentClass`), nn('http://xmlns.com/foaf/0.1/AuthenticatedAgent')),
+      quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
+      quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
+    ]) } as Representation);
     await expect(authorizer.handle({ identifier, permissions, credentials })).rejects.toThrow(UnauthorizedHttpError);
   });
 
   it('allows access to specific agents if the acl files identifies them.', async(): Promise<void> => {
     credentials.webId = 'http://test.com/user';
-    const store = {
-      getRepresentation: async(): Promise<Representation> => ({ data: streamifyArray([
-        quad(nn('auth'), nn(`${acl}agent`), nn(credentials.webId!)),
-        quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
-        quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
-      ]) } as Representation),
-    } as unknown as ResourceStore;
-    authorizer = new WebAclAuthorizer(aclManager, store);
+    store.getRepresentation = async(): Promise<Representation> => ({ data: streamifyArray([
+      quad(nn('auth'), nn(`${acl}agent`), nn(credentials.webId!)),
+      quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
+      quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
+    ]) } as Representation);
     await expect(authorizer.handle({ identifier, permissions, credentials })).resolves.toBeUndefined();
   });
 
   it('errors if a specific agents wants to access files not assigned to them.', async(): Promise<void> => {
     credentials.webId = 'http://test.com/user';
-    const store = {
-      getRepresentation: async(): Promise<Representation> => ({ data: streamifyArray([
-        quad(nn('auth'), nn(`${acl}agent`), nn('http://test.com/differentUser')),
-        quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
-        quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
-      ]) } as Representation),
-    } as unknown as ResourceStore;
-    authorizer = new WebAclAuthorizer(aclManager, store);
+    store.getRepresentation = async(): Promise<Representation> => ({ data: streamifyArray([
+      quad(nn('auth'), nn(`${acl}agent`), nn('http://test.com/differentUser')),
+      quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
+      quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
+    ]) } as Representation);
     await expect(authorizer.handle({ identifier, permissions, credentials })).rejects.toThrow(ForbiddenHttpError);
   });
 
   it('allows access to the acl file if control is allowed.', async(): Promise<void> => {
     credentials.webId = 'http://test.com/user';
     identifier.path = 'http://test.com/foo';
-    const store = {
-      getRepresentation: async(): Promise<Representation> => ({ data: streamifyArray([
-        quad(nn('auth'), nn(`${acl}agent`), nn(credentials.webId!)),
-        quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
-        quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Control`)),
-      ]) } as Representation),
-    } as unknown as ResourceStore;
+    store.getRepresentation = async(): Promise<Representation> => ({ data: streamifyArray([
+      quad(nn('auth'), nn(`${acl}agent`), nn(credentials.webId!)),
+      quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
+      quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Control`)),
+    ]) } as Representation);
     const aclIdentifier = await aclManager.getAclDocument(identifier);
-    authorizer = new WebAclAuthorizer(aclManager, store);
     await expect(authorizer.handle({ identifier: aclIdentifier, permissions, credentials })).resolves.toBeUndefined();
   });
 
   it('errors if an agent tries to edit the acl file without control permissions.', async(): Promise<void> => {
     credentials.webId = 'http://test.com/user';
     identifier.path = 'http://test.com/foo';
-    const store = {
-      getRepresentation: async(): Promise<Representation> => ({ data: streamifyArray([
-        quad(nn('auth'), nn(`${acl}agent`), nn(credentials.webId!)),
-        quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
-        quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
-      ]) } as Representation),
-    } as unknown as ResourceStore;
+    store.getRepresentation = async(): Promise<Representation> => ({ data: streamifyArray([
+      quad(nn('auth'), nn(`${acl}agent`), nn(credentials.webId!)),
+      quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
+      quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
+    ]) } as Representation);
     identifier = await aclManager.getAclDocument(identifier);
-    authorizer = new WebAclAuthorizer(aclManager, store);
     await expect(authorizer.handle({ identifier, permissions, credentials })).rejects.toThrow(ForbiddenHttpError);
   });
 
   it('passes errors of the ResourceStore along.', async(): Promise<void> => {
-    const store = {
-      async getRepresentation(): Promise<Representation> {
-        throw new Error('TEST!');
-      },
-    } as unknown as ResourceStore;
-    authorizer = new WebAclAuthorizer(aclManager, store);
+    store.getRepresentation = async(): Promise<Representation> => {
+      throw new Error('TEST!');
+    };
     await expect(authorizer.handle({ identifier, permissions, credentials })).rejects.toThrow('TEST!');
+  });
+
+  it('errors if the root container has no corresponding acl document.', async(): Promise<void> => {
+    store.getRepresentation = async(): Promise<Representation> => {
+      throw new NotFoundHttpError();
+    };
+    const promise = authorizer.handle({ identifier, permissions, credentials });
+    await expect(promise).rejects.toThrow('No ACL document found for root container');
+    await expect(promise).rejects.toThrow(InternalServerError);
   });
 });

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -80,7 +80,7 @@ describe('A DataAccessorBasedStore', (): void => {
   beforeEach(async(): Promise<void> => {
     accessor = new SimpleDataAccessor();
 
-    store = new DataAccessorBasedStore(accessor, root, identifierStrategy);
+    store = new DataAccessorBasedStore(accessor, identifierStrategy);
 
     containerMetadata = new RepresentationMetadata(
       { [RDF.type]: [ DataFactory.namedNode(LDP.Container), DataFactory.namedNode(LDP.BasicContainer) ]},

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -14,6 +14,7 @@ import { MethodNotAllowedHttpError } from '../../../src/util/errors/MethodNotAll
 import { NotFoundHttpError } from '../../../src/util/errors/NotFoundHttpError';
 import { NotImplementedHttpError } from '../../../src/util/errors/NotImplementedHttpError';
 import type { Guarded } from '../../../src/util/GuardedStream';
+import { SingleRootIdentifierStrategy } from '../../../src/util/identifiers/SingleRootIdentifierStrategy';
 import * as quadUtil from '../../../src/util/QuadUtil';
 import { guardedStreamFrom } from '../../../src/util/StreamUtil';
 import { CONTENT_TYPE, HTTP, LDP, RDF } from '../../../src/util/UriConstants';
@@ -71,6 +72,7 @@ describe('A DataAccessorBasedStore', (): void => {
   let store: DataAccessorBasedStore;
   let accessor: SimpleDataAccessor;
   const root = 'http://test.com/';
+  const identifierStrategy = new SingleRootIdentifierStrategy(root);
   let containerMetadata: RepresentationMetadata;
   let representation: Representation;
   const resourceData = 'text';
@@ -78,7 +80,7 @@ describe('A DataAccessorBasedStore', (): void => {
   beforeEach(async(): Promise<void> => {
     accessor = new SimpleDataAccessor();
 
-    store = new DataAccessorBasedStore(accessor, root);
+    store = new DataAccessorBasedStore(accessor, root, identifierStrategy);
 
     containerMetadata = new RepresentationMetadata(
       { [RDF.type]: [ DataFactory.namedNode(LDP.Container), DataFactory.namedNode(LDP.BasicContainer) ]},

--- a/test/unit/storage/MonitoringStore.test.ts
+++ b/test/unit/storage/MonitoringStore.test.ts
@@ -2,10 +2,12 @@ import type { Patch } from '../../../src/ldp/http/Patch';
 import type { Representation } from '../../../src/ldp/representation/Representation';
 import { MonitoringStore } from '../../../src/storage/MonitoringStore';
 import type { ResourceStore } from '../../../src/storage/ResourceStore';
+import { SingleRootIdentifierStrategy } from '../../../src/util/identifiers/SingleRootIdentifierStrategy';
 
 describe('A MonitoringStore', (): void => {
   let store: MonitoringStore;
   let source: ResourceStore;
+  const identifierStrategy = new SingleRootIdentifierStrategy('http://example.org/');
   let changedCallback: () => void;
 
   beforeEach(async(): Promise<void> => {
@@ -16,7 +18,7 @@ describe('A MonitoringStore', (): void => {
       deleteResource: jest.fn(async(): Promise<any> => undefined),
       modifyResource: jest.fn(async(): Promise<any> => undefined),
     };
-    store = new MonitoringStore(source);
+    store = new MonitoringStore(source, identifierStrategy);
     changedCallback = jest.fn();
     store.on('changed', changedCallback);
   });

--- a/test/unit/storage/accessors/SparqlDataAccessor.test.ts
+++ b/test/unit/storage/accessors/SparqlDataAccessor.test.ts
@@ -12,6 +12,7 @@ import { ConflictHttpError } from '../../../../src/util/errors/ConflictHttpError
 import { NotFoundHttpError } from '../../../../src/util/errors/NotFoundHttpError';
 import { UnsupportedMediaTypeHttpError } from '../../../../src/util/errors/UnsupportedMediaTypeHttpError';
 import type { Guarded } from '../../../../src/util/GuardedStream';
+import { SingleRootIdentifierStrategy } from '../../../../src/util/identifiers/SingleRootIdentifierStrategy';
 import { guardedStreamFrom } from '../../../../src/util/StreamUtil';
 import { CONTENT_TYPE, LDP, RDF } from '../../../../src/util/UriConstants';
 import { toNamedNode } from '../../../../src/util/UriUtil';
@@ -30,6 +31,7 @@ const simplifyQuery = (query: string | string[]): string => {
 describe('A SparqlDataAccessor', (): void => {
   const endpoint = 'http://test.com/sparql';
   const base = 'http://test.com/';
+  const identifierStrategy = new SingleRootIdentifierStrategy(base);
   let accessor: SparqlDataAccessor;
   let metadata: RepresentationMetadata;
   let data: Guarded<Readable>;
@@ -64,7 +66,7 @@ describe('A SparqlDataAccessor', (): void => {
     }));
 
     // This needs to be last so the fetcher can be mocked first
-    accessor = new SparqlDataAccessor(endpoint, base);
+    accessor = new SparqlDataAccessor(endpoint, base, identifierStrategy);
   });
 
   it('can only handle quad data.', async(): Promise<void> => {

--- a/test/unit/storage/accessors/SparqlDataAccessor.test.ts
+++ b/test/unit/storage/accessors/SparqlDataAccessor.test.ts
@@ -66,7 +66,7 @@ describe('A SparqlDataAccessor', (): void => {
     }));
 
     // This needs to be last so the fetcher can be mocked first
-    accessor = new SparqlDataAccessor(endpoint, base, identifierStrategy);
+    accessor = new SparqlDataAccessor(endpoint, identifierStrategy);
   });
 
   it('can only handle quad data.', async(): Promise<void> => {

--- a/test/unit/util/PathUtil.test.ts
+++ b/test/unit/util/PathUtil.test.ts
@@ -2,7 +2,6 @@ import {
   decodeUriPathComponents,
   encodeUriPathComponents,
   ensureTrailingSlash,
-  getParentContainer,
   toCanonicalUriPath,
 } from '../../../src/util/PathUtil';
 
@@ -27,18 +26,6 @@ describe('PathUtil', (): void => {
 
     it('encodes all parts of a path with encodeUriPathComponents.', async(): Promise<void> => {
       expect(encodeUriPathComponents('/a%20path&/name')).toEqual('/a%2520path%26/name');
-    });
-  });
-
-  describe('#getParentContainer', (): void => {
-    it('returns the parent URl for a single call.', async(): Promise<void> => {
-      expect(getParentContainer({ path: 'http://test.com/foo/bar' })).toEqual({ path: 'http://test.com/foo/' });
-      expect(getParentContainer({ path: 'http://test.com/foo/bar/' })).toEqual({ path: 'http://test.com/foo/' });
-    });
-
-    it('errors when the root of an URl is reached that does not match the input root.', async(): Promise<void> => {
-      expect((): any => getParentContainer({ path: 'http://test.com/' }))
-        .toThrow('Resource http://test.com/ does not have a parent container');
     });
   });
 });

--- a/test/unit/util/identifiers/SingleRootIdentifierStrategy.test.ts
+++ b/test/unit/util/identifiers/SingleRootIdentifierStrategy.test.ts
@@ -1,0 +1,33 @@
+import { SingleRootIdentifierStrategy } from '../../../../src/util/identifiers/SingleRootIdentifierStrategy';
+
+describe('A SingleRootIdentifierStrategy', (): void => {
+  const baseUrl = 'http://test.com/';
+  const manager = new SingleRootIdentifierStrategy(baseUrl);
+
+  it('verifies if identifiers are in its domain.', async(): Promise<void> => {
+    expect(manager.supportsIdentifier({ path: 'http://notest.com/' })).toBe(false);
+    expect(manager.supportsIdentifier({ path: baseUrl })).toBe(true);
+    expect(manager.supportsIdentifier({ path: `${baseUrl}foo/bar` })).toBe(true);
+  });
+
+  it('returns the parent identifier.', async(): Promise<void> => {
+    expect(manager.getParentContainer({ path: 'http://test.com/foo/bar' })).toEqual({ path: 'http://test.com/foo/' });
+    expect(manager.getParentContainer({ path: 'http://test.com/foo/bar/' })).toEqual({ path: 'http://test.com/foo/' });
+  });
+
+  it('errors when attempting to get the parent of an unsupported identifier.', async(): Promise<void> => {
+    expect((): any => manager.getParentContainer({ path: 'http://nottest.com/' }))
+      .toThrow('http://nottest.com/ is not supported');
+  });
+
+  it('errors when attempting to get the parent of a root container.', async(): Promise<void> => {
+    expect((): any => manager.getParentContainer({ path: 'http://test.com/' }))
+      .toThrow('http://test.com/ is a root container and has no parent');
+  });
+
+  it('checks for the root container by comparing with the base URL.', async(): Promise<void> => {
+    expect(manager.isRootContainer({ path: 'http://notest.com/' })).toBe(false);
+    expect(manager.isRootContainer({ path: baseUrl })).toBe(true);
+    expect(manager.isRootContainer({ path: `${baseUrl}foo/bar` })).toBe(false);
+  });
+});


### PR DESCRIPTION
Based on https://github.com/solid/community-server/issues/394#issuecomment-739805093

In preparation for some other issues where `isRootContainer` is needed.

I added the `toRelative` and `fromRelative` functions initially, but there are some problems with that interface so will have to rethink later. Pod provisioning would have same issues (which can be fixed I think, but I would prefer looking into that later).