### PR TITLE
Use base tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1110,6 +1110,18 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@tsconfig/node12": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.7.tgz",
+      "integrity": "sha512-dgasobK/Y0wVMswcipr3k0HpevxFJLijN03A8mYfEPvWvOs14v0ZlYTR4kIgMx8g4+fTyTFv8/jLCIfRqLDJ4A==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.0.tgz",
+      "integrity": "sha512-RKkL8eTdPv6t5EHgFKIVQgsDapugbuOptNd9OOunN/HAkzmmTnZELx1kNCK0rSdUYGmiFMM3rRQMAWiyp023LQ==",
+      "dev": true
+    },
     "@types/arrayify-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/arrayify-stream/-/arrayify-stream-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
   },
   "devDependencies": {
     "@microsoft/tsdoc-config": "^0.13.6",
+    "@tsconfig/node12": "^1.0.7",
     "@types/jest": "^26.0.13",
     "@types/rimraf": "^3.0.0",
     "@types/supertest": "^2.0.10",

--- a/test/configs/Util.ts
+++ b/test/configs/Util.ts
@@ -200,7 +200,8 @@ export const instantiateFromConfig = async(componentUrl: string, configFile: str
  * Initializes the root container of the server.
  * Useful for when the RootContainerInitializer was not instantiated.
  */
-export const initServerStore = async(server: Server, baseUrl: string, headers: HeadersInit = {}): Promise<void> => {
+export const initServerStore = async(server: Server, baseUrl: string,
+  headers: Record<string, string> = {}): Promise<void> => {
   const res = await fetch(baseUrl, {
     method: 'PUT',
     headers: {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,10 +1,6 @@
 {
-  "compilerOptions": {
-    "module": "commonjs",
-    "target": "es2017",
-    "esModuleInterop": true,
-    "incremental": true,
-    "noUnusedLocals": true,
-    "strict": true
-  }
+  "extends": "../tsconfig.json",
+  "include": [
+    "."
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,14 @@
 {
+  "extends": "@tsconfig/node12/tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es2017",
-    "newLine": "lf",
     "declaration": true,
-    "esModuleInterop": true,
     "incremental": true,
     "inlineSources": true,
+    "newLine": "lf",
     "noUnusedLocals": true,
-    "preserveConstEnums": true,
     "outDir": "dist",
+    "preserveConstEnums": true,
     "sourceMap": true,
-    "strict": true,
     "stripInternal": true
   },
   "include": [


### PR DESCRIPTION
It seems like an improvement to use a base tsconfig as per the TypeScript documentation:

https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#tsconfig-bases

Note: I also ordered the compiler options alphabetically.