### PR TITLE
fix: Docker COPY command for multiple files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:lts AS build
 WORKDIR /community-server
 
 ## Copy the package.json for audit
-COPY package*.json .
+COPY package*.json ./
 
 ## Verify if there are known vulnerabilities in the dependencies
 RUN npm audit --production --audit-level=high


### PR DESCRIPTION
# Description

The Dockerfile attempts to copy multiple JSON files with the `COPY` command.
However, this is not possible with `.` as directory. This can be fixed by using `./` as directory path.
Fixes #641

# Environment

Tested on the following setup:
- Armbian 21.02.2 Focal
- Odroid HC2 (armv7)