### PR TITLE
fix: Don't get normalized metadata for root containers

### DIFF
--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -185,7 +185,8 @@ export class DataAccessorBasedStore implements ResourceStore {
     try {
       return await this.accessor.getMetadata(identifier);
     } catch (error: unknown) {
-      if (error instanceof NotFoundHttpError) {
+      // Trimming the trailing slash of a root container is undefined as there is no parent container
+      if (error instanceof NotFoundHttpError && !this.identifierStrategy.isRootContainer(identifier)) {
         return this.accessor.getMetadata(
           { path: hasSlash ? trimTrailingSlashes(identifier.path) : ensureTrailingSlash(identifier.path) },
         );

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -262,6 +262,27 @@ describe('A DataAccessorBasedStore', (): void => {
         .rejects.toThrow(`${resourceID.path} conflicts with existing path ${resourceID.path}/`);
     });
 
+    // As discussed in #475, trimming the trailing slash of a root container in getNormalizedMetadata
+    // can result in undefined behaviour since there is no parent container.
+    it('will not trim the slash of root containers since there is no parent.', async(): Promise<void> => {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete accessor.data[root];
+
+      const mock = jest.spyOn(accessor, 'getMetadata');
+
+      const resourceID = { path: `${root}` };
+      representation.metadata.removeAll(RDF.type);
+      representation.metadata.contentType = 'text/turtle';
+      representation.data = guardedStreamFrom([ `<${`${root}`}> a <coolContainer>.` ]);
+
+      await expect(store.setRepresentation(resourceID, representation))
+        .resolves.toBeUndefined();
+      expect(mock).toHaveBeenCalledTimes(1);
+      expect(mock).toHaveBeenLastCalledWith(resourceID);
+
+      mock.mockRestore();
+    });
+
     it('will error if the target has a different resource type.', async(): Promise<void> => {
       const resourceID = { path: `${root}resource` };
       accessor.data[resourceID.path] = representation;


### PR DESCRIPTION
Fixes #456 . As added bonus it also results in you being able to give a folder that doesn't exist as CLI param and it will be created (no nested folders though).

This still has the `hasSlash` variable there. Could have renamed it to something else but 2 lines below we are actually changing the slashes so it makes sense to me. The slash logic has to stay because it's part of the spec: 

> If two URIs differ only in the trailing slash, and the server has associated a resource with one of them, then the other URI MUST NOT correspond to another resource.

The only way to remove that logic from the store would be to move the entire function (or most parts of it) to the IdentifierStrategy but I think that makes less sense.