### PR TITLE
feat: Solid community server Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,40 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  push_to_registries:
+    name: Push Docker image to GitHub Container Registry
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set tag in GitHub environment
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CONTAINER_REGISTRY_PERSONAL_ACCESS_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Use latest node LTS base image
+FROM node:lts
+
+# Clone the latest community server & install
+RUN git clone https://github.com/solid/community-server.git
+
+WORKDIR /community-server
+
+RUN npm ci
+
+RUN npm run build
+
+# Container config & data dir for volume sharing
+# Defaults to filestorage with /data directory (passed through CMD below)
+RUN mkdir /config && mkdir /data
+
+# Informs Docker that the container listens on the specified network port at runtime
+EXPOSE 3000
+
+# Set command run by the container
+ENTRYPOINT [ "node", "/community-server/bin/server.js" ]
+
+# By default run in filemode (overriden if passing alternative arguments)
+CMD [ "-c", "config/config-file.json", "-f", "/data" ]

--- a/README.md
+++ b/README.md
@@ -135,3 +135,25 @@ curl -I -H "Accept: text/plain" \
 ```shell
 curl -X OPTIONS -i http://localhost:3000/myfile.txt
 ```
+
+## Run using Docker
+
+A Docker image is available to run the containerised Solid Community Server against your filesystem.
+
+For example to run it against your current user's `~/Solid` directory and `http://localhost:3000`:
+
+```shell
+docker run --rm -v ~/Solid:/data -p 3000:3000 -it solid/solid-community-server:latest
+```
+
+The filestorage is just the default configuration, you can override with any of the configurations included with the server:
+
+```shell
+docker run --rm -p 3000:3000 -it ghcr.io/solid/solid-community-server:latest -c config/config-default.json
+```
+
+Or override it with your own config mapped to the right directory:
+
+```shell
+docker run --rm -v ~/solid-config:/config -p 3000:3000 -it ghcr.io/solid/solid-community-server:latest -c /config/my-config.json
+```


### PR DESCRIPTION
The Solid community server can be automatically published as a package and run.

Requirements for this action to work:
1. In the Solid organisation go to: Feature preview and enable "Improved container support"
2. In the Solid organisation, go to: Settings > Developer settings > Personal access tokens > Generate new token and select scopes `write:packages` and `delete:packages`; Generate the token
3. In the repository's settings, create a secret called `CONTAINER_REGISTRY_PERSONAL_ACCESS_TOKEN` and paste the Personal access token in it

On all new releases, the workflow should now be triggered.