### PR TITLE
Add Solid spec references + minor fixes

### DIFF
--- a/src/authorization/AclManager.ts
+++ b/src/authorization/AclManager.ts
@@ -2,6 +2,10 @@ import type { ResourceIdentifier } from '../ldp/representation/ResourceIdentifie
 
 /**
  * Handles where acl resources are stored.
+ *
+ * Solid, §4.3.3: "A given Solid resource MUST NOT be directly associated with more than one ACL auxiliary resource.
+ * A given ACL auxiliary resource MUST NOT be directly associated with more than one Solid resource."
+ * https://solid.github.io/specification/protocol#auxiliary-resources-reserved
  */
 export interface AclManager {
   /**

--- a/src/init/AclInitializer.ts
+++ b/src/init/AclInitializer.ts
@@ -51,6 +51,10 @@ export class AclInitializer extends Initializer {
 
   // Set up ACL so everything can still be done by default
   // Note that this will need to be adapted to go through all the correct channels later on
+  //
+  // Solid, §4.1: "The root container (pim:Storage) MUST have an ACL auxiliary resource directly associated to it.
+  // The associated ACL document MUST include an authorization policy with acl:Control access privilege."
+  // https://solid.github.io/specification/protocol#storage
   protected async setRootAclDocument(rootAcl: ResourceIdentifier): Promise<void> {
     const acl = `@prefix   acl:  <http://www.w3.org/ns/auth/acl#>.
 @prefix  foaf:  <http://xmlns.com/foaf/0.1/>.

--- a/src/init/RootContainerInitializer.ts
+++ b/src/init/RootContainerInitializer.ts
@@ -14,6 +14,10 @@ import namedNode = DataFactory.namedNode;
 
 /**
  * Initializes ResourceStores by creating a root container if it didn't exist yet.
+ *
+ * Solid, §4.1: "When a server supports a data pod, it MUST provide one or more storages (pim:Storage) –
+ * a space of URIs in which data can be accessed. A storage is the root container for all of its contained resources."
+ * https://solid.github.io/specification/protocol#storage
  */
 export class RootContainerInitializer extends Initializer {
   protected readonly logger = getLoggerFor(this);
@@ -59,6 +63,9 @@ export class RootContainerInitializer extends Initializer {
 
     // Make sure the root container is a pim:Storage
     // This prevents deletion of the root container as storage root containers can not be deleted
+    // Solid, §4.1: "Servers exposing the storage resource MUST advertise by including the HTTP Link header
+    // with rel="type" targeting http://www.w3.org/ns/pim/space#Storage when responding to storage’s request URI."
+    // https://solid.github.io/specification/protocol#storage
     metadata.add(RDF.type, PIM.terms.Storage);
 
     this.logger.debug(`Creating root container at ${this.baseId.path}`);

--- a/src/ldp/operations/PatchOperationHandler.ts
+++ b/src/ldp/operations/PatchOperationHandler.ts
@@ -1,4 +1,6 @@
+import { getLoggerFor } from '../../logging/LogUtil';
 import type { ResourceStore } from '../../storage/ResourceStore';
+import { BadRequestHttpError } from '../../util/errors/BadRequestHttpError';
 import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
 import type { Patch } from '../http/Patch';
 import { ResetResponseDescription } from '../http/response/ResetResponseDescription';
@@ -6,7 +8,13 @@ import type { ResponseDescription } from '../http/response/ResponseDescription';
 import type { Operation } from './Operation';
 import { OperationHandler } from './OperationHandler';
 
+/**
+ * Handles PATCH {@link Operation}s.
+ * Calls the modifyResource function from a {@link ResourceStore}.
+ */
 export class PatchOperationHandler extends OperationHandler {
+  protected readonly logger = getLoggerFor(this);
+
   private readonly store: ResourceStore;
 
   public constructor(store: ResourceStore) {
@@ -21,6 +29,13 @@ export class PatchOperationHandler extends OperationHandler {
   }
 
   public async handle(input: Operation): Promise<ResponseDescription> {
+    // Solid, §2.1: "A Solid server MUST reject PUT, POST and PATCH requests
+    // without the Content-Type header with a status code of 400."
+    // https://solid.github.io/specification/protocol#http-server
+    if (!input.body?.metadata.contentType) {
+      this.logger.warn('No Content-Type header specified on PATCH request');
+      throw new BadRequestHttpError('No Content-Type header specified on PATCH request');
+    }
     await this.store.modifyResource(input.target, input.body as Patch);
     return new ResetResponseDescription();
   }

--- a/src/ldp/operations/PostOperationHandler.ts
+++ b/src/ldp/operations/PostOperationHandler.ts
@@ -28,9 +28,12 @@ export class PostOperationHandler extends OperationHandler {
   }
 
   public async handle(input: Operation): Promise<ResponseDescription> {
-    if (!input.body) {
-      this.logger.warn('POST operations require a body');
-      throw new BadRequestHttpError('POST operations require a body');
+    // Solid, §2.1: "A Solid server MUST reject PUT, POST and PATCH requests
+    // without the Content-Type header with a status code of 400."
+    // https://solid.github.io/specification/protocol#http-server
+    if (!input.body?.metadata.contentType) {
+      this.logger.warn('No Content-Type header specified on POST request');
+      throw new BadRequestHttpError('No Content-Type header specified on POST request');
     }
     const identifier = await this.store.addResource(input.target, input.body);
     return new CreatedResponseDescription(identifier);

--- a/src/ldp/operations/PutOperationHandler.ts
+++ b/src/ldp/operations/PutOperationHandler.ts
@@ -28,9 +28,12 @@ export class PutOperationHandler extends OperationHandler {
   }
 
   public async handle(input: Operation): Promise<ResponseDescription> {
-    if (typeof input.body !== 'object') {
-      this.logger.warn('No body specified on PUT request');
-      throw new BadRequestHttpError('PUT operations require a body');
+    // Solid, §2.1: "A Solid server MUST reject PUT, POST and PATCH requests
+    // without the Content-Type header with a status code of 400."
+    // https://solid.github.io/specification/protocol#http-server
+    if (!input.body?.metadata.contentType) {
+      this.logger.warn('No Content-Type header specified on PUT request');
+      throw new BadRequestHttpError('No Content-Type header specified on PUT request');
     }
     await this.store.setRepresentation(input.target, input.body);
     return new ResetResponseDescription();

--- a/src/server/middleware/CorsHandler.ts
+++ b/src/server/middleware/CorsHandler.ts
@@ -22,6 +22,11 @@ interface SimpleCorsOptions {
 
 /**
  * Handler that sets CORS options on the response.
+ *
+ * Solid, §7.1: "A data pod MUST implement the CORS protocol [FETCH] such that, to the extent possible,
+ * the browser allows Solid apps to send any request and combination of request headers to the data pod,
+ * and the Solid app can read any response and response headers received from the data pod."
+ * Full details: https://solid.github.io/specification/protocol#cors-server
  */
 export class CorsHandler extends HttpHandler {
   private readonly corsHandler: RequestHandler;

--- a/src/storage/accessors/DataAccessor.ts
+++ b/src/storage/accessors/DataAccessor.ts
@@ -57,6 +57,11 @@ export interface DataAccessor {
 
   /**
    * Deletes the resource and its corresponding metadata.
+   *
+   * Solid, §5.4: "When a contained resource is deleted, the server MUST also remove the corresponding containment
+   * triple, which has the effect of removing the deleted resource from the containing container."
+   * https://solid.github.io/specification/protocol#deleting-resources
+   *
    * @param identifier - Resource to delete.
    */
   deleteResource: (identifier: ResourceIdentifier) => Promise<void>;

--- a/src/storage/patch/SparqlUpdatePatchHandler.ts
+++ b/src/storage/patch/SparqlUpdatePatchHandler.ts
@@ -92,7 +92,8 @@ export class SparqlUpdatePatchHandler extends PatchHandler {
       });
       this.logger.debug(`${store.size} quads in ${identifier.path}.`);
     } catch (error: unknown) {
-      // In case the resource does not exist yet we want to create it
+      // Solid, §5.1: "Clients who want to assign a URI to a resource, MUST use PUT and PATCH requests."
+      // https://solid.github.io/specification/protocol#resource-type-heuristics
       if (!(error instanceof NotFoundHttpError)) {
         throw error;
       }

--- a/src/util/PathUtil.ts
+++ b/src/util/PathUtil.ts
@@ -99,6 +99,8 @@ export function encodeUriPathComponents(path: string): string {
  * @param path - Path to check.
  */
 export function isContainerPath(path: string): boolean {
+  // Solid, §3.1: "Paths ending with a slash denote a container resource."
+  // https://solid.github.io/specification/protocol#uri-slash-semantics
   return path.endsWith('/');
 }
 

--- a/test/unit/authorization/WebAclAuthorizer.test.ts
+++ b/test/unit/authorization/WebAclAuthorizer.test.ts
@@ -8,7 +8,6 @@ import type { Representation } from '../../../src/ldp/representation/Representat
 import type { ResourceIdentifier } from '../../../src/ldp/representation/ResourceIdentifier';
 import type { ResourceStore } from '../../../src/storage/ResourceStore';
 import { ForbiddenHttpError } from '../../../src/util/errors/ForbiddenHttpError';
-import { InternalServerError } from '../../../src/util/errors/InternalServerError';
 import { NotFoundHttpError } from '../../../src/util/errors/NotFoundHttpError';
 import { UnauthorizedHttpError } from '../../../src/util/errors/UnauthorizedHttpError';
 import { SingleRootIdentifierStrategy } from '../../../src/util/identifiers/SingleRootIdentifierStrategy';
@@ -153,7 +152,7 @@ describe('A WebAclAuthorizer', (): void => {
     };
     const promise = authorizer.handle({ identifier, permissions, credentials });
     await expect(promise).rejects.toThrow('No ACL document found for root container');
-    await expect(promise).rejects.toThrow(InternalServerError);
+    await expect(promise).rejects.toThrow(ForbiddenHttpError);
   });
 
   it('allows an agent to append if they have write access.', async(): Promise<void> => {

--- a/test/unit/ldp/operations/PatchOperationHandler.test.ts
+++ b/test/unit/ldp/operations/PatchOperationHandler.test.ts
@@ -1,6 +1,8 @@
 import type { Operation } from '../../../../src/ldp/operations/Operation';
 import { PatchOperationHandler } from '../../../../src/ldp/operations/PatchOperationHandler';
+import { RepresentationMetadata } from '../../../../src/ldp/representation/RepresentationMetadata';
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
+import { BadRequestHttpError } from '../../../../src/util/errors/BadRequestHttpError';
 import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
 
 describe('A PatchOperationHandler', (): void => {
@@ -15,10 +17,17 @@ describe('A PatchOperationHandler', (): void => {
     await expect(handler.canHandle({ method: 'GET' } as Operation)).rejects.toThrow(NotImplementedHttpError);
   });
 
+  it('errors if there is no body or content-type.', async(): Promise<void> => {
+    await expect(handler.handle({ } as Operation)).rejects.toThrow(BadRequestHttpError);
+    await expect(handler.handle({ body: { metadata: new RepresentationMetadata() }} as Operation))
+      .rejects.toThrow(BadRequestHttpError);
+  });
+
   it('deletes the resource from the store and returns the correct response.', async(): Promise<void> => {
-    const result = await handler.handle({ target: { path: 'url' }, body: { binary: false }} as Operation);
+    const metadata = new RepresentationMetadata('text/turtle');
+    const result = await handler.handle({ target: { path: 'url' }, body: { metadata }} as Operation);
     expect(store.modifyResource).toHaveBeenCalledTimes(1);
-    expect(store.modifyResource).toHaveBeenLastCalledWith({ path: 'url' }, { binary: false });
+    expect(store.modifyResource).toHaveBeenLastCalledWith({ path: 'url' }, { metadata });
     expect(result.statusCode).toBe(205);
     expect(result.metadata).toBeUndefined();
     expect(result.data).toBeUndefined();

--- a/test/unit/ldp/operations/PostOperationHandler.test.ts
+++ b/test/unit/ldp/operations/PostOperationHandler.test.ts
@@ -20,12 +20,15 @@ describe('A PostOperationHandler', (): void => {
       .rejects.toThrow(NotImplementedHttpError);
   });
 
-  it('errors if there is no body.', async(): Promise<void> => {
-    await expect(handler.handle({ method: 'POST' } as Operation)).rejects.toThrow(BadRequestHttpError);
+  it('errors if there is no body or content-type.', async(): Promise<void> => {
+    await expect(handler.handle({ } as Operation)).rejects.toThrow(BadRequestHttpError);
+    await expect(handler.handle({ body: { metadata: new RepresentationMetadata() }} as Operation))
+      .rejects.toThrow(BadRequestHttpError);
   });
 
   it('adds the given representation to the store and returns the correct response.', async(): Promise<void> => {
-    const result = await handler.handle({ method: 'POST', body: { }} as Operation);
+    const metadata = new RepresentationMetadata('text/turtle');
+    const result = await handler.handle({ method: 'POST', body: { metadata }} as Operation);
     expect(result.statusCode).toBe(201);
     expect(result.metadata).toBeInstanceOf(RepresentationMetadata);
     expect(result.metadata?.get(HTTP.location)?.value).toBe('newPath');


### PR DESCRIPTION
I went through the Solid spec to add references to all relevant parts in the code. This included making some minor changes here and there to be fully compliant to some parts, also fixes #480 .

The code changes are:
 * Changing some of the errors being thrown in `DataAccesorBasedStore` and streamlining some of the behaviour there.
 * Checking for content-type in the POST/PUT/PATCH operation handlers.
 * Changing an error in the acl handler.

There are some duplicate quotes in `DataAccessorBasedStore` since some general quotes are sometimes relevant in multiple places, but it seemd ok to me since this is the class that does a large part of the behaviour interactions.

What might be more interesting is the list of things we're not compliant with, I'm going to make an issue for that later so it can be discussed there.

Would btw be really cool if someone made a script that listens to changes in the Solid spec and automatically checks if one of those changes a quote we have in our code so we know if we need to change something 😉 .