### PR TITLE
Accept relative references in SPARQL updates

### DIFF
--- a/src/ldp/http/SparqlUpdateBodyParser.ts
+++ b/src/ldp/http/SparqlUpdateBodyParser.ts
@@ -31,7 +31,7 @@ export class SparqlUpdateBodyParser extends BodyParser {
     let algebra: Algebra.Operation;
     try {
       const sparql = await readableToString(toAlgebraStream);
-      algebra = translate(sparql, { quads: true });
+      algebra = translate(sparql, { quads: true, baseIRI: request.url });
     } catch (error: unknown) {
       this.logger.warn('Could not translate SPARQL query to SPARQL algebra', { error });
       if (error instanceof Error) {

--- a/test/unit/ldp/http/SparqlUpdateBodyParser.test.ts
+++ b/test/unit/ldp/http/SparqlUpdateBodyParser.test.ts
@@ -61,4 +61,24 @@ describe('A SparqlUpdateBodyParser', (): void => {
       [ 'DELETE DATA { <http://test.com/s> <http://test.com/p> <http://test.com/o> }' ],
     );
   });
+
+  it('accepts relative references.', async(): Promise<void> => {
+    input.request = streamifyArray(
+      [ 'INSERT DATA { <#it> <http://test.com/p> <http://test.com/o> }' ],
+    ) as HttpRequest;
+    input.request.url = '/my-document.ttl';
+    const result = await bodyParser.handle(input);
+    expect(result.algebra.type).toBe(Algebra.types.DELETE_INSERT);
+    expect((result.algebra as Algebra.DeleteInsert).insert).toBeRdfIsomorphic([ quad(
+      namedNode('/my-document.ttl#it'),
+      namedNode('http://test.com/p'),
+      namedNode('http://test.com/o'),
+    ) ]);
+    expect(result.binary).toBe(true);
+    expect(result.metadata).toBe(input.metadata);
+
+    expect(await arrayifyStream(result.data)).toEqual(
+      [ 'INSERT DATA { <#it> <http://test.com/p> <http://test.com/o> }' ],
+    );
+  });
 });


### PR DESCRIPTION
I'm not sure if this is the correct fix, but I figured instead of opening an issue I could open a PR. Feel free to close it if there's a better way to do it, or it shouldn't be done for some reason.

I've been trying to create documents using PATCH, and I haven't been able to do it using relative references as I'd like. With this change at least it works, but it's still not ideal.

What I would like to achieve is having the relative references in the final document (I'm using the file storage config), something like this:

```turtle
<#it> <https://schema.org/name> "My document" .
```

But the best thing I've achieved is this (by passing './' as the baseIRI):

```turtle
<./#it> <https://schema.org/name> "My document" .
```

If this were only an implementation detail of how turtle files are stored in the filesystem I wouldn't mind, but at the moment when a user does a GET request the document is returned without any transformations. And I'd prefer to keep references as relative as possible.

This fix doesn't actually achieve that, because the request url will contain an absolute reference to the container and that isn't ideal either. But I figured it'd be better than hard-coding './'.