### PR TITLE
rm -rf node_modules not recognized on Windows 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "sparqlalgebrajs": "^2.3.1",
     "sparqljs": "^3.1.2",
     "streamify-array": "^1.0.1",
-    "ts-dpop": "^0.2.7",
+    "ts-dpop": "^0.3.0",
     "uuid": "^8.3.0",
     "winston": "^3.3.3",
     "winston-transport": "^4.4.0",


### PR DESCRIPTION
https://github.com/matthieubosquet/ts-dpop/issues/18#issuecomment-751404397