### PR TITLE
test: Always collect coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,19 +14,12 @@ module.exports = {
   ],
   testEnvironment: 'node',
   setupFilesAfterEnv: [ 'jest-rdf', '<rootDir>/test/util/SetupTests.ts' ],
+  collectCoverage: true,
   coveragePathIgnorePatterns: [
     '/dist/',
     '/node_modules/',
     '/test/',
   ],
-  coverageThreshold: {
-    './src': {
-      branches: 100,
-      functions: 100,
-      lines: 100,
-      statements: 100,
-    },
-  },
   // Slower machines had problems calling the WebSocket integration callbacks on time
   testTimeout: 10000,
 };

--- a/jest.coverage.config.js
+++ b/jest.coverage.config.js
@@ -1,0 +1,13 @@
+const jestConfig = require('./jest.config');
+
+module.exports = {
+  ...jestConfig,
+  coverageThreshold: {
+    './src': {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "test:deploy": "test/deploy/validate-package.sh",
     "test:ts": "tsc -p test --noEmit",
     "test:integration": "jest test/integration",
-    "test:unit": "jest --collectCoverage test/unit",
+    "test:unit": "jest --config=./jest.coverage.config.js test/unit",
     "test:watch": "jest --watch test/unit",
     "validate": "componentsjs-compile-config urn:solid-server:default:Initializer -c config/config-default.json -f > /dev/null",
     "version": "manual-git-changelog onversion",

--- a/test/unit/init/CliRunner.test.ts
+++ b/test/unit/init/CliRunner.test.ts
@@ -157,7 +157,9 @@ describe('CliRunner', (): void => {
 
   it('exits with output to stderr when instantiation fails.', async(): Promise<void> => {
     manager.instantiate.mockRejectedValueOnce(new Error('Fatal'));
-    new CliRunner().run();
+    new CliRunner().run({
+      argv: [ 'node', 'script' ],
+    });
     await new Promise((resolve): any => setImmediate(resolve));
 
     expect(write).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
Collect coverage by default, but only set the thresholds when running `test:unit`.

I ran into the issue where I often tested single test files if I'm working on a single class, but I also wanted to see if the coverage for tha class remained at 100%. This also sometimes caused jest to cache the results without coverage which would create issues when running the full tests if I didn't clear the jest cache.

I never actually use `test:watch` so not sure if it should also be added there. Not sure what the use case is for that one.