### PR TITLE
docs: add -b CLI parameter description for Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,8 @@ Common usage:
   ```shell
   docker run --rm -v ~/solid-config:/config -p 3000:3000 -it css:latest -c /config/my-config.json
   ```
+- If you run the Docker image on your selfhosted infrastructure, you need to supply the domainname:
+  ```shell
+  docker run --rm -p 3000:3000 -it css:latest -c /config/my-config.json -b http://example.org
+  ```
+  Note that you should not use `https` here as your reverse proxy strips that away for the server.


### PR DESCRIPTION
# Description

I deployed the Community Server on my selfhosted infrastructure and made it accessible at https://data.dylanvanassche.be.
However, if I follow the instructions, the server fails with:
```
InternalServerError: http://data.dylanvanassche.be/ is not supported
    at SingleRootIdentifierStrategy.getParentContainer (/community-server/dist/util/identifiers/BaseIdentifierStrategy.js:14:19)
    at WebAclAuthorizer.getAclRecursive (/community-server/dist/authorization/WebAclAuthorizer.js:186:48)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async WebAclAuthorizer.handle (/community-server/dist/authorization/WebAclAuthorizer.js:41:23)
    at async AuthenticatedLdpHandler.runHandlers (/community-server/dist/ldp/AuthenticatedLdpHandler.js:75:35)
    at async AuthenticatedLdpHandler.handle (/community-server/dist/ldp/AuthenticatedLdpHandler.js:46:61)
    at async SequenceHandler.handle (/community-server/dist/util/handlers/SequenceHandler.js:27:26)
    at async Server.<anonymous> (/community-server/dist/server/BaseHttpServerFactory.js:25:17)
```

It is necessary to specify the domainname using the `-b` CLI argument as `-b http://data.dylanvanassche.be`.
Since this runs behind a reverse proxy, `https` is not needed.

# Environment
- Armbian 21.02.2 Focal
- Odroid HC2 (armv7)
- Traefik reverse proxy
- Nomad + Consul cluster