### PR TITLE
fix: Token verification lenient on client_id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1102,9 +1102,9 @@
       }
     },
     "@solid/identity-token-verifier": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@solid/identity-token-verifier/-/identity-token-verifier-0.4.3.tgz",
-      "integrity": "sha512-LwE3QOImK4prBMR2Q79Jx70Aghk5K+rH+BrsSlgqYVv+zl0u2Ir47LtptBvxTq6CjpYeoZ7Hxgao5g8B/AMCQw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@solid/identity-token-verifier/-/identity-token-verifier-0.5.0.tgz",
+      "integrity": "sha512-PJoGEVDh9rpuZe7FUwcqpsCD4Fz2+YrIEStnosLwBahyc5EKICtnP2qaIWx2p1AOxYGNR02Ub8BYOJgDlzC3BQ==",
       "requires": {
         "cross-fetch": "^3.0.6",
         "jose": "^3.5.0",
@@ -6438,9 +6438,9 @@
       "dev": true
     },
     "jose": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-3.5.0.tgz",
-      "integrity": "sha512-pW9z+ny33gxX2wXLQl3SkPQWGaUvOMYLijuiMHIHUYIDsrZjdMqYYS5UTkusuMzZkqe5T8YImA4FOqqB1IWmRg=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-3.5.1.tgz",
+      "integrity": "sha512-BQQJafCDvsmtc/LaK57cjfhU/1AKBhJSbJhKPq+uhrjMoV/sh3/dbk9cm08nAeSGS6j+sjhWoY+LZPUXiKzYzw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   ],
   "dependencies": {
     "@rdfjs/data-model": "^1.2.0",
-    "@solid/identity-token-verifier": "^0.4.3",
+    "@solid/identity-token-verifier": "^0.5.0",
     "@types/arrayify-stream": "^1.0.0",
     "@types/async-lock": "^1.1.2",
     "@types/cors": "^2.8.6",


### PR DESCRIPTION
Updated https://github.com/solid/identity-token-verifier to be lenient on the [presence of the required](https://solid.github.io/authentication-panel/solid-oidc/#tokens-access) `client_id` claim in access tokens as it is not widely implemented in the Solid identity providers as of now.

See also: https://github.com/solid/identity-token-verifier/commit/ffa9ad4b04abdb43ae4cc6e63670a38c78789472