### PR TITLE
feat: Support .meta files for pod provisioning

### DIFF
--- a/src/storage/accessors/FileDataAccessor.ts
+++ b/src/storage/accessors/FileDataAccessor.ts
@@ -16,7 +16,7 @@ import type { Guarded } from '../../util/GuardedStream';
 import { isContainerIdentifier } from '../../util/PathUtil';
 import { parseQuads, pushQuad, serializeQuads } from '../../util/QuadUtil';
 import { generateContainmentQuads, generateResourceQuads } from '../../util/ResourceUtil';
-import { CONTENT_TYPE, DCTERMS, POSIX, RDF, XSD } from '../../util/UriConstants';
+import { CONTENT_TYPE, DCTERMS, LDP, POSIX, RDF, XSD } from '../../util/UriConstants';
 import { toNamedNode, toTypedLiteral } from '../../util/UriUtil';
 import type { FileIdentifierMapper, ResourceLink } from '../mapping/FileIdentifierMapper';
 import type { DataAccessor } from './DataAccessor';
@@ -210,7 +210,9 @@ export class FileDataAccessor implements DataAccessor {
    */
   private async writeMetadata(link: ResourceLink, metadata: RepresentationMetadata): Promise<boolean> {
     // These are stored by file system conventions
-    metadata.removeAll(RDF.type);
+    metadata.remove(RDF.type, toNamedNode(LDP.Resource));
+    metadata.remove(RDF.type, toNamedNode(LDP.Container));
+    metadata.remove(RDF.type, toNamedNode(LDP.BasicContainer));
     metadata.removeAll(CONTENT_TYPE);
     const quads = metadata.quads();
     const metadataLink = await this.getMetadataLink(link.identifier);

--- a/templates/.meta
+++ b/templates/.meta
@@ -1,0 +1,3 @@
+@prefix pim: <http://www.w3.org/ns/pim/space#>.
+
+<> a pim:Storage.


### PR DESCRIPTION
This opens up a lot more possibilities with the templates and will prevent random pod deletion after #426 .

This does encode what the metadata files should look like (content-type wise and extension) in the template generator, but generalizing that would cover most of the generator so probably would need a new class anyway if new template types should be supported.