### PR TITLE
feat: Require an issuer registration token

### DIFF
--- a/src/identity/interaction/email-password/handler/EmailPasswordRegisterHandler.ts
+++ b/src/identity/interaction/email-password/handler/EmailPasswordRegisterHandler.ts
@@ -56,7 +56,7 @@ export class EmailPasswordRegisterHandler extends IdPInteractionHttpHandler {
       // Qualify WebId
       assert(webId && typeof webId === 'string', 'WebId required');
       prefilledWebId = webId;
-      await this.webIdOwnershipValidator.assertWebId(webId);
+      await this.webIdOwnershipValidator.assertWebId(webId, interactionDetails.uid);
 
       // Qualify password
       assert(password && typeof password === 'string', 'Password required');

--- a/src/identity/interaction/util/BasicIssuerReferenceWebIdOwnershipValidator.ts
+++ b/src/identity/interaction/util/BasicIssuerReferenceWebIdOwnershipValidator.ts
@@ -45,7 +45,7 @@ export class BasicIssuerReferenceWebIdOwnershipValidator extends WebIdOwnershipV
     const matchingInteractionId = webIdNode.has(SOLID_OIDC_ISSUER_REGISTRATION_TOKEN, literal(interactionId));
     if (matchingIssuers.values.length === 0 || matchingInteractionId.values.length === 0) {
       let errorMessage = matchingIssuers.values.length === 0 ? `<${webId}> <${SOLID_OIDC_ISSUER.value}> <${this.issuer}> .\n` : '' ;
-      errorMessage = errorMessage.concat(matchingInteractionId.values.length === 0 ? `<${this.issuer}> <${SOLID_OIDC_ISSUER_REGISTRATION_TOKEN.value}> <${interactionId}> .\n` : '');
+      errorMessage = errorMessage.concat(matchingInteractionId.values.length === 0 ? `<${this.issuer}> <${SOLID_OIDC_ISSUER_REGISTRATION_TOKEN.value}> "${interactionId}" .\n` : '');
       errorMessage = errorMessage.concat('Must be added to the WebId')
       throw new Error(errorMessage);
     }

--- a/src/identity/interaction/util/BasicIssuerReferenceWebIdOwnershipValidator.ts
+++ b/src/identity/interaction/util/BasicIssuerReferenceWebIdOwnershipValidator.ts
@@ -1,4 +1,4 @@
-import { namedNode } from '@rdfjs/dataset';
+import { literal, namedNode } from '@rdfjs/dataset';
 import fetch from '@rdfjs/fetch';
 import type { DatasetResponse } from '@rdfjs/fetch-lite';
 import type { AnyPointer } from 'clownface';
@@ -6,7 +6,8 @@ import clownface from 'clownface';
 import type { DatasetCore } from 'rdf-js';
 import { WebIdOwnershipValidator } from './WebIdOwnershipValidator';
 
-const SOLID_ISSUER = namedNode('http://www.w3.org/ns/solid/terms#oidcIssuer');
+const SOLID_OIDC_ISSUER = namedNode('http://www.w3.org/ns/solid/terms#oidcIssuer');
+const SOLID_OIDC_ISSUER_REGISTRATION_TOKEN = namedNode('http://www.w3.org/ns/solid/terms#oidcIssuerRegistrationToken');
 
 /**
  * Validates is a WebId is okay to register based on if it
@@ -24,7 +25,7 @@ export class BasicIssuerReferenceWebIdOwnershipValidator extends WebIdOwnershipV
     this.issuer = issuer;
   }
 
-  public async assertWebId(webId: string): Promise<void> {
+  public async assertWebId(webId: string, interactionId: string): Promise<void> {
     let rawResponse: DatasetResponse<DatasetCore>;
     try {
       rawResponse = await fetch(webId) as DatasetResponse<DatasetCore>;
@@ -40,9 +41,13 @@ export class BasicIssuerReferenceWebIdOwnershipValidator extends WebIdOwnershipV
       throw new Error('Could not parse WebId rdf');
     }
     const webIdNode = dataset.namedNode(namedNode(webId));
-    const matchingNodes = webIdNode.has(SOLID_ISSUER, namedNode(this.issuer));
-    if (matchingNodes.values.length === 0) {
-      throw new Error(`"<${webId}> <${SOLID_ISSUER.value}> <${this.issuer}>" must be added to the WebId`);
+    const matchingIssuers = webIdNode.has(SOLID_OIDC_ISSUER, namedNode(this.issuer));
+    const matchingInteractionId = webIdNode.has(SOLID_OIDC_ISSUER_REGISTRATION_TOKEN, literal(interactionId));
+    if (matchingIssuers.values.length === 0 || matchingInteractionId.values.length === 0) {
+      let errorMessage = matchingIssuers.values.length === 0 ? `<${webId}> <${SOLID_OIDC_ISSUER.value}> <${this.issuer}> .\n` : '' ;
+      errorMessage = errorMessage.concat(matchingInteractionId.values.length === 0 ? `<${this.issuer}> <${SOLID_OIDC_ISSUER_REGISTRATION_TOKEN.value}> <${interactionId}> .\n` : '');
+      errorMessage = errorMessage.concat('Must be added to the WebId')
+      throw new Error(errorMessage);
     }
   }
 }

--- a/src/identity/interaction/util/WebIdOwnershipValidator.ts
+++ b/src/identity/interaction/util/WebIdOwnershipValidator.ts
@@ -3,5 +3,5 @@
  * throw an error if the WebId is not valid.
  */
 export abstract class WebIdOwnershipValidator {
-  abstract assertWebId(webId: string): Promise<void>;
+  abstract assertWebId(webId: string, interactionId: String): Promise<void>;
 }


### PR DESCRIPTION
Require a registration token for Solid OIDC Issuer registration.
Resolves: https://github.com/solid/community-server/issues/581

Note: we'll need to get this through the specification track once we find this stable/working/useful enough in order to get a standard predicate for the confirmation token.