### PR TITLE
Fix problem with guarded streams still throwing async errors

### DIFF
--- a/test/integration/GuardedStream.test.ts
+++ b/test/integration/GuardedStream.test.ts
@@ -1,0 +1,53 @@
+import {
+  RepresentationMetadata,
+  TypedRepresentationConverter,
+  readableToString,
+  ChainedConverter,
+  guardedStreamFrom,
+  RdfToQuadConverter, BasicRepresentation, getLoggerFor,
+} from '../../src';
+import type { Representation,
+  RepresentationConverterArgs,
+  Logger } from '../../src';
+
+jest.mock('../../src/logging/LogUtil', (): any => {
+  const logger: Logger = { error: jest.fn(), debug: jest.fn(), warn: jest.fn(), info: jest.fn() } as any;
+  return { getLoggerFor: (): Logger => logger };
+});
+const logger: jest.Mocked<Logger> = getLoggerFor('GuardedStream') as any;
+
+class DummyConverter extends TypedRepresentationConverter {
+  public async getInputTypes(): Promise<Record<string, number>> {
+    return { '*/*': 1 };
+  }
+
+  public async getOutputTypes(): Promise<Record<string, number>> {
+    return { 'custom/type': 1 };
+  }
+
+  public async handle({ representation }: RepresentationConverterArgs): Promise<Representation> {
+    const data = guardedStreamFrom([ 'dummy' ]);
+    const metadata = new RepresentationMetadata(representation.metadata, 'custom/type');
+
+    return { binary: true, data, metadata };
+  }
+}
+
+describe('A chained converter where data gets ignored', (): void => {
+  const identifier = { path: 'http://test.com/' };
+  const rep = new BasicRepresentation('<a:b> <a:b> c!', identifier, 'text/turtle');
+  const converter = new ChainedConverter([
+    new RdfToQuadConverter(),
+    new DummyConverter(),
+  ]);
+
+  it('does not throw on async crash.', async(): Promise<void> => {
+    jest.useFakeTimers();
+    const result = await converter.handleSafe({ identifier, representation: rep, preferences: {}});
+
+    expect(await readableToString(result.data)).toBe('dummy');
+
+    jest.advanceTimersByTime(1000);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes #462 
Based on https://github.com/solid/community-server/pull/462#issuecomment-758013492

The test in the first commit fails before doing the changes in the second commit.

This solution works and all tests pass, but now I get some of these errors when running the integrations tests:

```
ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.
      at Function.get (node_modules/logform/index.js:28:14)
      at WinstonLoggerFactory.createLogger (src/logging/WinstonLoggerFactory.ts:283:32)
      at LazyLogger.log (src/logging/LazyLogger.ts:290:58)
      at LazyLogger.error (src/logging/Logger.ts:322:17)
      at Timeout._onTimeout (src/util/GuardedStream.ts:33:24)
```

Which seems to imply that the guarded stream is now trying to log errors that are not being listened to. So keeping this PR in draft mode until I know if this is a problem with the new solution or the integration tests themselves.