### PR TITLE
refactor: ESLint ignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,0 @@
-coverage
-dist
-docs
-node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
-node_modules
-
+coverage
 dist
 docs
-
+node_modules
 .eslintcache
-coverage
 tsconfig.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "docker:stop": "./test/docker/docker-stop.sh",
     "docs": "typedoc",
     "jest": "jest",
-    "lint": "eslint . --cache",
+    "lint": "eslint . --cache --ignore-path .gitignore",
     "prepare": "npm run build",
     "start": "node ./bin/server.js",
     "test": "npm run test:ts && npm run jest",


### PR DESCRIPTION
It feels like everything that is versioned and supported by ESLint should be linted and everything that isn't versioned shouldn't be linted.
Hence, I feel like the .eslintignore is mostly redundant.

I ordered alphabetically .gitignore and base ESLint ignore on it.