### PR TITLE
fix: make new pod profile card public

### DIFF
--- a/templates/pod/profile/card.acl
+++ b/templates/pod/profile/card.acl
@@ -1,0 +1,17 @@
+# ACL resource for the WebId profile document
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+# The profile is readable by the public.
+<#public>
+    a acl:Authorization;
+    acl:agentClass foaf:Agent;
+    acl:accessTo <./card>;
+    acl:mode acl:Read.
+
+# The owner has full access to the profile.
+<#owner>
+    a acl:Authorization;
+    acl:agent <{{webId}}>;
+    acl:accessTo <./card>;
+    acl:mode acl:Read, acl:Write, acl:Control.

--- a/templates/pod/profile/card.acl
+++ b/templates/pod/profile/card.acl
@@ -11,9 +11,11 @@
     acl:accessTo <./card>;
     acl:mode acl:Read.
 
-# The owner has full access to the profile.
+# The owner has full access to the entire
+# profile directory.
 <#owner>
     a acl:Authorization;
     acl:agent <{{webId}}>;
     acl:accessTo <./card>;
+    acl:default <./>;
     acl:mode acl:Read, acl:Write, acl:Control.

--- a/templates/pod/profile/card.acl
+++ b/templates/pod/profile/card.acl
@@ -16,6 +16,6 @@
 <#owner>
     a acl:Authorization;
     acl:agent <{{webId}}>;
-    acl:accessTo <./card>;
+    acl:accessTo <./>;
     acl:default <./>;
     acl:mode acl:Read, acl:Write, acl:Control.

--- a/templates/pod/profile/card.acl
+++ b/templates/pod/profile/card.acl
@@ -2,7 +2,9 @@
 @prefix acl: <http://www.w3.org/ns/auth/acl#>.
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 
-# The profile is readable by the public.
+# The WebID profile is readable by the public.
+# This is required for discovery and verification,
+# e.g. when checking identity providers.
 <#public>
     a acl:Authorization;
     acl:agentClass foaf:Agent;

--- a/templates/pod/profile/card.acl
+++ b/templates/pod/profile/card.acl
@@ -1,4 +1,4 @@
-# ACL resource for the WebId profile document
+# ACL resource for the WebID profile document
 @prefix acl: <http://www.w3.org/ns/auth/acl#>.
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 


### PR DESCRIPTION
Solves #657 by adding ACL file for profile card.

Signed-off-by: Wouter Termont <woutermont@gmail.com>