### PR TITLE
Implement actual read/write locking algorithm

### DIFF
--- a/config/presets/storage-wrapper.json
+++ b/config/presets/storage-wrapper.json
@@ -51,10 +51,19 @@
       "@id": "urn:solid-server:default:ResourceLocker",
       "@type": "WrappedExpiringReadWriteLocker",
       "WrappedExpiringReadWriteLocker:_locker": {
-        "@type": "EqualReadWriteLocker",
-        "EqualReadWriteLocker:_locker": {
+        "@type": "GreedyReadWriteLocker",
+        "GreedyReadWriteLocker:_locker": {
           "@type": "SingleThreadedResourceLocker"
-        }
+        },
+        "GreedyReadWriteLocker:_storage": {
+          "@type": "ResourceIdentifierStorage",
+          "ResourceIdentifierStorage:_source": {
+            "@type": "MemoryMapStorage"
+          }
+        },
+        "GreedyReadWriteLocker:_suffixes_count": "count",
+        "GreedyReadWriteLocker:_suffixes_read": "read",
+        "GreedyReadWriteLocker:_suffixes_write": "write"
       },
       "WrappedExpiringReadWriteLocker:_expiration": 3000
     },

--- a/config/presets/storage-wrapper.json
+++ b/config/presets/storage-wrapper.json
@@ -49,11 +49,14 @@
 
     {
       "@id": "urn:solid-server:default:ResourceLocker",
-      "@type": "WrappedExpiringResourceLocker",
-      "WrappedExpiringResourceLocker:_locker": {
-        "@type": "SingleThreadedResourceLocker"
+      "@type": "WrappedExpiringReadWriteLocker",
+      "WrappedExpiringReadWriteLocker:_locker": {
+        "@type": "EqualReadWriteLocker",
+        "EqualReadWriteLocker:_locker": {
+          "@type": "SingleThreadedResourceLocker"
+        }
       },
-      "WrappedExpiringResourceLocker:_expiration": 3000
+      "WrappedExpiringReadWriteLocker:_expiration": 3000
     },
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,7 @@ export * from './util/identifiers/SingleRootIdentifierStrategy';
 // Util/Locking
 export * from './util/locking/ExpiringReadWriteLocker';
 export * from './util/locking/EqualReadWriteLocker';
+export * from './util/locking/GreedyReadWriteLocker';
 export * from './util/locking/ReadWriteLocker';
 export * from './util/locking/ResourceLocker';
 export * from './util/locking/SingleThreadedResourceLocker';

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,12 @@ export * from './storage/conversion/RdfToQuadConverter';
 export * from './storage/conversion/RepresentationConverter';
 export * from './storage/conversion/TypedRepresentationConverter';
 
+// Storage/KeyValueStorage
+export * from './storage/keyvalue/JsonResourceStorage';
+export * from './storage/keyvalue/KeyValueStorage';
+export * from './storage/keyvalue/MemoryMapStorage';
+export * from './storage/keyvalue/ResourceIdentifierStorage';
+
 // Storage/Mapping
 export * from './storage/mapping/BaseFileIdentifierMapper';
 export * from './storage/mapping/ExtensionBasedMapper';

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,10 +199,12 @@ export * from './util/identifiers/IdentifierStrategy';
 export * from './util/identifiers/SingleRootIdentifierStrategy';
 
 // Util/Locking
-export * from './util/locking/ExpiringResourceLocker';
+export * from './util/locking/ExpiringReadWriteLocker';
+export * from './util/locking/EqualReadWriteLocker';
+export * from './util/locking/ReadWriteLocker';
 export * from './util/locking/ResourceLocker';
 export * from './util/locking/SingleThreadedResourceLocker';
-export * from './util/locking/WrappedExpiringResourceLocker';
+export * from './util/locking/WrappedExpiringReadWriteLocker';
 
 // Util
 export * from './util/ContentTypes';

--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -5,7 +5,7 @@ import type { Representation } from '../ldp/representation/Representation';
 import type { RepresentationPreferences } from '../ldp/representation/RepresentationPreferences';
 import type { ResourceIdentifier } from '../ldp/representation/ResourceIdentifier';
 import { getLoggerFor } from '../logging/LogUtil';
-import type { ExpiringResourceLocker } from '../util/locking/ExpiringResourceLocker';
+import type { ExpiringReadWriteLocker } from '../util/locking/ExpiringReadWriteLocker';
 import type { AtomicResourceStore } from './AtomicResourceStore';
 import type { Conditions } from './Conditions';
 import type { ResourceStore } from './ResourceStore';
@@ -19,9 +19,9 @@ export class LockingResourceStore implements AtomicResourceStore {
   protected readonly logger = getLoggerFor(this);
 
   private readonly source: ResourceStore;
-  private readonly locks: ExpiringResourceLocker;
+  private readonly locks: ExpiringReadWriteLocker;
 
-  public constructor(source: ResourceStore, locks: ExpiringResourceLocker) {
+  public constructor(source: ResourceStore, locks: ExpiringReadWriteLocker) {
     this.source = source;
     this.locks = locks;
   }

--- a/src/storage/keyvalue/JsonResourceStorage.ts
+++ b/src/storage/keyvalue/JsonResourceStorage.ts
@@ -1,0 +1,64 @@
+import { BasicRepresentation } from '../../ldp/representation/BasicRepresentation';
+import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
+import { NotFoundHttpError } from '../../util/errors/NotFoundHttpError';
+import { readableToString } from '../../util/StreamUtil';
+import type { ResourceStore } from '../ResourceStore';
+import type { KeyValueStorage } from './KeyValueStorage';
+
+/**
+ * A {@link KeyValueStorage} for strings using a {@link ResourceStore} as backend.
+ *
+ * Values will be sent as data streams to the given identifiers,
+ * so how these are stored depend on the underlying store.
+ *
+ * All non-404 errors will be re-thrown.
+ */
+export class JsonResourceStorage implements KeyValueStorage<ResourceIdentifier, unknown> {
+  private readonly source: ResourceStore;
+
+  public constructor(source: ResourceStore) {
+    this.source = source;
+  }
+
+  public async get(identifier: ResourceIdentifier): Promise<unknown | undefined> {
+    try {
+      const representation = await this.source.getRepresentation(identifier, { type: { 'application/json': 1 }});
+      return JSON.parse(await readableToString(representation.data));
+    } catch (error: unknown) {
+      if (!NotFoundHttpError.isInstance(error)) {
+        throw error;
+      }
+    }
+  }
+
+  public async has(identifier: ResourceIdentifier): Promise<boolean> {
+    try {
+      const representation = await this.source.getRepresentation(identifier, { type: { 'application/json': 1 }});
+      representation.data.destroy();
+      return true;
+    } catch (error: unknown) {
+      if (!NotFoundHttpError.isInstance(error)) {
+        throw error;
+      }
+      return false;
+    }
+  }
+
+  public async set(identifier: ResourceIdentifier, value: unknown): Promise<this> {
+    const representation = new BasicRepresentation(JSON.stringify(value), identifier, 'application/json');
+    await this.source.setRepresentation(identifier, representation);
+    return this;
+  }
+
+  public async delete(identifier: ResourceIdentifier): Promise<boolean> {
+    try {
+      await this.source.deleteResource(identifier);
+      return true;
+    } catch (error: unknown) {
+      if (!NotFoundHttpError.isInstance(error)) {
+        throw error;
+      }
+      return false;
+    }
+  }
+}

--- a/src/storage/keyvalue/KeyValueStorage.ts
+++ b/src/storage/keyvalue/KeyValueStorage.ts
@@ -1,0 +1,36 @@
+/**
+ * A simple storage solution that can be used for internal values that need to be stored.
+ * In general storages taking objects as keys are expected to work with different instances
+ * of an object with the same values. Exceptions to this expectation should be clearly documented.
+ */
+export interface KeyValueStorage<TKey, TValue> {
+  /**
+   * Returns the value stored for the given identifier.
+   * `undefined` if no value is stored.
+   * @param identifier - Identifier to get the value for.
+   */
+  get: (key: TKey) => Promise<TValue | undefined>;
+
+  /**
+   * Checks if there is a value stored for the given key.
+   * @param identifier - Identifier to check.
+   */
+  has: (key: TKey) => Promise<boolean>;
+
+  /**
+   * Sets the value for the given key.
+   * @param key - Key to set/update.
+   * @param value - Value to store.
+   *
+   * @returns The storage.
+   */
+  set: (key: TKey, value: TValue) => Promise<this>;
+
+  /**
+   * Deletes the value stored for the given key.
+   * @param key - Key to delete.
+   *
+   * @returns If there was a value to delete.
+   */
+  delete: (key: TKey) => Promise<boolean>;
+}

--- a/src/storage/keyvalue/MemoryMapStorage.ts
+++ b/src/storage/keyvalue/MemoryMapStorage.ts
@@ -1,0 +1,31 @@
+import type { KeyValueStorage } from './KeyValueStorage';
+
+/**
+ * A {@link KeyValueStorage} which uses a JavaScript Map for internal storage.
+ * Warning: Uses a Map object, which internally uses `Object.is` for key equality,
+ * so object keys have to be the same objects.
+ */
+export class MemoryMapStorage<TKey, TValue> implements KeyValueStorage<TKey, TValue> {
+  private readonly data: Map<TKey, TValue>;
+
+  public constructor() {
+    this.data = new Map<TKey, TValue>();
+  }
+
+  public async get(key: TKey): Promise<TValue | undefined> {
+    return this.data.get(key);
+  }
+
+  public async has(key: TKey): Promise<boolean> {
+    return this.data.has(key);
+  }
+
+  public async set(key: TKey, value: TValue): Promise<this> {
+    this.data.set(key, value);
+    return this;
+  }
+
+  public async delete(key: TKey): Promise<boolean> {
+    return this.data.delete(key);
+  }
+}

--- a/src/storage/keyvalue/ResourceIdentifierStorage.ts
+++ b/src/storage/keyvalue/ResourceIdentifierStorage.ts
@@ -1,0 +1,33 @@
+import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
+import type { KeyValueStorage } from './KeyValueStorage';
+
+/**
+ * Wrapper class that internally converts ResourceIdentifiers to strings so Storages
+ * that do not check value equivalence can be used with ResourceIdentifiers.
+ *
+ * Specifically: this makes it so a Storage based on a Map object can be used with ResourceIdentifiers.
+ */
+export class ResourceIdentifierStorage<T> implements KeyValueStorage<ResourceIdentifier, T> {
+  private readonly source: KeyValueStorage<string, T>;
+
+  public constructor(source: KeyValueStorage<string, T>) {
+    this.source = source;
+  }
+
+  public async get(key: ResourceIdentifier): Promise<T | undefined> {
+    return this.source.get(key.path);
+  }
+
+  public async has(key: ResourceIdentifier): Promise<boolean> {
+    return this.source.has(key.path);
+  }
+
+  public async set(key: ResourceIdentifier, value: T): Promise<this> {
+    await this.source.set(key.path, value);
+    return this;
+  }
+
+  public async delete(key: ResourceIdentifier): Promise<boolean> {
+    return this.source.delete(key.path);
+  }
+}

--- a/src/util/locking/EqualReadWriteLocker.ts
+++ b/src/util/locking/EqualReadWriteLocker.ts
@@ -1,0 +1,37 @@
+import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
+import type { ReadWriteLocker } from './ReadWriteLocker';
+import type { ResourceLocker } from './ResourceLocker';
+
+/**
+ * A {@link ReadWriteLocker} that gives no priority to read or write operations: both use the same lock.
+ */
+export class EqualReadWriteLocker implements ReadWriteLocker {
+  private readonly locker: ResourceLocker;
+
+  public constructor(locker: ResourceLocker) {
+    this.locker = locker;
+  }
+
+  public async withReadLock<T>(identifier: ResourceIdentifier, whileLocked: () => (Promise<T> | T)): Promise<T> {
+    return this.withLock(identifier, whileLocked);
+  }
+
+  public async withWriteLock<T>(identifier: ResourceIdentifier, whileLocked: () => (Promise<T> | T)): Promise<T> {
+    return this.withLock(identifier, whileLocked);
+  }
+
+  /**
+   * Acquires a new lock for the requested identifier.
+   * Will resolve when the input function resolves.
+   * @param identifier - Identifier of resource that needs to be locked.
+   * @param whileLocked - Function to resolve while the resource is locked.
+   */
+  private async withLock<T>(identifier: ResourceIdentifier, whileLocked: () => T | Promise<T>): Promise<T> {
+    await this.locker.acquire(identifier);
+    try {
+      return await whileLocked();
+    } finally {
+      await this.locker.release(identifier);
+    }
+  }
+}

--- a/src/util/locking/ExpiringReadWriteLocker.ts
+++ b/src/util/locking/ExpiringReadWriteLocker.ts
@@ -1,12 +1,12 @@
 import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
-import type { ResourceLocker } from './ResourceLocker';
+import type { ReadWriteLocker } from './ReadWriteLocker';
 
 /**
- * A {@link ResourceLocker} where the locks expire after a given time.
+ * A {@link ReadWriteLocker} where the locks expire after a given time.
  */
-export interface ExpiringResourceLocker extends ResourceLocker {
+export interface ExpiringReadWriteLocker extends ReadWriteLocker {
   /**
-   * As {@link ResourceLocker.withReadLock} but the locked function gets called with a `maintainLock` callback function
+   * As {@link ReadWriteLocker.withReadLock} but the locked function gets called with a `maintainLock` callback function
    * to reset the lock expiration every time it is called.
    * The resulting promise will reject once the lock expires.
    *
@@ -18,8 +18,8 @@ export interface ExpiringResourceLocker extends ResourceLocker {
   => Promise<T>;
 
   /**
-   * As {@link ResourceLocker.withWriteLock} but the locked function gets called with a `maintainLock` callback function
-   * to reset the lock expiration every time it is called.
+   * As {@link ReadWriteLocker.withWriteLock} but the locked function gets called with a `maintainLock`
+   * callback function to reset the lock expiration every time it is called.
    * The resulting promise will reject once the lock expires.
    *
    * @param identifier - Identifier of the resource that needs to be locked.

--- a/src/util/locking/GreedyReadWriteLocker.ts
+++ b/src/util/locking/GreedyReadWriteLocker.ts
@@ -1,0 +1,151 @@
+import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
+import type { KeyValueStorage } from '../../storage/keyvalue/KeyValueStorage';
+import { ForbiddenHttpError } from '../errors/ForbiddenHttpError';
+import { InternalServerError } from '../errors/InternalServerError';
+import type { ReadWriteLocker } from './ReadWriteLocker';
+import type { ResourceLocker } from './ResourceLocker';
+
+export interface GreedyReadWriteSuffixes {
+  count: string;
+  read: string;
+  write: string;
+}
+
+/**
+ * A {@link ReadWriteLocker} that allows for multiple simultaneous read operations.
+ * Write operations will be blocked as long as read operations are not finished.
+ * New read operations are allowed while this is going on, which will cause write operations to wait longer.
+ *
+ * Based on https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock#Using_two_mutexes .
+ * As soon as 1 read lock request is made, the write lock is locked.
+ * Internally a counter keeps track of the amount of active read locks.
+ * Only when this number reaches 0 will the write lock be released again.
+ * The internal read lock is only locked to increase/decrease this counter and is released afterwards.
+ * This allows for multiple read operations, although only 1 at the time can update the counter,
+ * which means there can still be a small waiting period if there are multiple simultaneous read operations.
+ */
+export class GreedyReadWriteLocker implements ReadWriteLocker {
+  private readonly locker: ResourceLocker;
+  private readonly storage: KeyValueStorage<ResourceIdentifier, number>;
+  private readonly suffixes: GreedyReadWriteSuffixes;
+
+  /**
+   * @param locker - Used for creating read and write locks.
+   * @param storage - Used for storing the amount of active read operations on a resource.
+   * @param suffixes - Used to generate identifiers with the given suffixes.
+   *                   `count` is used for the identifier used to store the counter.
+   *                   `read` and `write` are used for the 2 types of locks that are needed.
+   */
+  public constructor(locker: ResourceLocker, storage: KeyValueStorage<ResourceIdentifier, number>,
+    suffixes: GreedyReadWriteSuffixes = { count: 'count', read: 'read', write: 'write' }) {
+    this.locker = locker;
+    this.storage = storage;
+    this.suffixes = suffixes;
+  }
+
+  public async withReadLock<T>(identifier: ResourceIdentifier, whileLocked: () => (Promise<T> | T)): Promise<T> {
+    await this.preReadSetup(identifier);
+    try {
+      return await whileLocked();
+    } finally {
+      await this.postReadCleanup(identifier);
+    }
+  }
+
+  public async withWriteLock<T>(identifier: ResourceIdentifier, whileLocked: () => (Promise<T> | T)): Promise<T> {
+    if (identifier.path.endsWith(`.${this.suffixes.count}`)) {
+      throw new ForbiddenHttpError('This resource is used for internal purposes.');
+    }
+    const write = this.getWriteLockIdentifier(identifier);
+    await this.locker.acquire(write);
+    try {
+      return await whileLocked();
+    } finally {
+      await this.locker.release(write);
+    }
+  }
+
+  /**
+   * This identifier is used for storing the count of active read operations.
+   */
+  private getCountIdentifier(identifier: ResourceIdentifier): ResourceIdentifier {
+    return { path: `${identifier.path}.${this.suffixes.count}` };
+  }
+
+  /**
+   * This is the identifier for the read lock: the lock that is used to safely update and read the count.
+   */
+  private getReadLockIdentifier(identifier: ResourceIdentifier): ResourceIdentifier {
+    return { path: `${identifier.path}.${this.suffixes.read}` };
+  }
+
+  /**
+   * This is the identifier for the write lock, making sure there is at most 1 write operation active.
+   */
+  private getWriteLockIdentifier(identifier: ResourceIdentifier): ResourceIdentifier {
+    return { path: `${identifier.path}.${this.suffixes.write}` };
+  }
+
+  /**
+   * Safely updates the count before starting a read operation.
+   */
+  private async preReadSetup(identifier: ResourceIdentifier): Promise<void> {
+    await this.withInternalReadLock(identifier, async(): Promise<void> => {
+      const count = await this.incrementCount(identifier, +1);
+      if (count === 1) {
+        // There is at least 1 read operation so write operations are blocked
+        const write = this.getWriteLockIdentifier(identifier);
+        await this.locker.acquire(write);
+      }
+    });
+  }
+
+  /**
+   * Safely decreases the count after the read operation is finished.
+   */
+  private async postReadCleanup(identifier: ResourceIdentifier): Promise<void> {
+    await this.withInternalReadLock(identifier, async(): Promise<void> => {
+      const count = await this.incrementCount(identifier, -1);
+      if (count === 0) {
+        // All read locks have been released so a write operation is possible again
+        const write = this.getWriteLockIdentifier(identifier);
+        await this.locker.release(write);
+      }
+    });
+  }
+
+  /**
+   * Safely runs an action on the count.
+   */
+  private async withInternalReadLock<T>(identifier: ResourceIdentifier, whileLocked: () => (Promise<T> | T)):
+  Promise<T> {
+    const read = this.getReadLockIdentifier(identifier);
+    await this.locker.acquire(read);
+    try {
+      return await whileLocked();
+    } finally {
+      await this.locker.release(read);
+    }
+  }
+
+  /**
+   * Updates the count with the given modifier.
+   * Creates the data if it didn't exist yet.
+   * Deletes the data when the count reaches zero.
+   */
+  private async incrementCount(identifier: ResourceIdentifier, mod: number): Promise<number> {
+    const countIdentifier = this.getCountIdentifier(identifier);
+    let number = await this.storage.get(countIdentifier) ?? 0;
+    number += mod;
+    if (number === 0) {
+      // Make sure there is no remaining data once all locks are released
+      await this.storage.delete(countIdentifier);
+    } else if (number > 0) {
+      await this.storage.set(countIdentifier, number);
+    } else {
+      // Failsafe in case something goes wrong with the count storage
+      throw new InternalServerError('Read counter would become negative. Something is wrong with the count storage.');
+    }
+    return number;
+  }
+}

--- a/src/util/locking/ReadWriteLocker.ts
+++ b/src/util/locking/ReadWriteLocker.ts
@@ -1,0 +1,30 @@
+import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
+
+/**
+ * Allows the locking of resources which is needed for non-atomic {@link ResourceStore}s.
+ */
+export interface ReadWriteLocker {
+  /**
+   * Run the given function while the resource is locked.
+   * The lock will be released when the (async) input function resolves.
+   * This function should be used for operations that only require reading the resource.
+   *
+   * @param identifier - Identifier of the resource that needs to be locked.
+   * @param whileLocked - A function to execute while the resource is locked.
+   *
+   * @returns A promise resolving when the lock is released.
+   */
+  withReadLock: <T>(identifier: ResourceIdentifier, whileLocked: () => T | Promise<T>) => Promise<T>;
+
+  /**
+   * Run the given function while the resource is locked.
+   * The lock will be released when the (async) input function resolves.
+   * This function should be used for operations that could modify the resource.
+   *
+   * @param identifier - Identifier of the resource that needs to be locked.
+   * @param whileLocked - A function to execute while the resource is locked.
+   *
+   * @returns A promise resolving when the lock is released.
+   */
+  withWriteLock: <T>(identifier: ResourceIdentifier, whileLocked: () => T | Promise<T>) => Promise<T>;
+}

--- a/src/util/locking/ResourceLocker.ts
+++ b/src/util/locking/ResourceLocker.ts
@@ -1,30 +1,23 @@
 import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
 
 /**
- * Allows the locking of resources which is needed for non-atomic {@link ResourceStore}s.
+ * An interface for classes that only have 1 way to lock interfaces.
+ * In general this should only be used by components implementing the {@link ReadWriteLocker} interface.
+ * Other components that require locking of resources should use that interface.
  */
 export interface ResourceLocker {
   /**
-   * Run the given function while the resource is locked.
-   * The lock will be released when the (async) input function resolves.
-   * This function should be used for operations that only require reading the resource.
-   *
-   * @param identifier - Identifier of the resource that needs to be locked.
-   * @param whileLocked - A function to execute while the resource is locked.
-   *
-   * @returns A promise resolving when the lock is released.
+   * Acquires a lock on the requested identifier.
+   * The promise will resolve when the lock has been acquired.
+   * @param identifier - Resource to acquire a lock on.
    */
-  withReadLock: <T>(identifier: ResourceIdentifier, whileLocked: () => T | Promise<T>) => Promise<T>;
+  acquire: (identifier: ResourceIdentifier) => Promise<void>;
 
   /**
-   * Run the given function while the resource is locked.
-   * The lock will be released when the (async) input function resolves.
-   * This function should be used for operations that could modify the resource.
-   *
-   * @param identifier - Identifier of the resource that needs to be locked.
-   * @param whileLocked - A function to execute while the resource is locked.
-   *
-   * @returns A promise resolving when the lock is released.
+   * Releases a lock on the requested identifier.
+   * The promise will resolve when the lock has been released.
+   * In case there is no lock on the resource an error should be thrown.
+   * @param identifier - Resource to release the lock on.
    */
-  withWriteLock: <T>(identifier: ResourceIdentifier, whileLocked: () => T | Promise<T>) => Promise<T>;
+  release: (identifier: ResourceIdentifier) => Promise<void>;
 }

--- a/src/util/locking/WrappedExpiringReadWriteLocker.ts
+++ b/src/util/locking/WrappedExpiringReadWriteLocker.ts
@@ -1,24 +1,24 @@
 import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
 import { getLoggerFor } from '../../logging/LogUtil';
 import { InternalServerError } from '../errors/InternalServerError';
-import type { ExpiringResourceLocker } from './ExpiringResourceLocker';
-import type { ResourceLocker } from './ResourceLocker';
+import type { ExpiringReadWriteLocker } from './ExpiringReadWriteLocker';
+import type { ReadWriteLocker } from './ReadWriteLocker';
 import Timeout = NodeJS.Timeout;
 
 /**
- * Wraps around an existing {@link ResourceLocker} and adds expiration logic to prevent locks from getting stuck.
+ * Wraps around an existing {@link ReadWriteLocker} and adds expiration logic to prevent locks from getting stuck.
  */
-export class WrappedExpiringResourceLocker implements ExpiringResourceLocker {
+export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
   protected readonly logger = getLoggerFor(this);
 
-  protected readonly locker: ResourceLocker;
+  protected readonly locker: ReadWriteLocker;
   protected readonly expiration: number;
 
   /**
    * @param locker - Instance of ResourceLocker to use for acquiring a lock.
    * @param expiration - Time in ms after which the lock expires.
    */
-  public constructor(locker: ResourceLocker, expiration: number) {
+  public constructor(locker: ReadWriteLocker, expiration: number) {
     this.locker = locker;
     this.expiration = expiration;
   }

--- a/test/unit/storage/LockingResourceStore.test.ts
+++ b/test/unit/storage/LockingResourceStore.test.ts
@@ -4,7 +4,7 @@ import type { Representation } from '../../../src/ldp/representation/Representat
 import type { ResourceIdentifier } from '../../../src/ldp/representation/ResourceIdentifier';
 import { LockingResourceStore } from '../../../src/storage/LockingResourceStore';
 import type { ResourceStore } from '../../../src/storage/ResourceStore';
-import type { ExpiringResourceLocker } from '../../../src/util/locking/ExpiringResourceLocker';
+import type { ExpiringReadWriteLocker } from '../../../src/util/locking/ExpiringReadWriteLocker';
 import { guardedStreamFrom } from '../../../src/util/StreamUtil';
 
 function emptyFn(): void {
@@ -13,7 +13,7 @@ function emptyFn(): void {
 
 describe('A LockingResourceStore', (): void => {
   let store: LockingResourceStore;
-  let locker: ExpiringResourceLocker;
+  let locker: ExpiringReadWriteLocker;
   let source: ResourceStore;
   let order: string[];
   let timeoutTrigger: EventEmitter;

--- a/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
+++ b/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
@@ -1,0 +1,81 @@
+import { BasicRepresentation } from '../../../../src/ldp/representation/BasicRepresentation';
+import type { Representation } from '../../../../src/ldp/representation/Representation';
+import type { ResourceIdentifier } from '../../../../src/ldp/representation/ResourceIdentifier';
+import { JsonResourceStorage } from '../../../../src/storage/keyvalue/JsonResourceStorage';
+import type { ResourceStore } from '../../../../src/storage/ResourceStore';
+import { NotFoundHttpError } from '../../../../src/util/errors/NotFoundHttpError';
+import { readableToString } from '../../../../src/util/StreamUtil';
+
+describe('A JsonResourceStorage', (): void => {
+  const identifier1: ResourceIdentifier = { path: 'http://test.com/foo' };
+  const identifier2: ResourceIdentifier = { path: 'http://test.com/bar' };
+  let store: ResourceStore;
+  let storage: JsonResourceStorage;
+
+  beforeEach(async(): Promise<void> => {
+    const data: Record<string, string> = { };
+    store = {
+      async getRepresentation(identifier: ResourceIdentifier): Promise<Representation> {
+        if (!data[identifier.path]) {
+          throw new NotFoundHttpError();
+        } else {
+          return new BasicRepresentation(data[identifier.path], identifier);
+        }
+      },
+      async setRepresentation(identifier: ResourceIdentifier, representation: Representation): Promise<void> {
+        data[identifier.path] = await readableToString(representation.data);
+      },
+      async deleteResource(identifier: ResourceIdentifier): Promise<void> {
+        if (!data[identifier.path]) {
+          throw new NotFoundHttpError();
+        }
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete data[identifier.path];
+      },
+    } as any;
+
+    storage = new JsonResourceStorage(store);
+  });
+
+  it('returns undefined if there is no matching data.', async(): Promise<void> => {
+    await expect(storage.get(identifier1)).resolves.toBeUndefined();
+  });
+
+  it('returns data if it was set beforehand.', async(): Promise<void> => {
+    await expect(storage.set(identifier1, 'apple')).resolves.toBe(storage);
+    await expect(storage.get(identifier1)).resolves.toBe('apple');
+  });
+
+  it('can check if data is present.', async(): Promise<void> => {
+    await expect(storage.has(identifier1)).resolves.toBe(false);
+    await expect(storage.set(identifier1, 'apple')).resolves.toBe(storage);
+    await expect(storage.has(identifier1)).resolves.toBe(true);
+  });
+
+  it('can delete data.', async(): Promise<void> => {
+    await expect(storage.has(identifier1)).resolves.toBe(false);
+    await expect(storage.delete(identifier1)).resolves.toBe(false);
+    await expect(storage.has(identifier1)).resolves.toBe(false);
+    await expect(storage.set(identifier1, 'apple')).resolves.toBe(storage);
+    await expect(storage.has(identifier1)).resolves.toBe(true);
+    await expect(storage.delete(identifier1)).resolves.toBe(true);
+    await expect(storage.has(identifier1)).resolves.toBe(false);
+  });
+
+  it('can handle multiple identifiers.', async(): Promise<void> => {
+    await expect(storage.set(identifier1, 'apple')).resolves.toBe(storage);
+    await expect(storage.has(identifier1)).resolves.toBe(true);
+    await expect(storage.has(identifier2)).resolves.toBe(false);
+    await expect(storage.set(identifier2, 'pear')).resolves.toBe(storage);
+    await expect(storage.get(identifier1)).resolves.toBe('apple');
+  });
+
+  it('re-throws errors thrown by the store.', async(): Promise<void> => {
+    store.getRepresentation = jest.fn().mockRejectedValue(new Error('bad GET'));
+    await expect(storage.get(identifier1)).rejects.toThrow('bad GET');
+    await expect(storage.has(identifier1)).rejects.toThrow('bad GET');
+
+    store.deleteResource = jest.fn().mockRejectedValue(new Error('bad DELETE'));
+    await expect(storage.delete(identifier1)).rejects.toThrow('bad DELETE');
+  });
+});

--- a/test/unit/storage/keyvalue/MemoryMapStorage.test.ts
+++ b/test/unit/storage/keyvalue/MemoryMapStorage.test.ts
@@ -1,0 +1,45 @@
+import type { ResourceIdentifier } from '../../../../src/ldp/representation/ResourceIdentifier';
+import { MemoryMapStorage } from '../../../../src/storage/keyvalue/MemoryMapStorage';
+
+describe('A MemoryMapStorage', (): void => {
+  const identifier1: ResourceIdentifier = { path: 'http://test.com/foo' };
+  const identifier2: ResourceIdentifier = { path: 'http://test.com/bar' };
+  let storage: MemoryMapStorage<ResourceIdentifier, string>;
+
+  beforeEach(async(): Promise<void> => {
+    storage = new MemoryMapStorage<ResourceIdentifier, string>();
+  });
+
+  it('returns undefined if there is no matching data.', async(): Promise<void> => {
+    await expect(storage.get(identifier1)).resolves.toBeUndefined();
+  });
+
+  it('returns data if it was set beforehand.', async(): Promise<void> => {
+    await expect(storage.set(identifier1, 'apple')).resolves.toBe(storage);
+    await expect(storage.get(identifier1)).resolves.toBe('apple');
+  });
+
+  it('can check if data is present.', async(): Promise<void> => {
+    await expect(storage.has(identifier1)).resolves.toBe(false);
+    await expect(storage.set(identifier1, 'apple')).resolves.toBe(storage);
+    await expect(storage.has(identifier1)).resolves.toBe(true);
+  });
+
+  it('can delete data.', async(): Promise<void> => {
+    await expect(storage.has(identifier1)).resolves.toBe(false);
+    await expect(storage.delete(identifier1)).resolves.toBe(false);
+    await expect(storage.has(identifier1)).resolves.toBe(false);
+    await expect(storage.set(identifier1, 'apple')).resolves.toBe(storage);
+    await expect(storage.has(identifier1)).resolves.toBe(true);
+    await expect(storage.delete(identifier1)).resolves.toBe(true);
+    await expect(storage.has(identifier1)).resolves.toBe(false);
+  });
+
+  it('can handle multiple identifiers.', async(): Promise<void> => {
+    await expect(storage.set(identifier1, 'apple')).resolves.toBe(storage);
+    await expect(storage.has(identifier1)).resolves.toBe(true);
+    await expect(storage.has(identifier2)).resolves.toBe(false);
+    await expect(storage.set(identifier2, 'pear')).resolves.toBe(storage);
+    await expect(storage.get(identifier1)).resolves.toBe('apple');
+  });
+});

--- a/test/unit/storage/keyvalue/ResourceIdentifierStorage.test.ts
+++ b/test/unit/storage/keyvalue/ResourceIdentifierStorage.test.ts
@@ -1,0 +1,37 @@
+import type { KeyValueStorage } from '../../../../src/storage/keyvalue/KeyValueStorage';
+import { ResourceIdentifierStorage } from '../../../../src/storage/keyvalue/ResourceIdentifierStorage';
+
+describe('A ResourceIdentifierStorage', (): void => {
+  const path = 'http://test.com/foo';
+  const identifier = { path };
+  let source: KeyValueStorage<string, number>;
+  let storage: ResourceIdentifierStorage<number>;
+
+  beforeEach(async(): Promise<void> => {
+    source = {
+      get: jest.fn(),
+      has: jest.fn(),
+      set: jest.fn(),
+      delete: jest.fn(),
+    };
+    storage = new ResourceIdentifierStorage(source);
+  });
+
+  it('calls the corresponding function on the source Storage.', async(): Promise<void> => {
+    await storage.get(identifier);
+    expect(source.get).toHaveBeenCalledTimes(1);
+    expect(source.get).toHaveBeenLastCalledWith(path);
+
+    await storage.has(identifier);
+    expect(source.has).toHaveBeenCalledTimes(1);
+    expect(source.has).toHaveBeenLastCalledWith(path);
+
+    await storage.set(identifier, 5);
+    expect(source.set).toHaveBeenCalledTimes(1);
+    expect(source.set).toHaveBeenLastCalledWith(path, 5);
+
+    await storage.delete(identifier);
+    expect(source.delete).toHaveBeenCalledTimes(1);
+    expect(source.delete).toHaveBeenLastCalledWith(path);
+  });
+});

--- a/test/unit/util/locking/EqualReadWriteLocker.test.ts
+++ b/test/unit/util/locking/EqualReadWriteLocker.test.ts
@@ -1,0 +1,62 @@
+import { EqualReadWriteLocker } from '../../../../src/util/locking/EqualReadWriteLocker';
+import type { ResourceLocker } from '../../../../src/util/locking/ResourceLocker';
+
+describe('An EqualReadWriteLocker', (): void => {
+  let sourceLocker: ResourceLocker;
+  let locker: EqualReadWriteLocker;
+  let emptyFn: () => void;
+  const identifier = { path: 'http://test.com/res' };
+
+  beforeEach(async(): Promise<void> => {
+    emptyFn = jest.fn();
+
+    sourceLocker = {
+      acquire: jest.fn(),
+      release: jest.fn(),
+    };
+    locker = new EqualReadWriteLocker(sourceLocker);
+  });
+
+  it('locks and unlocks a resource for a read lock.', async(): Promise<void> => {
+    const prom = locker.withReadLock(identifier, emptyFn);
+    expect(sourceLocker.acquire).toHaveBeenCalledTimes(1);
+    expect(sourceLocker.acquire).toHaveBeenLastCalledWith(identifier);
+    expect(emptyFn).toHaveBeenCalledTimes(0);
+    expect(sourceLocker.release).toHaveBeenCalledTimes(0);
+
+    await expect(prom).resolves.toBeUndefined();
+    expect(sourceLocker.acquire).toHaveBeenCalledTimes(1);
+    expect(emptyFn).toHaveBeenCalledTimes(1);
+    expect(sourceLocker.release).toHaveBeenCalledTimes(1);
+    expect(sourceLocker.release).toHaveBeenLastCalledWith(identifier);
+  });
+
+  it('locks and unlocks a resource for a write lock.', async(): Promise<void> => {
+    const prom = locker.withWriteLock(identifier, emptyFn);
+    expect(sourceLocker.acquire).toHaveBeenCalledTimes(1);
+    expect(sourceLocker.acquire).toHaveBeenLastCalledWith(identifier);
+    expect(emptyFn).toHaveBeenCalledTimes(0);
+    expect(sourceLocker.release).toHaveBeenCalledTimes(0);
+
+    await expect(prom).resolves.toBeUndefined();
+    expect(sourceLocker.acquire).toHaveBeenCalledTimes(1);
+    expect(emptyFn).toHaveBeenCalledTimes(1);
+    expect(sourceLocker.release).toHaveBeenCalledTimes(1);
+    expect(sourceLocker.release).toHaveBeenLastCalledWith(identifier);
+  });
+
+  it('unlocks correctly if the whileLocked function errors.', async(): Promise<void> => {
+    emptyFn = jest.fn().mockRejectedValue(new Error('bad data!'));
+    const prom = locker.withWriteLock(identifier, emptyFn);
+    expect(sourceLocker.acquire).toHaveBeenCalledTimes(1);
+    expect(sourceLocker.acquire).toHaveBeenLastCalledWith(identifier);
+    expect(emptyFn).toHaveBeenCalledTimes(0);
+    expect(sourceLocker.release).toHaveBeenCalledTimes(0);
+
+    await expect(prom).rejects.toThrow('bad data!');
+    expect(sourceLocker.acquire).toHaveBeenCalledTimes(1);
+    expect(emptyFn).toHaveBeenCalledTimes(1);
+    expect(sourceLocker.release).toHaveBeenCalledTimes(1);
+    expect(sourceLocker.release).toHaveBeenLastCalledWith(identifier);
+  });
+});

--- a/test/unit/util/locking/GreedyReadWriteLocker.test.ts
+++ b/test/unit/util/locking/GreedyReadWriteLocker.test.ts
@@ -1,0 +1,319 @@
+import { EventEmitter } from 'events';
+import type { ResourceIdentifier } from '../../../../src/ldp/representation/ResourceIdentifier';
+import type { KeyValueStorage } from '../../../../src/storage/keyvalue/KeyValueStorage';
+import { ForbiddenHttpError } from '../../../../src/util/errors/ForbiddenHttpError';
+import { InternalServerError } from '../../../../src/util/errors/InternalServerError';
+import { GreedyReadWriteLocker } from '../../../../src/util/locking/GreedyReadWriteLocker';
+import type { ResourceLocker } from '../../../../src/util/locking/ResourceLocker';
+
+// A simple ResourceLocker that keeps a queue of lock requests
+class MemoryLocker implements ResourceLocker {
+  private readonly locks: Record<string, (() => void)[]>;
+
+  public constructor() {
+    this.locks = {};
+  }
+
+  public async acquire(identifier: ResourceIdentifier): Promise<void> {
+    const { path } = identifier;
+    if (!this.locks[path]) {
+      this.locks[path] = [];
+    } else {
+      return new Promise((resolve): void => {
+        this.locks[path].push(resolve);
+      });
+    }
+  }
+
+  public async release(identifier: ResourceIdentifier): Promise<void> {
+    const { path } = identifier;
+    if (this.locks[path].length > 0) {
+      this.locks[path].shift()!();
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete this.locks[path];
+    }
+  }
+}
+
+describe('A GreedyReadWriteLocker', (): void => {
+  let sourceLocker: ResourceLocker;
+  let storage: KeyValueStorage<ResourceIdentifier, number>;
+  const resourceId = { path: 'http://test.com/resource' };
+  const resource2Id = { path: 'http://test.com/resource2' };
+  let locker: GreedyReadWriteLocker;
+
+  beforeEach(async(): Promise<void> => {
+    sourceLocker = new MemoryLocker();
+
+    const map = new Map<string, number>();
+    storage = {
+      get: async(identifier: ResourceIdentifier): Promise<number | undefined> => map.get(identifier.path),
+      has: async(identifier: ResourceIdentifier): Promise<boolean> => map.has(identifier.path),
+      set: async(identifier: ResourceIdentifier, value: number): Promise<any> => map.set(identifier.path, value),
+      delete: async(identifier: ResourceIdentifier): Promise<boolean> => map.delete(identifier.path),
+    };
+
+    locker = new GreedyReadWriteLocker(sourceLocker, storage);
+  });
+
+  it('does not block single read operations.', async(): Promise<void> => {
+    await expect(locker.withReadLock(resourceId, (): any => 5)).resolves.toBe(5);
+  });
+
+  it('does not block single write operations.', async(): Promise<void> => {
+    await expect(locker.withWriteLock(resourceId, (): any => 5)).resolves.toBe(5);
+  });
+
+  it('errors when trying to writeLock a count identifier.', async(): Promise<void> => {
+    await expect(locker.withWriteLock({ path: `http://test.com/foo.count` }, (): any => 5))
+      .rejects.toThrow(ForbiddenHttpError);
+
+    locker = new GreedyReadWriteLocker(sourceLocker, storage, { count: 'dummy', read: 'read', write: 'write' });
+    await expect(locker.withWriteLock({ path: `http://test.com/foo.dummy` }, (): any => 5))
+      .rejects.toThrow(ForbiddenHttpError);
+  });
+
+  it('errors if the read counter has an unexpected value.', async(): Promise<void> => {
+    storage.get = jest.fn().mockResolvedValue(0);
+    await expect(locker.withReadLock(resourceId, (): any => 5)).rejects.toThrow(InternalServerError);
+  });
+
+  it('does not block multiple read operations.', async(): Promise<void> => {
+    const order: string[] = [];
+    const emitter = new EventEmitter();
+
+    const unlocks = [ 0, 1, 2 ].map((num): any => new Promise((resolve): any => emitter.on(`release${num}`, resolve)));
+    const promises = [ 0, 1, 2 ].map((num): any => locker.withReadLock(resourceId, async(): Promise<number> => {
+      order.push(`start ${num}`);
+      await unlocks[num];
+      order.push(`finish ${num}`);
+      return num;
+    }));
+
+    // Allow time to attach listeners
+    await new Promise(setImmediate);
+
+    emitter.emit('release2');
+    await expect(promises[2]).resolves.toBe(2);
+    emitter.emit('release0');
+    await expect(promises[0]).resolves.toBe(0);
+    emitter.emit('release1');
+    await expect(promises[1]).resolves.toBe(1);
+
+    expect(order).toEqual([ 'start 0', 'start 1', 'start 2', 'finish 2', 'finish 0', 'finish 1' ]);
+  });
+
+  it('blocks multiple write operations.', async(): Promise<void> => {
+    // Previous test but with write locks
+    const order: string[] = [];
+    const emitter = new EventEmitter();
+
+    const unlocks = [ 0, 1, 2 ].map((num): any => new Promise((resolve): any => emitter.on(`release${num}`, resolve)));
+    const promises = [ 0, 1, 2 ].map((num): any => locker.withWriteLock(resourceId, async(): Promise<number> => {
+      order.push(`start ${num}`);
+      await unlocks[num];
+      order.push(`finish ${num}`);
+      return num;
+    }));
+
+    // Allow time to attach listeners
+    await new Promise(setImmediate);
+
+    emitter.emit('release2');
+
+    // Allow time to finish write 2
+    await new Promise(setImmediate);
+
+    emitter.emit('release0');
+    emitter.emit('release1');
+    await Promise.all([ promises[2], promises[0], promises[1] ]);
+    expect(order).toEqual([ 'start 0', 'finish 0', 'start 1', 'finish 1', 'start 2', 'finish 2' ]);
+  });
+
+  it('allows multiple write operations on different resources.', async(): Promise<void> => {
+    // Previous test but with write locks
+    const order: string[] = [];
+    const emitter = new EventEmitter();
+
+    const resources = [ resourceId, resource2Id ];
+    const unlocks = [ 0, 1 ].map((num): any => new Promise((resolve): any => emitter.on(`release${num}`, resolve)));
+    const promises = [ 0, 1 ].map((num): any => locker.withWriteLock(resources[num], async(): Promise<number> => {
+      order.push(`start ${num}`);
+      await unlocks[num];
+      order.push(`finish ${num}`);
+      return num;
+    }));
+
+    // Allow time to attach listeners
+    await new Promise(setImmediate);
+
+    emitter.emit('release1');
+    await expect(promises[1]).resolves.toBe(1);
+    emitter.emit('release0');
+    await expect(promises[0]).resolves.toBe(0);
+
+    expect(order).toEqual([ 'start 0', 'start 1', 'finish 1', 'finish 0' ]);
+  });
+
+  it('blocks write operations during read operations.', async(): Promise<void> => {
+    const order: string[] = [];
+    const emitter = new EventEmitter();
+
+    const promRead = new Promise((resolve): any => {
+      emitter.on('releaseRead', resolve);
+    });
+
+    // We want to make sure the write operation only starts while the read operation is busy
+    // Otherwise the internal write lock might not be acquired yet
+    const delayedLockWrite = new Promise((resolve): void => {
+      emitter.on('readStarted', (): void => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        locker.withWriteLock(resourceId, (): any => {
+          order.push('write');
+          resolve();
+        });
+      });
+    });
+
+    const lockRead = locker.withReadLock(resourceId, async(): Promise<void> => {
+      emitter.emit('readStarted');
+      order.push('read start');
+      await promRead;
+      order.push('read finish');
+    });
+
+    // Allow time to attach listeners
+    await new Promise(setImmediate);
+
+    const promAll = Promise.all([ delayedLockWrite, lockRead ]);
+
+    emitter.emit('releaseRead');
+    await promAll;
+    expect(order).toEqual([ 'read start', 'read finish', 'write' ]);
+  });
+
+  it('allows write operations on different resources during read operations.', async(): Promise<void> => {
+    const order: string[] = [];
+    const emitter = new EventEmitter();
+
+    const promRead = new Promise((resolve): any => {
+      emitter.on('releaseRead', resolve);
+    });
+
+    const delayedLockWrite = new Promise((resolve): void => {
+      emitter.on('readStarted', (): void => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        locker.withWriteLock(resource2Id, (): any => {
+          order.push('write');
+          resolve();
+        });
+      });
+    });
+
+    const lockRead = locker.withReadLock(resourceId, async(): Promise<void> => {
+      emitter.emit('readStarted');
+      order.push('read start');
+      await promRead;
+      order.push('read finish');
+    });
+
+    // Allow time to attach listeners
+    await new Promise(setImmediate);
+
+    const promAll = Promise.all([ delayedLockWrite, lockRead ]);
+
+    emitter.emit('releaseRead');
+    await promAll;
+    expect(order).toEqual([ 'read start', 'write', 'read finish' ]);
+  });
+
+  it('prioritizes read operations when a read operation is waiting.', async(): Promise<void> => {
+    // This test is very similar to the previous ones but adds an extra read lock
+    const order: string[] = [];
+    const emitter = new EventEmitter();
+
+    const promRead1 = new Promise((resolve): any => emitter.on('releaseRead1', resolve));
+    const promRead2 = new Promise((resolve): any => emitter.on('releaseRead2', resolve));
+
+    const delayedLockWrite = new Promise((resolve): void => {
+      emitter.on('readStarted', (): void => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        locker.withWriteLock(resourceId, (): any => {
+          order.push('write');
+          resolve();
+        });
+      });
+    });
+
+    const delayedLockRead2 = new Promise((resolve): void => {
+      emitter.on('readStarted', (): void => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        locker.withReadLock(resourceId, async(): Promise<void> => {
+          order.push('read 2 start');
+          await promRead2;
+          order.push('read 2 finish');
+          resolve();
+        });
+      });
+    });
+
+    const lockRead = locker.withReadLock(resourceId, async(): Promise<void> => {
+      emitter.emit('readStarted');
+      order.push('read 1 start');
+      await promRead1;
+      order.push('read 1 finish');
+    });
+
+    // Allow time to attach listeners
+    await new Promise(setImmediate);
+
+    const promAll = Promise.all([ delayedLockWrite, lockRead, delayedLockRead2 ]);
+
+    emitter.emit('releaseRead1');
+
+    // Allow time to finish read 1
+    await new Promise(setImmediate);
+
+    emitter.emit('releaseRead2');
+    await promAll;
+    expect(order).toEqual([ 'read 1 start', 'read 2 start', 'read 1 finish', 'read 2 finish', 'write' ]);
+  });
+
+  it('blocks read operations during write operations.', async(): Promise<void> => {
+    // Again similar but with read and write order switched
+    const order: string[] = [];
+    const emitter = new EventEmitter();
+
+    const promWrite = new Promise((resolve): any => {
+      emitter.on('releaseWrite', resolve);
+    });
+
+    // We want to make sure the read operation only starts while the write operation is busy
+    const delayedLockRead = new Promise((resolve): void => {
+      emitter.on('writeStarted', (): void => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        locker.withReadLock(resourceId, (): any => {
+          order.push('read');
+          resolve();
+        });
+      });
+    });
+
+    const lockWrite = locker.withWriteLock(resourceId, async(): Promise<void> => {
+      emitter.emit('writeStarted');
+      order.push('write start');
+      await promWrite;
+      order.push('write finish');
+    });
+
+    // Allow time to attach listeners
+    await new Promise(setImmediate);
+
+    const promAll = Promise.all([ delayedLockRead, lockWrite ]);
+
+    emitter.emit('releaseWrite');
+    await promAll;
+    expect(order).toEqual([ 'write start', 'write finish', 'read' ]);
+  });
+});

--- a/test/unit/util/locking/WrappedExpiringReadWriteLocker.test.ts
+++ b/test/unit/util/locking/WrappedExpiringReadWriteLocker.test.ts
@@ -1,15 +1,15 @@
 import type { ResourceIdentifier } from '../../../../src/ldp/representation/ResourceIdentifier';
-import type { ResourceLocker } from '../../../../src/util/locking/ResourceLocker';
-import { WrappedExpiringResourceLocker } from '../../../../src/util/locking/WrappedExpiringResourceLocker';
+import type { ReadWriteLocker } from '../../../../src/util/locking/ReadWriteLocker';
+import { WrappedExpiringReadWriteLocker } from '../../../../src/util/locking/WrappedExpiringReadWriteLocker';
 
 jest.useFakeTimers();
 
-describe('A WrappedExpiringResourceLocker', (): void => {
+describe('A WrappedExpiringReadWriteLocker', (): void => {
   const identifier = { path: 'path' };
   let syncCb: () => string;
   let asyncCb: () => Promise<string>;
-  let wrappedLocker: ResourceLocker;
-  let locker: WrappedExpiringResourceLocker;
+  let wrappedLocker: ReadWriteLocker;
+  let locker: WrappedExpiringReadWriteLocker;
   const expiration = 1000;
 
   beforeEach(async(): Promise<void> => {
@@ -25,7 +25,7 @@ describe('A WrappedExpiringResourceLocker', (): void => {
       setImmediate((): void => resolve('async'));
     }));
 
-    locker = new WrappedExpiringResourceLocker(wrappedLocker, expiration);
+    locker = new WrappedExpiringReadWriteLocker(wrappedLocker, expiration);
   });
 
   it('calls the wrapped locker for locking.', async(): Promise<void> => {


### PR DESCRIPTION
Closes #32, closes #542 .

First off, there are still some potential issues with this solution for which I'm not sure if we already have the parts in place to fix them all, more on this below.

Since we now have a read/write interface for our lockers, it should be possible to actually implement a locker that handles those locks differently. The only locking mechanism we currently have is the single threaded one with one kind of lock. I partially returned to the interface of having 1 type of lock, but in such a way that the actual lock is not exposed. This way this interface can also be used by multi-threaded locking solutions, such as a lockfile solution. The idea would then be that we could have read/write locking algorithms independent of the locking mechanism being used in the backend. The `EqualReadWriteLocker` (wich does not differentiate between read and write locks internally) is an example of how our current locking mechanism is implemented using this interface.

The main new thing of this PR is the `GreedyReadWriteLocker`, which implements the algorithm described in #32. It's greedy because it keeps accepting new read requests while a read lock is present, which could theoretically cause write locks to wait infinitely long. It does so by, for each resource, keeping a read lock, write lock and read counter (which counts how many read operations are still going on). Since we want to store this counter in an independent way (to also support multi-threading), a ResourceStore is used for this, as this is the only thing we have in place for storing data. 

There are some potential issues with this. Most of this is going to be written under the assumption of using a file store backend with a lockfile solution for locks as that one has the most potential issues. One consequence of this can already be seen by requesting the root container if this locker is in place:
```turtle
@prefix dc: <http://purl.org/dc/terms/>.
@prefix ldp: <http://www.w3.org/ns/ldp#>.
@prefix posix: <http://www.w3.org/ns/posix/stat#>.
@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.

<> a ldp:Container, ldp:BasicContainer, ldp:Resource;
    ldp:contains <.acl>, <.count>.
```
Note the `<.count>` there, this is the identifier of the resource which is used to store the count of read operations for this resource, which when doing the request would be 1. So similar issue as #385. If a lockfile solution was used for locking we would also see a `<.write>` there as that lock would also be active during this operation (to prevent write operations during a read). One solution for that would perhaps be to have a specific auxiliary handler for this as in #554. The `<.write>` could potentially also cause problems when trying to delete a container since the container would be containing its own lock.

Another problem would be when for example accessing a resource `/foo/bar/baz` on an empty pod. Since locking happens before accessing the store we would not know this resource exists and first create the containers `/foo/` and `/foo/bar` so we can write the lock in there, which we probably do not want.

Both of the solutions above would be fixed if we use a different ResourceStore just for the locks. This could for example be another folder somewhere. A lot of empty folders would be created there then though. Another solution would be to create a new ResourceStore specifically for this which converts the URIs to single file names which all end up in the same folder, or even create a new interface InternalStorage for things like this.

Note that the algorithm itself works fine and does what we expect it to do, the problems are the side effects.

All these problems could currently also be avoided by having a SingleThreaded implementation of this. Then all of this could simply be stored in memory and would not be seen by any other components. But since we eventually want multithreaded locks anyway it seemed like a good idea to immediately look into the general solution.