### PR TITLE
Support WAC-Allow header

### DIFF
--- a/config/presets/ldp/response-writer.json
+++ b/config/presets/ldp/response-writer.json
@@ -43,6 +43,9 @@
               "LinkRelMetadataWriter:_linkRelMap_value": "acl"
             }
           ]
+        },
+        {
+          "@type": "WacAllowMetadataWriter"
         }
       ]
     },

--- a/src/authorization/AllowEverythingAuthorizer.ts
+++ b/src/authorization/AllowEverythingAuthorizer.ts
@@ -1,10 +1,19 @@
+import type { PermissionSet } from '../ldp/permissions/PermissionSet';
 import { Authorizer } from './Authorizer';
+import { WebAclAuthorization } from './WebAclAuthorization';
+
+const allowEverything: PermissionSet = {
+  read: true,
+  write: true,
+  append: true,
+  control: true,
+};
 
 /**
  * Authorizer which allows all access independent of the identifier and requested permissions.
  */
 export class AllowEverythingAuthorizer extends Authorizer {
-  public async handle(): Promise<void> {
-    // Allows all actions
+  public async handle(): Promise<WebAclAuthorization> {
+    return new WebAclAuthorization(allowEverything, allowEverything);
   }
 }

--- a/src/authorization/Authorization.ts
+++ b/src/authorization/Authorization.ts
@@ -1,0 +1,12 @@
+import type { RepresentationMetadata } from '../ldp/representation/RepresentationMetadata';
+
+/**
+ * The output of an Authorizer
+ */
+export interface Authorization {
+  /**
+   * Add metadata relevant for this Authorization.
+   * @param metadata - Metadata to update.
+   */
+  addMetadata: (metadata: RepresentationMetadata) => void;
+}

--- a/src/authorization/Authorizer.ts
+++ b/src/authorization/Authorizer.ts
@@ -2,12 +2,13 @@ import type { Credentials } from '../authentication/Credentials';
 import type { PermissionSet } from '../ldp/permissions/PermissionSet';
 import type { ResourceIdentifier } from '../ldp/representation/ResourceIdentifier';
 import { AsyncHandler } from '../util/handlers/AsyncHandler';
+import type { Authorization } from './Authorization';
 
 /**
  * Verifies if the given credentials have access to the given permissions on the given resource.
  * An {@link Error} with the necessary explanation will be thrown when permissions are not granted.
  */
-export abstract class Authorizer extends AsyncHandler<AuthorizerArgs> {}
+export abstract class Authorizer extends AsyncHandler<AuthorizerArgs, Authorization> {}
 
 export interface AuthorizerArgs {
   /**

--- a/src/authorization/AuxiliaryAuthorizer.ts
+++ b/src/authorization/AuxiliaryAuthorizer.ts
@@ -1,6 +1,7 @@
 import type { AuxiliaryIdentifierStrategy } from '../ldp/auxiliary/AuxiliaryIdentifierStrategy';
 import { getLoggerFor } from '../logging/LogUtil';
 import { NotImplementedHttpError } from '../util/errors/NotImplementedHttpError';
+import type { Authorization } from './Authorization';
 import type { AuthorizerArgs } from './Authorizer';
 import { Authorizer } from './Authorizer';
 
@@ -26,13 +27,13 @@ export class AuxiliaryAuthorizer extends Authorizer {
     return this.resourceAuthorizer.canHandle(resourceAuth);
   }
 
-  public async handle(auxiliaryAuth: AuthorizerArgs): Promise<void> {
+  public async handle(auxiliaryAuth: AuthorizerArgs): Promise<Authorization> {
     const resourceAuth = this.getRequiredAuthorization(auxiliaryAuth);
     this.logger.debug(`Checking auth request for ${auxiliaryAuth.identifier.path} on ${resourceAuth.identifier.path}`);
     return this.resourceAuthorizer.handle(resourceAuth);
   }
 
-  public async handleSafe(auxiliaryAuth: AuthorizerArgs): Promise<void> {
+  public async handleSafe(auxiliaryAuth: AuthorizerArgs): Promise<Authorization> {
     const resourceAuth = this.getRequiredAuthorization(auxiliaryAuth);
     this.logger.debug(`Checking auth request for ${auxiliaryAuth.identifier.path} to ${resourceAuth.identifier.path}`);
     return this.resourceAuthorizer.handleSafe(resourceAuth);

--- a/src/authorization/WebAclAuthorization.ts
+++ b/src/authorization/WebAclAuthorization.ts
@@ -1,0 +1,35 @@
+import type { PermissionSet } from '../ldp/permissions/PermissionSet';
+import type { RepresentationMetadata } from '../ldp/representation/RepresentationMetadata';
+import { ACL, AUTH } from '../util/Vocabularies';
+import type { Authorization } from './Authorization';
+
+/**
+ * Indicates which permissions are available on the requested resource.
+ */
+export class WebAclAuthorization implements Authorization {
+  /**
+   * Permissions granted to the agent requesting the resource.
+   */
+  public user: PermissionSet;
+  /**
+   * Permissions granted to the public.
+   */
+  public everyone: PermissionSet;
+
+  public constructor(user: PermissionSet, everyone: PermissionSet) {
+    this.user = user;
+    this.everyone = everyone;
+  }
+
+  public addMetadata(metadata: RepresentationMetadata): void {
+    for (const mode of (Object.keys(this.user) as (keyof PermissionSet)[])) {
+      const capitalizedMode = mode.charAt(0).toUpperCase() + mode.slice(1) as 'Read' | 'Write' | 'Append' | 'Control';
+      if (this.user[mode]) {
+        metadata.add(AUTH.terms.userMode, ACL.terms[capitalizedMode]);
+      }
+      if (this.everyone[mode]) {
+        metadata.add(AUTH.terms.publicMode, ACL.terms[capitalizedMode]);
+      }
+    }
+  }
+}

--- a/src/authorization/WebAclAuthorizer.ts
+++ b/src/authorization/WebAclAuthorizer.ts
@@ -16,6 +16,7 @@ import type { IdentifierStrategy } from '../util/identifiers/IdentifierStrategy'
 import { ACL, FOAF } from '../util/Vocabularies';
 import type { AuthorizerArgs } from './Authorizer';
 import { Authorizer } from './Authorizer';
+import { WebAclAuthorization } from './WebAclAuthorization';
 
 /**
  * Handles most web access control predicates such as
@@ -48,36 +49,60 @@ export class WebAclAuthorizer extends Authorizer {
    * Will throw an error if this is not the case.
    * @param input - Relevant data needed to check if access can be granted.
    */
-  public async handle({ identifier, permissions, credentials }: AuthorizerArgs): Promise<void> {
+  public async handle({ identifier, permissions, credentials }: AuthorizerArgs): Promise<WebAclAuthorization> {
     const modes = (Object.keys(permissions) as (keyof PermissionSet)[]).filter((key): boolean => permissions[key]);
 
     // Verify that all required modes are set for the given agent
     this.logger.debug(`Checking if ${credentials.webId} has ${modes.join()} permissions for ${identifier.path}`);
     const store = await this.getAclRecursive(identifier);
+    const authorization = this.createAuthorization(credentials, store);
     for (const mode of modes) {
-      this.checkPermission(credentials, store, mode);
+      this.checkPermission(credentials, authorization, mode);
     }
     this.logger.debug(`${credentials.webId} has ${modes.join()} permissions for ${identifier.path}`);
+    return authorization;
   }
 
   /**
-   * Checks if any of the triples in the store grant the agent permission to use the given mode.
+   * Creates an Authorization object based on the quads found in the store.
+   * @param agent - Agent who's credentials will be used for the `user` field.
+   * @param store - Store containing all relevant authorization triples.
+   */
+  private createAuthorization(agent: Credentials, store: Store): WebAclAuthorization {
+    const publicPermissions = this.createPermissions({}, store);
+    const userPermissions = this.createPermissions(agent, store);
+
+    return new WebAclAuthorization(userPermissions, publicPermissions);
+  }
+
+  /**
+   * Creates the authorization permissions for the given credentials.
+   * @param credentials - Credentials to find the permissions for.
+   * @param store - Store containing all relevant authorization triples.
+   */
+  private createPermissions(credentials: Credentials, store: Store): PermissionSet {
+    const permissions: PermissionSet = {
+      read: false,
+      write: false,
+      append: false,
+      control: false,
+    };
+    for (const mode of (Object.keys(permissions) as (keyof PermissionSet)[])) {
+      permissions[mode] = this.hasPermission(credentials, store, mode);
+    }
+    return permissions;
+  }
+
+  /**
+   * Checks if the authorization grants the agent permission to use the given mode.
    * Throws a {@link ForbiddenHttpError} or {@link UnauthorizedHttpError} depending on the credentials
    * if access is not allowed.
    * @param agent - Agent that wants access.
-   * @param store - A store containing the relevant triples for authorization.
-   * @param mode - Which mode is requested. Probable one of ('write' | 'read' | 'append' | 'control').
+   * @param authorization - An Authorization containing the permissions the agent has on the resource.
+   * @param mode - Which mode is requested.
    */
-  private checkPermission(agent: Credentials, store: Store, mode: string): void {
-    const modeString = ACL[this.capitalize(mode) as 'Write' | 'Read' | 'Append' | 'Control'];
-    const auths = this.getModePermissions(store, modeString);
-
-    // Having write permissions implies having append permissions
-    if (modeString === ACL.Append) {
-      auths.push(...this.getModePermissions(store, ACL.Write));
-    }
-
-    if (!auths.some((term): boolean => this.hasAccess(agent, term, store))) {
+  private checkPermission(agent: Credentials, authorization: WebAclAuthorization, mode: keyof PermissionSet): void {
+    if (!authorization.user[mode]) {
       const isLoggedIn = typeof agent.webId === 'string';
       if (isLoggedIn) {
         this.logger.warn(`Agent ${agent.webId} has no ${mode} permissions`);
@@ -90,6 +115,24 @@ export class WebAclAuthorizer extends Authorizer {
         throw new UnauthorizedHttpError();
       }
     }
+  }
+
+  /**
+   * Checks if the given agent has permission to execute the given mode based on the triples in the store.
+   * @param agent - Agent that wants access.
+   * @param store - A store containing the relevant triples for authorization.
+   * @param mode - Which mode is requested.
+   */
+  private hasPermission(agent: Credentials, store: Store, mode: keyof PermissionSet): boolean {
+    const modeString = ACL[this.capitalize(mode) as 'Write' | 'Read' | 'Append' | 'Control'];
+    const auths = this.getModePermissions(store, modeString);
+
+    // Having write permissions implies having append permissions
+    if (modeString === ACL.Append) {
+      auths.push(...this.getModePermissions(store, ACL.Write));
+    }
+
+    return auths.some((term): boolean => this.hasAccess(agent, term, store));
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export * from './ldp/http/metadata/MetadataExtractor';
 export * from './ldp/http/metadata/MetadataParser';
 export * from './ldp/http/metadata/MetadataWriter';
 export * from './ldp/http/metadata/SlugParser';
+export * from './ldp/http/metadata/WacAllowMetadataWriter';
 
 // LDP/HTTP/Response
 export * from './ldp/http/response/CreatedResponseDescription';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,10 @@ export * from './authentication/UnsecureWebIdExtractor';
 
 // Authorization
 export * from './authorization/AllowEverythingAuthorizer';
+export * from './authorization/Authorization';
 export * from './authorization/Authorizer';
 export * from './authorization/AuxiliaryAuthorizer';
+export * from './authorization/WebAclAuthorization';
 export * from './authorization/WebAclAuthorizer';
 
 // Init

--- a/src/ldp/AuthenticatedLdpHandler.ts
+++ b/src/ldp/AuthenticatedLdpHandler.ts
@@ -127,7 +127,9 @@ export class AuthenticatedLdpHandler extends HttpHandler {
     this.logger.verbose(`Required permissions are read: ${read}, write: ${write}, append: ${append}`);
 
     try {
-      await this.authorizer.handleSafe({ credentials, identifier: operation.target, permissions });
+      const authorization = await this.authorizer
+        .handleSafe({ credentials, identifier: operation.target, permissions });
+      operation.authorization = authorization;
     } catch (error: unknown) {
       this.logger.verbose(`Authorization failed: ${(error as any).message}`);
       throw error;

--- a/src/ldp/http/metadata/WacAllowMetadataWriter.ts
+++ b/src/ldp/http/metadata/WacAllowMetadataWriter.ts
@@ -1,0 +1,40 @@
+import type { Term } from 'rdf-js';
+import type { HttpResponse } from '../../../server/HttpResponse';
+import { addHeader } from '../../../util/HeaderUtil';
+import { ACL, AUTH } from '../../../util/Vocabularies';
+import type { RepresentationMetadata } from '../../representation/RepresentationMetadata';
+import { MetadataWriter } from './MetadataWriter';
+
+/**
+ * Add the necessary WAC-Allow header values.
+ * Solid, §10.1: "Servers exposing client’s access privileges on a resource URL MUST advertise
+ * by including the WAC-Allow HTTP header in the response of HTTP HEAD and GET requests."
+ * https://solid.github.io/specification/protocol#web-access-control
+ */
+export class WacAllowMetadataWriter extends MetadataWriter {
+  public async handle(input: { response: HttpResponse; metadata: RepresentationMetadata }): Promise<void> {
+    const userModes = input.metadata.getAll(AUTH.terms.userMode).map(this.aclToPermission);
+    const publicModes = input.metadata.getAll(AUTH.terms.publicMode).map(this.aclToPermission);
+
+    const headerStrings: string[] = [];
+    if (userModes.length > 0) {
+      headerStrings.push(this.createAccessParam('user', userModes));
+    }
+    if (publicModes.length > 0) {
+      headerStrings.push(this.createAccessParam('public', publicModes));
+    }
+
+    // Only add the header if there are permissions to show
+    if (headerStrings.length > 0) {
+      addHeader(input.response, 'WAC-Allow', headerStrings.join(','));
+    }
+  }
+
+  private aclToPermission(aclTerm: Term): string {
+    return aclTerm.value.slice(ACL.namespace.length).toLowerCase();
+  }
+
+  private createAccessParam(name: string, modes: string[]): string {
+    return `${name}="${modes.join(' ')}"`;
+  }
+}

--- a/src/ldp/operations/GetOperationHandler.ts
+++ b/src/ldp/operations/GetOperationHandler.ts
@@ -25,6 +25,9 @@ export class GetOperationHandler extends OperationHandler {
 
   public async handle(input: Operation): Promise<ResponseDescription> {
     const body = await this.store.getRepresentation(input.target, input.preferences);
+
+    input.authorization?.addMetadata(body.metadata);
+
     return new OkResponseDescription(body.metadata, body.data);
   }
 }

--- a/src/ldp/operations/HeadOperationHandler.ts
+++ b/src/ldp/operations/HeadOperationHandler.ts
@@ -29,6 +29,8 @@ export class HeadOperationHandler extends OperationHandler {
     // Close the Readable as we will not return it.
     body.data.destroy();
 
+    input.authorization?.addMetadata(body.metadata);
+
     return new OkResponseDescription(body.metadata);
   }
 }

--- a/src/ldp/operations/Operation.ts
+++ b/src/ldp/operations/Operation.ts
@@ -1,3 +1,4 @@
+import type { Authorization } from '../../authorization/Authorization';
 import type { Representation } from '../representation/Representation';
 import type { RepresentationPreferences } from '../representation/RepresentationPreferences';
 import type { ResourceIdentifier } from '../representation/ResourceIdentifier';
@@ -18,6 +19,10 @@ export interface Operation {
    * Representation preferences of the response. Will be empty if there are none.
    */
   preferences: RepresentationPreferences;
+  /**
+   * This value will be set if the Operation was authorized by an Authorizer.
+   */
+  authorization?: Authorization;
   /**
    * Optional representation of the body.
    */

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -68,6 +68,11 @@ export const ACL = createUriAndTermNamespace('http://www.w3.org/ns/auth/acl#',
   'Control',
 );
 
+export const AUTH = createUriAndTermNamespace('urn:solid:auth:',
+  'userMode',
+  'publicMode',
+);
+
 export const DC = createUriAndTermNamespace('http://purl.org/dc/terms/',
   'modified',
 );

--- a/test/integration/LdpHandlerWithAuth.test.ts
+++ b/test/integration/LdpHandlerWithAuth.test.ts
@@ -75,6 +75,7 @@ describe.each(stores)('An LDP handler with auth using %s', (name, { storeUrn, te
     expect(response._getBuffer().toString()).toContain('TESTFILE2');
     expect(response.getHeaders().link).toContain(`<${LDP.Resource}>; rel="type"`);
     expect(response.getHeaders().link).toContain(`<${id}.acl>; rel="acl"`);
+    expect(response.getHeaders()['wac-allow']).toBe('user="read write append",public="read write append"');
 
     // DELETE file
     await resourceHelper.deleteResource(id);
@@ -107,6 +108,7 @@ describe.each(stores)('An LDP handler with auth using %s', (name, { storeUrn, te
     expect(response._getBuffer().toString()).toContain('TEST');
     expect(response.getHeaders().link).toContain(`<${LDP.Resource}>; rel="type"`);
     expect(response.getHeaders().link).toContain(`<http://test.com/permanent.txt.acl>; rel="acl"`);
+    expect(response.getHeaders()['wac-allow']).toBe('user="read",public="read"');
 
     // Try to delete permanent file
     response = await resourceHelper.deleteResource('http://test.com/permanent.txt', true);
@@ -147,5 +149,6 @@ describe.each(stores)('An LDP handler with auth using %s', (name, { storeUrn, te
 
     const response = await resourceHelper.performRequest(new URL('http://test.com/.acl'), 'GET', { accept: '*/*' });
     expect(response.statusCode).toBe(200);
+    expect(response.getHeaders()['wac-allow']).toBe('user="control",public="control"');
   });
 });

--- a/test/integration/ServerWithAuth.test.ts
+++ b/test/integration/ServerWithAuth.test.ts
@@ -112,5 +112,6 @@ describe('A server with authorization', (): void => {
       [],
     );
     expect(response.statusCode).toBe(200);
+    expect(response.getHeaders()['wac-allow']).toBe('user="read write append",public="read write append"');
   });
 });

--- a/test/unit/authorization/AllowEverythingAuthorizer.test.ts
+++ b/test/unit/authorization/AllowEverythingAuthorizer.test.ts
@@ -1,13 +1,23 @@
 import { AllowEverythingAuthorizer } from '../../../src/authorization/AllowEverythingAuthorizer';
+import type { PermissionSet } from '../../../src/ldp/permissions/PermissionSet';
 
 describe('An AllowEverythingAuthorizer', (): void => {
   const authorizer = new AllowEverythingAuthorizer();
+  const allowEverything: PermissionSet = {
+    read: true,
+    write: true,
+    append: true,
+    control: true,
+  };
 
   it('can handle everything.', async(): Promise<void> => {
     await expect(authorizer.canHandle({} as any)).resolves.toBeUndefined();
   });
 
-  it('always returns undefined.', async(): Promise<void> => {
-    await expect(authorizer.handle()).resolves.toBeUndefined();
+  it('always returns an empty Authorization.', async(): Promise<void> => {
+    await expect(authorizer.handle()).resolves.toEqual({
+      user: allowEverything,
+      everyone: allowEverything,
+    });
   });
 });

--- a/test/unit/authorization/WebAclAuthorization.test.ts
+++ b/test/unit/authorization/WebAclAuthorization.test.ts
@@ -1,0 +1,43 @@
+import { WebAclAuthorization } from '../../../src/authorization/WebAclAuthorization';
+import { RepresentationMetadata } from '../../../src/ldp/representation/RepresentationMetadata';
+import { ACL, AUTH } from '../../../src/util/Vocabularies';
+import 'jest-rdf';
+
+describe('A WebAclAuthorization', (): void => {
+  let authorization: WebAclAuthorization;
+  let metadata: RepresentationMetadata;
+
+  beforeEach(async(): Promise<void> => {
+    authorization = new WebAclAuthorization(
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      },
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      },
+    );
+
+    metadata = new RepresentationMetadata();
+  });
+
+  it('adds no metadata if there are no permissions.', async(): Promise<void> => {
+    expect(authorization.addMetadata(metadata)).toBeUndefined();
+    expect(metadata.quads()).toHaveLength(0);
+  });
+
+  it('adds corresponding acl metadata for all permissions present.', async(): Promise<void> => {
+    authorization.user.read = true;
+    authorization.user.write = true;
+    authorization.everyone.read = true;
+    expect(authorization.addMetadata(metadata)).toBeUndefined();
+    expect(metadata.quads()).toHaveLength(3);
+    expect(metadata.getAll(AUTH.terms.userMode)).toEqualRdfTermArray([ ACL.terms.Read, ACL.terms.Write ]);
+    expect(metadata.get(AUTH.terms.publicMode)).toEqualRdfTerm(ACL.terms.Read);
+  });
+});

--- a/test/unit/ldp/AuthenticatedLdpHandler.test.ts
+++ b/test/unit/ldp/AuthenticatedLdpHandler.test.ts
@@ -70,7 +70,7 @@ describe('An AuthenticatedLdpHandler', (): void => {
   });
 
   it('errors an invalid object was thrown by a handler.', async(): Promise< void> => {
-    args.authorizer.handle = async(): Promise<void> => {
+    args.authorizer.handle = async(): Promise<any> => {
       throw 'apple';
     };
     const handler = new AuthenticatedLdpHandler(args);

--- a/test/unit/ldp/http/metadata/WacAllowMetadataWriter.test.ts
+++ b/test/unit/ldp/http/metadata/WacAllowMetadataWriter.test.ts
@@ -1,0 +1,43 @@
+import { createResponse } from 'node-mocks-http';
+import { WacAllowMetadataWriter } from '../../../../../src/ldp/http/metadata/WacAllowMetadataWriter';
+import { RepresentationMetadata } from '../../../../../src/ldp/representation/RepresentationMetadata';
+import type { HttpResponse } from '../../../../../src/server/HttpResponse';
+import { ACL, AUTH } from '../../../../../src/util/Vocabularies';
+
+describe('WacAllowMetadataWriter', (): void => {
+  const writer = new WacAllowMetadataWriter();
+  let response: HttpResponse;
+
+  beforeEach(async(): Promise<void> => {
+    response = createResponse();
+  });
+
+  it('adds no header if there is no relevant metadata.', async(): Promise<void> => {
+    const metadata = new RepresentationMetadata();
+    await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
+    expect(response.getHeaders()).toEqual({ });
+  });
+
+  it('adds a WAC-Allow header if there is relevant metadata.', async(): Promise<void> => {
+    const metadata = new RepresentationMetadata({
+      [AUTH.userMode]: [ ACL.terms.Read, ACL.terms.Write ],
+      [AUTH.publicMode]: [ ACL.terms.Read ],
+    });
+    await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
+
+    expect(response.getHeaders()).toEqual({
+      'wac-allow': 'user="read write",public="read"',
+    });
+  });
+
+  it('only adds a header value for entries with at least 1 permission.', async(): Promise<void> => {
+    const metadata = new RepresentationMetadata({
+      [AUTH.userMode]: [ ACL.terms.Read, ACL.terms.Write ],
+    });
+    await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
+
+    expect(response.getHeaders()).toEqual({
+      'wac-allow': 'user="read write"',
+    });
+  });
+});

--- a/test/unit/ldp/operations/GetOperationHandler.test.ts
+++ b/test/unit/ldp/operations/GetOperationHandler.test.ts
@@ -1,3 +1,4 @@
+import type { Authorization } from '../../../../src/authorization/Authorization';
 import { GetOperationHandler } from '../../../../src/ldp/operations/GetOperationHandler';
 import type { Operation } from '../../../../src/ldp/operations/Operation';
 import type { Representation } from '../../../../src/ldp/representation/Representation';
@@ -21,5 +22,13 @@ describe('A GetOperationHandler', (): void => {
     expect(result.statusCode).toBe(200);
     expect(result.metadata).toBe('metadata');
     expect(result.data).toBe('data');
+  });
+
+  it('adds authorization metadata in case the operation is an AuthorizedOperation.', async(): Promise<void> => {
+    const authorization: Authorization = { addMetadata: jest.fn() };
+    const result = await handler.handle({ target: { path: 'url' }, authorization } as Operation);
+    expect(result.statusCode).toBe(200);
+    expect(authorization.addMetadata).toHaveBeenCalledTimes(1);
+    expect(authorization.addMetadata).toHaveBeenLastCalledWith('metadata');
   });
 });

--- a/test/unit/ldp/operations/HeadOperationHandler.test.ts
+++ b/test/unit/ldp/operations/HeadOperationHandler.test.ts
@@ -1,4 +1,5 @@
 import type { Readable } from 'stream';
+import type { Authorization } from '../../../../src/authorization/Authorization';
 import { HeadOperationHandler } from '../../../../src/ldp/operations/HeadOperationHandler';
 import type { Operation } from '../../../../src/ldp/operations/Operation';
 import type { Representation } from '../../../../src/ldp/representation/Representation';
@@ -31,5 +32,13 @@ describe('A HeadOperationHandler', (): void => {
     expect(result.metadata).toBe('metadata');
     expect(result.data).toBeUndefined();
     expect(data.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds authorization metadata in case the operation is an AuthorizedOperation.', async(): Promise<void> => {
+    const authorization: Authorization = { addMetadata: jest.fn() };
+    const result = await handler.handle({ target: { path: 'url' }, authorization } as Operation);
+    expect(result.statusCode).toBe(200);
+    expect(authorization.addMetadata).toHaveBeenCalledTimes(1);
+    expect(authorization.addMetadata).toHaveBeenLastCalledWith('metadata');
   });
 });


### PR DESCRIPTION
Closes #225.

Depends on #554 since there are several changes to permissions and authorization there.

I tried to tread a fine line between not making anything to ACL-specific, but also not adding too many interfaces/classes just for this single header.

The idea is that an `Authorizer` now returns an `Authorization` object (in case it doesn't fail) which is an empty interface except for the `addMetadata` function, allowing full freedom on how to fill that in depending on the authorization model being used. This then gets attached to the `Operation`, and the GET/HEAD handlers call the `addMetadata` on the resulting metadata, which then gets used by a `MetadataWriter` to create the header.

I choose to have the `addMetadata` function in the `Authorization` object since otherwise we would need a new interface `AuthorizationMetadataHandler` (or something like that) which would need an implementation and be injected in the GET/HEAD handlers, which seemed too much just for supporting this header.

I added checks for the header in the integration tests where this was relevant, but I noticed that our integration for ACL-specific cases is quite lacking actually. We might need some more there (I actually added some specific ones in #615 for subdomains, so could be based on the config used there once it is merged).