### PR TITLE
Ignore query string when extracting LDP target

### DIFF
--- a/config/presets/ldp/request-parser.json
+++ b/config/presets/ldp/request-parser.json
@@ -27,7 +27,8 @@
     },
     {
       "@id": "urn:solid-server:default:TargetExtractor",
-      "@type": "OriginalUrlExtractor"
+      "@type": "OriginalUrlExtractor",
+      "OriginalUrlExtractor:_options_includeQueryString": false
     }
   ]
 }

--- a/src/ldp/http/OriginalUrlExtractor.ts
+++ b/src/ldp/http/OriginalUrlExtractor.ts
@@ -9,6 +9,13 @@ import { TargetExtractor } from './TargetExtractor';
  * Reconstructs the original URL of an incoming {@link HttpRequest}.
  */
 export class OriginalUrlExtractor extends TargetExtractor {
+  private readonly includeQueryString: boolean;
+
+  public constructor(options: { includeQueryString?: boolean } = {}) {
+    super();
+    this.includeQueryString = options.includeQueryString ?? true;
+  }
+
   public async handle({ request: { url, connection, headers }}: { request: HttpRequest }): Promise<ResourceIdentifier> {
     if (!url) {
       throw new Error('Missing URL');
@@ -37,7 +44,13 @@ export class OriginalUrlExtractor extends TargetExtractor {
 
     // URL object applies punycode encoding to domain
     const base = `${protocol}://${host}`;
-    const path = new URL(toCanonicalUriPath(url), base).href;
-    return { path };
+    const originalUrl = new URL(toCanonicalUriPath(url), base);
+
+    // Drop the query string if requested
+    if (!this.includeQueryString) {
+      originalUrl.search = '';
+    }
+
+    return { path: originalUrl.href };
   }
 }

--- a/src/util/PathUtil.ts
+++ b/src/util/PathUtil.ts
@@ -90,27 +90,35 @@ export function getExtension(path: string): string {
 }
 
 /**
+ * Performs a transformation on the path components of a URI.
+ */
+function transformPathComponents(path: string, transform: (part: string) => string): string {
+  const [ , base, queryString ] = /^([^?]*)(.*)$/u.exec(path)!;
+  const transformed = base.split('/').map(transform).join('/');
+  return !queryString ? transformed : `${transformed}${queryString}`;
+}
+
+/**
  * Converts a URI path to the canonical version by splitting on slashes,
- * decoding any percent-based encodings,
- * and then encoding any special characters.
+ * decoding any percent-based encodings, and then encoding any special characters.
  */
 export function toCanonicalUriPath(path: string): string {
-  return path.split('/').map((part): string =>
-    encodeURIComponent(decodeURIComponent(part))).join('/');
+  return transformPathComponents(path, (part): string =>
+    encodeURIComponent(decodeURIComponent(part)));
 }
 
 /**
  * Decodes all components of a URI path.
  */
 export function decodeUriPathComponents(path: string): string {
-  return path.split('/').map(decodeURIComponent).join('/');
+  return transformPathComponents(path, decodeURIComponent);
 }
 
 /**
  * Encodes all (non-slash) special characters in a URI path.
  */
 export function encodeUriPathComponents(path: string): string {
-  return path.split('/').map(encodeURIComponent).join('/');
+  return transformPathComponents(path, encodeURIComponent);
 }
 
 /**

--- a/test/integration/LdpHandlerWithoutAuth.test.ts
+++ b/test/integration/LdpHandlerWithoutAuth.test.ts
@@ -69,6 +69,18 @@ describe.each(stores)('An LDP handler without auth using %s', (name, { storeUrn,
     expect(response.getHeaders().link).toContain(`<${BASE}/.acl>; rel="acl"`);
   });
 
+  it('can read a folder listing with a query string.', async():
+  Promise<void> => {
+    const response = await resourceHelper.getResource(`${BASE}/?abc=def&xyz`);
+    expect(response.statusCode).toBe(200);
+    expect(response.getHeaders()).toHaveProperty('content-type', 'text/turtle');
+
+    const data = response._getData().toString();
+    expect(data).toContain(`<> a ldp:Container`);
+    expect(response.getHeaders().link).toContain(`<${LDP.Container}>; rel="type"`);
+    expect(response.getHeaders().link).toContain(`<${BASE}/.acl>; rel="acl"`);
+  });
+
   it('can add a file to the store, read it and delete it.', async():
   Promise<void> => {
     // POST

--- a/test/unit/ldp/http/OriginalUrlExtractor.test.ts
+++ b/test/unit/ldp/http/OriginalUrlExtractor.test.ts
@@ -26,6 +26,17 @@ describe('A OriginalUrlExtractor', (): void => {
       .resolves.toEqual({ path: 'http://test.com/url' });
   });
 
+  it('returns an input URL with query string.', async(): Promise<void> => {
+    const noQuery = new OriginalUrlExtractor({ includeQueryString: false });
+    await expect(noQuery.handle({ request: { url: '/url?abc=def&xyz', headers: { host: 'test.com' }} as any }))
+      .resolves.toEqual({ path: 'http://test.com/url' });
+  });
+
+  it('drops the query string when includeQueryString is set to false.', async(): Promise<void> => {
+    await expect(extractor.handle({ request: { url: '/url?abc=def&xyz', headers: { host: 'test.com' }} as any }))
+      .resolves.toEqual({ path: 'http://test.com/url?abc=def&xyz' });
+  });
+
   it('supports host:port combinations.', async(): Promise<void> => {
     await expect(extractor.handle({ request: { url: 'url', headers: { host: 'localhost:3000' }} as any }))
       .resolves.toEqual({ path: 'http://localhost:3000/url' });

--- a/test/unit/util/PathUtil.test.ts
+++ b/test/unit/util/PathUtil.test.ts
@@ -52,17 +52,33 @@ describe('PathUtil', (): void => {
     });
   });
 
-  describe('UriPath functions', (): void => {
-    it('makes sure only the necessary parts are encoded with toCanonicalUriPath.', async(): Promise<void> => {
+  describe('#toCanonicalUriPath', (): void => {
+    it('encodes only the necessary parts.', async(): Promise<void> => {
       expect(toCanonicalUriPath('/a%20path&/name')).toEqual('/a%20path%26/name');
     });
 
-    it('decodes all parts of a path with decodeUriPathComponents.', async(): Promise<void> => {
+    it('leaves the query string untouched.', async(): Promise<void> => {
+      expect(toCanonicalUriPath('/a%20path&/name?abc=def&xyz')).toEqual('/a%20path%26/name?abc=def&xyz');
+    });
+  });
+
+  describe('#decodeUriPathComponents', (): void => {
+    it('decodes all parts of a path.', async(): Promise<void> => {
       expect(decodeUriPathComponents('/a%20path&/name')).toEqual('/a path&/name');
     });
 
-    it('encodes all parts of a path with encodeUriPathComponents.', async(): Promise<void> => {
+    it('leaves the query string untouched.', async(): Promise<void> => {
+      expect(decodeUriPathComponents('/a%20path&/name?abc=def&xyz')).toEqual('/a path&/name?abc=def&xyz');
+    });
+  });
+
+  describe('#encodeUriPathComponents', (): void => {
+    it('encodes all parts of a path.', async(): Promise<void> => {
       expect(encodeUriPathComponents('/a%20path&/name')).toEqual('/a%2520path%26/name');
+    });
+
+    it('leaves the query string untouched.', async(): Promise<void> => {
+      expect(encodeUriPathComponents('/a%20path&/name?abc=def&xyz')).toEqual('/a%2520path%26/name?abc=def&xyz');
     });
   });
 });

--- a/test/util/TestHelpers.ts
+++ b/test/util/TestHelpers.ts
@@ -73,8 +73,7 @@ export class ResourceHelper {
     data: Buffer,
   ): Promise<MockResponse<any>> {
     const request = Readable.from([ data ]) as HttpRequest;
-
-    request.url = requestUrl.pathname;
+    request.url = `${requestUrl.pathname}${requestUrl.search}`;
     request.method = method;
     request.headers = headers;
     request.headers.host = requestUrl.host;

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -17,7 +17,7 @@ export async function performRequest(
   data: string[],
 ): Promise<MockResponse<any>> {
   const request = streamifyArray(data) as HttpRequest;
-  request.url = requestUrl.pathname;
+  request.url = `${requestUrl.pathname}${requestUrl.search}`;
   request.method = method;
   request.headers = headers;
   request.headers.host = requestUrl.host;


### PR DESCRIPTION
Interesting case where LDP and https://github.com/solid/community-server/pull/502 diverge