### PR TITLE
fix: Make default HttpHandler a WaterfallHandler

### DIFF
--- a/config/presets/http.json
+++ b/config/presets/http.json
@@ -26,10 +26,15 @@
           "@id": "urn:solid-server:default:Middleware"
         },
         {
-          "@id": "urn:solid-server:default:PodManagerHandler"
-        },
-        {
-          "@id": "urn:solid-server:default:LdpHandler"
+          "@type": "WaterfallHandler",
+          "WaterfallHandler:_handlers": [
+            {
+              "@id": "urn:solid-server:default:PodManagerHandler"
+            },
+            {
+              "@id": "urn:solid-server:default:LdpHandler"
+            }
+          ]
         }
       ]
     }

--- a/test/integration/Middleware.test.ts
+++ b/test/integration/Middleware.test.ts
@@ -5,6 +5,7 @@ import { HttpHandler } from '../../src/server/HttpHandler';
 import type { HttpRequest } from '../../src/server/HttpRequest';
 import type { HttpResponse } from '../../src/server/HttpResponse';
 import { instantiateFromConfig } from '../configs/Util';
+import { StaticAsyncHandler } from '../util/StaticAsyncHandler';
 
 const port = 6002;
 
@@ -21,7 +22,7 @@ describe('An Express server with middleware', (): void => {
   beforeAll(async(): Promise<void> => {
     const factory = await instantiateFromConfig(
       'urn:solid-server:default:ExpressHttpServerFactory', 'middleware.json', {
-        'urn:solid-server:default:PodManagerHandler': new SimpleHttpHandler(),
+        'urn:solid-server:default:PodManagerHandler': new StaticAsyncHandler(false, null),
         'urn:solid-server:default:LdpHandler': new SimpleHttpHandler(),
         'urn:solid-server:default:variable:port': port,
         'urn:solid-server:default:variable:baseUrl': 'https://example.pod/',


### PR DESCRIPTION
Accidentally stumbled upon this when making #428 . Currently all requests to `/pods` will also be sent to the LDP handler.

As it currently is, the config for inserting the pod http handler in the config has always been wrong. It used to work because the `AllVoidCompositeHandler` used to ignore errors, but since the change to `SequenceHandler` it probably never worked anymore. Perhaps this also caused the confusion in #421 .

This does mean that the middleware will only run for requests that reach the LDP handler. If we want the middleware to always run more changes will be required.

Should also investigate how the pod creation integration test didn't catch this. Perhaps a timing issue because the pod handler managed to respond first.