### PR TITLE
refactor: Async recursive handler

### DIFF
--- a/src/ldp/AuthenticatedLdpHandler.ts
+++ b/src/ldp/AuthenticatedLdpHandler.ts
@@ -72,7 +72,7 @@ export class AuthenticatedLdpHandler extends HttpHandler {
    * @returns A promise resolving if this request can be handled, otherwise rejecting with an Error.
    */
   public async canHandle(input: { request: HttpRequest; response: HttpResponse }): Promise<void> {
-    return this.requestParser.canHandle(input.request);
+    await this.requestParser.canHandle(input.request);
   }
 
   /**

--- a/src/ldp/http/BasicRequestParser.ts
+++ b/src/ldp/http/BasicRequestParser.ts
@@ -9,7 +9,7 @@ import type { TargetExtractor } from './TargetExtractor';
 /**
  * Input parsers required for a {@link BasicRequestParser}.
  */
-export interface SimpleRequestParserArgs {
+export interface BasicRequestParserArgs {
   targetExtractor: TargetExtractor;
   preferenceParser: PreferenceParser;
   metadataExtractor: MetadataExtractor;
@@ -26,7 +26,7 @@ export class BasicRequestParser extends RequestParser {
   private readonly metadataExtractor!: MetadataExtractor;
   private readonly bodyParser!: BodyParser;
 
-  public constructor(args: SimpleRequestParserArgs) {
+  public constructor(args: BasicRequestParserArgs) {
     super();
     Object.assign(this, args);
   }

--- a/src/util/AsyncHandler.ts
+++ b/src/util/AsyncHandler.ts
@@ -10,7 +10,7 @@ export abstract class AsyncHandler<TIn = void, TOut = void> {
    * @returns A promise resolving if this input can be handled, rejecting with an Error if not.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public async canHandle(input: TIn): Promise<void> {
+  public async canHandle(input: TIn): Promise<void | AsyncHandler<TIn, TOut>> {
     // Support any input by default
   }
 
@@ -20,7 +20,7 @@ export abstract class AsyncHandler<TIn = void, TOut = void> {
    *
    * @returns A promise resolving when the handling is finished. Return value depends on the given type.
    */
-  public abstract handle(input: TIn): Promise<TOut>;
+  public abstract handle(input: TIn, handler?: AsyncHandler<TIn, TOut>): Promise<TOut>;
 
   /**
    * Helper function that first runs the canHandle function followed by the handle function.


### PR DESCRIPTION
This allows following the regular pattern of canHandle/handle with handlers that are recursive.
It fixes the Waterfall. I think I can simplify the Sequence one as well if this is ok.