### PR TITLE
fix: IdP crashes if interaction ID doesn't exist

### DIFF
--- a/src/server/util/BasicOnErrorHttpHandler.ts
+++ b/src/server/util/BasicOnErrorHttpHandler.ts
@@ -9,6 +9,8 @@ export class BasicOnErrorHttpHandler extends OnErrorHttpHandler {
     if (input.error instanceof Error) {
       input.input.response.end(`${input.error.stack}`);
     }
-    input.input.response.end('Error');
+    else {
+      input.input.response.end('Error');
+    }
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/solid/community-server/issues/586

Can't write after stream is ended/end it twice.