### PR TITLE
fix: Remove all instanceof checks

### DIFF
--- a/src/authorization/WebAclAuthorizer.ts
+++ b/src/authorization/WebAclAuthorizer.ts
@@ -149,7 +149,7 @@ export class WebAclAuthorizer extends Authorizer {
       const resourceId = await this.aclManager.getAclConstrainedResource(id);
       return this.filterData(data, recurse ? ACL.default : ACL.accessTo, resourceId.path);
     } catch (error: unknown) {
-      if (error instanceof NotFoundHttpError) {
+      if (NotFoundHttpError.isInstance(error)) {
         this.logger.debug(`No direct ACL document found for ${id.path}`);
       } else {
         this.logger.error(`Error reading ACL for ${id.path}: ${(error as Error).message}`, { error });

--- a/src/ldp/AuthenticatedLdpHandler.ts
+++ b/src/ldp/AuthenticatedLdpHandler.ts
@@ -6,6 +6,7 @@ import type { HttpHandlerInput } from '../server/HttpHandler';
 import { HttpHandler } from '../server/HttpHandler';
 import type { HttpRequest } from '../server/HttpRequest';
 import type { HttpResponse } from '../server/HttpResponse';
+import { isNativeError } from '../util/errors/ErrorUtil';
 import type { RequestParser } from './http/RequestParser';
 import type { ResponseDescription } from './http/response/ResponseDescription';
 import type { ResponseWriter } from './http/ResponseWriter';
@@ -95,7 +96,7 @@ export class AuthenticatedLdpHandler extends HttpHandler {
     try {
       writeData = { response: input.response, result: await this.runHandlers(input.request) };
     } catch (error: unknown) {
-      if (error instanceof Error) {
+      if (isNativeError(error)) {
         writeData = { response: input.response, result: error };
       } else {
         throw error;

--- a/src/ldp/http/BasicResponseWriter.ts
+++ b/src/ldp/http/BasicResponseWriter.ts
@@ -1,6 +1,7 @@
 import { getLoggerFor } from '../../logging/LogUtil';
 import type { HttpResponse } from '../../server/HttpResponse';
 import { INTERNAL_QUADS } from '../../util/ContentTypes';
+import { isNativeError } from '../../util/errors/ErrorUtil';
 import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
 import { pipeSafely } from '../../util/StreamUtil';
 import type { MetadataWriter } from './metadata/MetadataWriter';
@@ -20,7 +21,7 @@ export class BasicResponseWriter extends ResponseWriter {
   }
 
   public async canHandle(input: { response: HttpResponse; result: ResponseDescription | Error }): Promise<void> {
-    if (input.result instanceof Error || input.result.metadata?.contentType === INTERNAL_QUADS) {
+    if (isNativeError(input.result) || input.result.metadata?.contentType === INTERNAL_QUADS) {
       throw new NotImplementedHttpError('Only successful binary responses are supported');
     }
   }

--- a/src/ldp/http/ErrorResponseWriter.ts
+++ b/src/ldp/http/ErrorResponseWriter.ts
@@ -1,5 +1,6 @@
 import { getLoggerFor } from '../../logging/LogUtil';
 import type { HttpResponse } from '../../server/HttpResponse';
+import { isNativeError } from '../../util/errors/ErrorUtil';
 import { HttpError } from '../../util/errors/HttpError';
 import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
 import type { ResponseDescription } from './response/ResponseDescription';
@@ -12,14 +13,14 @@ export class ErrorResponseWriter extends ResponseWriter {
   protected readonly logger = getLoggerFor(this);
 
   public async canHandle(input: { response: HttpResponse; result: ResponseDescription | Error }): Promise<void> {
-    if (!(input.result instanceof Error)) {
+    if (!isNativeError(input.result)) {
       throw new NotImplementedHttpError('Only errors are supported');
     }
   }
 
   public async handle(input: { response: HttpResponse; result: Error }): Promise<void> {
     let code = 500;
-    if (input.result instanceof HttpError) {
+    if (HttpError.isInstance(input.result)) {
       code = input.result.statusCode;
     }
     input.response.setHeader('content-type', 'text/plain');

--- a/src/ldp/http/SparqlUpdateBodyParser.ts
+++ b/src/ldp/http/SparqlUpdateBodyParser.ts
@@ -4,12 +4,12 @@ import { translate } from 'sparqlalgebrajs';
 import { getLoggerFor } from '../../logging/LogUtil';
 import { APPLICATION_SPARQL_UPDATE } from '../../util/ContentTypes';
 import { BadRequestHttpError } from '../../util/errors/BadRequestHttpError';
+import { isNativeError } from '../../util/errors/ErrorUtil';
 import { UnsupportedMediaTypeHttpError } from '../../util/errors/UnsupportedMediaTypeHttpError';
 import { pipeSafely, readableToString } from '../../util/StreamUtil';
 import type { BodyParserArgs } from './BodyParser';
 import { BodyParser } from './BodyParser';
 import type { SparqlUpdatePatch } from './SparqlUpdatePatch';
-
 /**
  * {@link BodyParser} that supports `application/sparql-update` content.
  * Will convert the incoming update string to algebra in a {@link SparqlUpdatePatch}.
@@ -34,7 +34,7 @@ export class SparqlUpdateBodyParser extends BodyParser {
       algebra = translate(sparql, { quads: true, baseIRI: metadata.identifier.value });
     } catch (error: unknown) {
       this.logger.warn('Could not translate SPARQL query to SPARQL algebra', { error });
-      if (error instanceof Error) {
+      if (isNativeError(error)) {
         throw new BadRequestHttpError(error.message);
       }
       throw new BadRequestHttpError();

--- a/src/pods/PodManagerHttpHandler.ts
+++ b/src/pods/PodManagerHttpHandler.ts
@@ -5,6 +5,7 @@ import { HttpHandler } from '../server/HttpHandler';
 import type { HttpRequest } from '../server/HttpRequest';
 import type { HttpResponse } from '../server/HttpResponse';
 import { BadRequestHttpError } from '../util/errors/BadRequestHttpError';
+import { isNativeError } from '../util/errors/ErrorUtil';
 import { InternalServerError } from '../util/errors/InternalServerError';
 import { NotImplementedHttpError } from '../util/errors/NotImplementedHttpError';
 import type { AgentParser } from './agent/AgentParser';
@@ -59,7 +60,7 @@ export class PodManagerHttpHandler extends HttpHandler {
 
       await this.responseWriter.handleSafe({ response, result: new CreatedResponseDescription(id) });
     } catch (error: unknown) {
-      if (error instanceof Error) {
+      if (isNativeError(error)) {
         await this.responseWriter.handleSafe({ response, result: error });
       } else {
         await this.responseWriter.handleSafe({ response, result: new InternalServerError('Unexpected error') });

--- a/src/server/ExpressHttpServerFactory.ts
+++ b/src/server/ExpressHttpServerFactory.ts
@@ -2,6 +2,7 @@ import type { Server } from 'http';
 import type { Express } from 'express';
 import express from 'express';
 import { getLoggerFor } from '../logging/LogUtil';
+import { isNativeError } from '../util/errors/ErrorUtil';
 import { guardStream } from '../util/GuardedStream';
 import type { HttpHandler } from './HttpHandler';
 import type { HttpServerFactory } from './HttpServerFactory';
@@ -26,7 +27,7 @@ export class ExpressHttpServerFactory implements HttpServerFactory {
         this.logger.info(`Received request for ${request.url}`);
         await this.handler.handleSafe({ request: guardStream(request), response });
       } catch (error: unknown) {
-        const errMsg = error instanceof Error ? `${error.name}: ${error.message}\n${error.stack}` : 'Unknown error.';
+        const errMsg = isNativeError(error) ? `${error.name}: ${error.message}\n${error.stack}` : 'Unknown error.';
         this.logger.error(errMsg);
         if (response.headersSent) {
           response.end();

--- a/src/storage/RoutingResourceStore.ts
+++ b/src/storage/RoutingResourceStore.ts
@@ -53,7 +53,7 @@ export class RoutingResourceStore implements ResourceStore {
     try {
       return await this.rule.handleSafe({ identifier });
     } catch (error: unknown) {
-      if (error instanceof NotImplementedHttpError) {
+      if (NotImplementedHttpError.isInstance(error)) {
         throw new NotFoundHttpError();
       }
       throw error;

--- a/src/storage/StoreUtil.ts
+++ b/src/storage/StoreUtil.ts
@@ -1,6 +1,6 @@
 import type { ResourceIdentifier } from '../ldp/representation/ResourceIdentifier';
-import type { ResourceStore } from '../storage/ResourceStore';
 import { NotFoundHttpError } from '../util/errors/NotFoundHttpError';
+import type { ResourceStore } from './ResourceStore';
 
 export async function containsResource(store: ResourceStore, identifier: ResourceIdentifier): Promise<boolean> {
   try {
@@ -8,7 +8,7 @@ export async function containsResource(store: ResourceStore, identifier: Resourc
     result.data.destroy();
     return true;
   } catch (error: unknown) {
-    if (error instanceof NotFoundHttpError) {
+    if (NotFoundHttpError.isInstance(error)) {
       return false;
     }
     throw error;

--- a/src/storage/accessors/InMemoryDataAccessor.ts
+++ b/src/storage/accessors/InMemoryDataAccessor.ts
@@ -72,7 +72,7 @@ export class InMemoryDataAccessor implements DataAccessor {
       entry.metadata = metadata;
     } catch (error: unknown) {
       // Create new entry if it didn't exist yet
-      if (error instanceof NotFoundHttpError) {
+      if (NotFoundHttpError.isInstance(error)) {
         const { parent, name } = this.getParentEntry(identifier);
         parent.entries[name] = {
           entries: {},

--- a/src/storage/accessors/SparqlDataAccessor.ts
+++ b/src/storage/accessors/SparqlDataAccessor.ts
@@ -20,6 +20,7 @@ import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdenti
 import { getLoggerFor } from '../../logging/LogUtil';
 import { INTERNAL_QUADS } from '../../util/ContentTypes';
 import { ConflictHttpError } from '../../util/errors/ConflictHttpError';
+import { isNativeError } from '../../util/errors/ErrorUtil';
 import { NotFoundHttpError } from '../../util/errors/NotFoundHttpError';
 import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
 import { UnsupportedMediaTypeHttpError } from '../../util/errors/UnsupportedMediaTypeHttpError';
@@ -310,7 +311,7 @@ export class SparqlDataAccessor implements DataAccessor {
     try {
       return guardStream(await this.fetcher.fetchTriples(this.endpoint, query));
     } catch (error: unknown) {
-      if (error instanceof Error) {
+      if (isNativeError(error)) {
         this.logger.error(`SPARQL endpoint ${this.endpoint} error: ${error.message}`);
       }
       throw error;
@@ -327,7 +328,7 @@ export class SparqlDataAccessor implements DataAccessor {
     try {
       return await this.fetcher.fetchUpdate(this.endpoint, query);
     } catch (error: unknown) {
-      if (error instanceof Error) {
+      if (isNativeError(error)) {
         this.logger.error(`SPARQL endpoint ${this.endpoint} error: ${error.message}`);
       }
       throw error;

--- a/src/storage/patch/SparqlUpdatePatchHandler.ts
+++ b/src/storage/patch/SparqlUpdatePatchHandler.ts
@@ -115,7 +115,7 @@ export class SparqlUpdatePatchHandler extends PatchHandler {
     } catch (error: unknown) {
       // Solid, §5.1: "Clients who want to assign a URI to a resource, MUST use PUT and PATCH requests."
       // https://solid.github.io/specification/protocol#resource-type-heuristics
-      if (!(error instanceof NotFoundHttpError)) {
+      if (!NotFoundHttpError.isInstance(error)) {
         throw error;
       }
       this.logger.debug(`Patching new resource ${identifier.path}.`);

--- a/src/util/WaterfallHandler.ts
+++ b/src/util/WaterfallHandler.ts
@@ -1,6 +1,7 @@
 import { getLoggerFor } from '../logging/LogUtil';
 import type { AsyncHandler } from './AsyncHandler';
 import { BadRequestHttpError } from './errors/BadRequestHttpError';
+import { isNativeError } from './errors/ErrorUtil';
 import { HttpError } from './errors/HttpError';
 import { InternalServerError } from './errors/InternalServerError';
 
@@ -84,9 +85,9 @@ export class WaterfallHandler<TIn, TOut> implements AsyncHandler<TIn, TOut> {
 
         return handler;
       } catch (error: unknown) {
-        if (error instanceof HttpError) {
+        if (HttpError.isInstance(error)) {
           errors.push(error);
-        } else if (error instanceof Error) {
+        } else if (isNativeError(error)) {
           errors.push(new InternalServerError(error.message));
         } else {
           errors.push(new InternalServerError('Unknown error'));

--- a/src/util/errors/BadRequestHttpError.ts
+++ b/src/util/errors/BadRequestHttpError.ts
@@ -12,4 +12,8 @@ export class BadRequestHttpError extends HttpError {
   public constructor(message?: string) {
     super(400, 'BadRequestHttpError', message ?? 'The given input is not supported by the server configuration.');
   }
+
+  public static isInstance(error: any): error is BadRequestHttpError {
+    return HttpError.isInstance(error) && error.statusCode === 400;
+  }
 }

--- a/src/util/errors/ConflictHttpError.ts
+++ b/src/util/errors/ConflictHttpError.ts
@@ -6,4 +6,8 @@ export class ConflictHttpError extends HttpError {
   public constructor(message?: string) {
     super(409, 'ConflictHttpError', message);
   }
+
+  public static isInstance(error: any): error is ConflictHttpError {
+    return HttpError.isInstance(error) && error.statusCode === 409;
+  }
 }

--- a/src/util/errors/ErrorUtil.ts
+++ b/src/util/errors/ErrorUtil.ts
@@ -1,0 +1,8 @@
+import { types } from 'util';
+
+/**
+ * Checks if the input is an {@link Error}.
+ */
+export function isNativeError(error: any): error is Error {
+  return types.isNativeError(error);
+}

--- a/src/util/errors/ForbiddenHttpError.ts
+++ b/src/util/errors/ForbiddenHttpError.ts
@@ -7,4 +7,8 @@ export class ForbiddenHttpError extends HttpError {
   public constructor(message?: string) {
     super(403, 'ForbiddenHttpError', message);
   }
+
+  public static isInstance(error: any): error is ForbiddenHttpError {
+    return HttpError.isInstance(error) && error.statusCode === 403;
+  }
 }

--- a/src/util/errors/HttpError.ts
+++ b/src/util/errors/HttpError.ts
@@ -1,9 +1,12 @@
+import { isNativeError } from './ErrorUtil';
+
 /**
  * A class for all errors that could be thrown by Solid.
  * All errors inheriting from this should fix the status code thereby hiding the HTTP internals from other components.
  */
 export class HttpError extends Error {
-  public statusCode: number;
+  protected static readonly statusCode: number;
+  public readonly statusCode: number;
 
   /**
    * Creates a new HTTP error. Subclasses should call this with their fixed status code.
@@ -15,5 +18,9 @@ export class HttpError extends Error {
     super(message);
     this.statusCode = statusCode;
     this.name = name;
+  }
+
+  public static isInstance(error: any): error is HttpError {
+    return isNativeError(error) && typeof (error as any).statusCode === 'number';
   }
 }

--- a/src/util/errors/InternalServerError.ts
+++ b/src/util/errors/InternalServerError.ts
@@ -6,4 +6,8 @@ export class InternalServerError extends HttpError {
   public constructor(message?: string) {
     super(500, 'InternalServerError', message);
   }
+
+  public static isInstance(error: any): error is InternalServerError {
+    return HttpError.isInstance(error) && error.statusCode === 500;
+  }
 }

--- a/src/util/errors/MethodNotAllowedHttpError.ts
+++ b/src/util/errors/MethodNotAllowedHttpError.ts
@@ -6,4 +6,8 @@ export class MethodNotAllowedHttpError extends HttpError {
   public constructor(message?: string) {
     super(405, 'MethodNotAllowedHttpError', message);
   }
+
+  public static isInstance(error: any): error is MethodNotAllowedHttpError {
+    return HttpError.isInstance(error) && error.statusCode === 405;
+  }
 }

--- a/src/util/errors/NotFoundHttpError.ts
+++ b/src/util/errors/NotFoundHttpError.ts
@@ -6,4 +6,8 @@ export class NotFoundHttpError extends HttpError {
   public constructor(message?: string) {
     super(404, 'NotFoundHttpError', message);
   }
+
+  public static isInstance(error: any): error is NotFoundHttpError {
+    return HttpError.isInstance(error) && error.statusCode === 404;
+  }
 }

--- a/src/util/errors/NotImplementedHttpError.ts
+++ b/src/util/errors/NotImplementedHttpError.ts
@@ -7,4 +7,8 @@ export class NotImplementedHttpError extends HttpError {
   public constructor(message?: string) {
     super(501, 'NotImplementedHttpError', message);
   }
+
+  public static isInstance(error: any): error is NotImplementedHttpError {
+    return HttpError.isInstance(error) && error.statusCode === 501;
+  }
 }

--- a/src/util/errors/UnauthorizedHttpError.ts
+++ b/src/util/errors/UnauthorizedHttpError.ts
@@ -7,4 +7,8 @@ export class UnauthorizedHttpError extends HttpError {
   public constructor(message?: string) {
     super(401, 'UnauthorizedHttpError', message);
   }
+
+  public static isInstance(error: any): error is UnauthorizedHttpError {
+    return HttpError.isInstance(error) && error.statusCode === 401;
+  }
 }

--- a/src/util/errors/UnsupportedMediaTypeHttpError.ts
+++ b/src/util/errors/UnsupportedMediaTypeHttpError.ts
@@ -7,4 +7,8 @@ export class UnsupportedMediaTypeHttpError extends HttpError {
   public constructor(message?: string) {
     super(415, 'UnsupportedMediaTypeHttpError', message);
   }
+
+  public static isInstance(error: any): error is UnsupportedMediaTypeHttpError {
+    return HttpError.isInstance(error) && error.statusCode === 415;
+  }
 }

--- a/test/unit/util/errors/HttpError.test.ts
+++ b/test/unit/util/errors/HttpError.test.ts
@@ -1,0 +1,40 @@
+import { BadRequestHttpError } from '../../../../src/util/errors/BadRequestHttpError';
+import { ConflictHttpError } from '../../../../src/util/errors/ConflictHttpError';
+import { ForbiddenHttpError } from '../../../../src/util/errors/ForbiddenHttpError';
+import { HttpError } from '../../../../src/util/errors/HttpError';
+import { InternalServerError } from '../../../../src/util/errors/InternalServerError';
+import { MethodNotAllowedHttpError } from '../../../../src/util/errors/MethodNotAllowedHttpError';
+import { NotFoundHttpError } from '../../../../src/util/errors/NotFoundHttpError';
+import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
+import { UnauthorizedHttpError } from '../../../../src/util/errors/UnauthorizedHttpError';
+import { UnsupportedMediaTypeHttpError } from '../../../../src/util/errors/UnsupportedMediaTypeHttpError';
+
+// Only used to make typings easier in the tests
+class FixedHttpError extends HttpError {
+  public constructor(message?: string) {
+    super(0, '', message);
+  }
+}
+
+describe('An HttpError', (): void => {
+  const errors: [string, number, typeof FixedHttpError][] = [
+    [ 'BadRequestHttpError', 400, BadRequestHttpError ],
+    [ 'UnauthorizedHttpError', 401, UnauthorizedHttpError ],
+    [ 'ForbiddenHttpError', 403, ForbiddenHttpError ],
+    [ 'NotFoundHttpError', 404, NotFoundHttpError ],
+    [ 'MethodNotAllowedHttpError', 405, MethodNotAllowedHttpError ],
+    [ 'ConflictHttpError', 409, ConflictHttpError ],
+    [ 'MethodNotAllowedHttpError', 405, MethodNotAllowedHttpError ],
+    [ 'UnsupportedMediaTypeHttpError', 415, UnsupportedMediaTypeHttpError ],
+    [ 'InternalServerError', 500, InternalServerError ],
+    [ 'NotImplementedHttpError', 501, NotImplementedHttpError ],
+  ];
+
+  it.each(errors)('%s is valid', (name, statusCode, constructor): void => {
+    const instance = new constructor('message');
+    expect(constructor.isInstance(instance)).toBeTruthy();
+    expect(instance.statusCode).toBe(statusCode);
+    expect(instance.name).toBe(name);
+    expect(instance.message).toBe('message');
+  });
+});


### PR DESCRIPTION
Closes #464.

I looked into having a fancy static typing solution so only 1 instance of the function had to be written, but all solutions I found had typing issues or got way too extensive for something that is just a simple change so I kept it simple in the end.

Also includes an extra unit test to make sure our errors actually have the correct status codes.