### PR TITLE
Fallback to X-Forwarded-* headers

### DIFF
--- a/src/ldp/UnsecureWebSocketsProtocol.ts
+++ b/src/ldp/UnsecureWebSocketsProtocol.ts
@@ -44,7 +44,7 @@ class WebSocketListener extends EventEmitter {
     }
 
     // Store the HTTP host and protocol
-    const forwarded = parseForwarded(headers.forwarded);
+    const forwarded = parseForwarded(headers);
     this.host = forwarded.host ?? headers.host ?? 'localhost';
     this.protocol = forwarded.proto === 'https' || (socket as any).secure ? 'https:' : 'http:';
   }

--- a/src/ldp/http/OriginalUrlExtractor.ts
+++ b/src/ldp/http/OriginalUrlExtractor.ts
@@ -1,6 +1,6 @@
 import type { TLSSocket } from 'tls';
 import type { HttpRequest } from '../../server/HttpRequest';
-import { parseForwarded, parseXForwarded } from '../../util/HeaderUtil';
+import { parseForwarded } from '../../util/HeaderUtil';
 import { toCanonicalUriPath } from '../../util/PathUtil';
 import type { ResourceIdentifier } from '../representation/ResourceIdentifier';
 import { TargetExtractor } from './TargetExtractor';
@@ -21,26 +21,17 @@ export class OriginalUrlExtractor extends TargetExtractor {
       throw new Error('Missing URL');
     }
 
-    // Extract host and protocol (possibly overridden by the Forwarded header)
+    // Extract host and protocol (possibly overridden by the Forwarded/X-Forwarded-* header)
     let { host }: { host?: string } = headers;
     let protocol = (connection as TLSSocket)?.encrypted ? 'https' : 'http';
-    if (headers.forwarded) {
-      const forwarded = parseForwarded(headers.forwarded);
-      if (forwarded.host) {
-        ({ host } = forwarded);
-      }
-      if (forwarded.proto) {
-        ({ proto: protocol } = forwarded);
-      }
-    } else if (headers['x-forwarded-host'] ?? headers['x-forwarded-proto']) {
-      const xHost = headers['x-forwarded-host'] as string;
-      const xProto = headers['x-forwarded-proto'] as string;
-      if (xHost) {
-        host = parseXForwarded(xHost)[0];
-      }
-      if (xProto) {
-        protocol = parseXForwarded(xProto)[0];
-      }
+
+    // Check Forwarded/X-Forwarded-* headers
+    const forwarded = parseForwarded(headers);
+    if (forwarded.host) {
+      ({ host } = forwarded);
+    }
+    if (forwarded.proto) {
+      ({ proto: protocol } = forwarded);
     }
 
     // Perform a sanity check on the host

--- a/src/ldp/http/OriginalUrlExtractor.ts
+++ b/src/ldp/http/OriginalUrlExtractor.ts
@@ -22,7 +22,7 @@ export class OriginalUrlExtractor extends TargetExtractor {
     }
 
     // Extract host and protocol (possibly overridden by the Forwarded/X-Forwarded-* header)
-    let { host }: { host?: string } = headers;
+    let { host } = headers;
     let protocol = (connection as TLSSocket)?.encrypted ? 'https' : 'http';
 
     // Check Forwarded/X-Forwarded-* headers

--- a/src/util/HeaderUtil.ts
+++ b/src/util/HeaderUtil.ts
@@ -447,3 +447,14 @@ export function parseForwarded(value = ''): Forwarded {
   }
   return forwarded;
 }
+
+/**
+ * Parses an X-Forwarded-* header value into an array.
+ *
+ * @param value - The X-Forwarded-* header value.
+ *
+ * @returns An array of trimmed values from the header.
+ */
+export function parseXForwarded(value = ''): string[] {
+  return value.split(',').map((val): string => val.trim());
+}

--- a/src/util/HeaderUtil.ts
+++ b/src/util/HeaderUtil.ts
@@ -441,7 +441,7 @@ export interface Forwarded {
 }
 
 /**
- * Parses a Forwarded header value and will fallback to X-Forwarded-* headers.
+ * Parses a Forwarded header value and will fall back to X-Forwarded-* headers.
  *
  * @param headers - The incomming http headers.
  *

--- a/src/util/HeaderUtil.ts
+++ b/src/util/HeaderUtil.ts
@@ -448,10 +448,9 @@ export function parseForwarded(headers: IncomingHttpHeaders): Forwarded {
   } else {
     const suffixes = [ 'host', 'proto' ];
     for (const suffix of suffixes) {
-      let value = (headers[`x-forwarded-${suffix}`]) as string;
-      value = (value ?? '').trim().replace(/\s*,.*/u, '');
+      const value = headers[`x-forwarded-${suffix}`] as string;
       if (value) {
-        forwarded[suffix] = value;
+        forwarded[suffix] = value.trim().replace(/\s*,.*/u, '');
       }
     }
   }

--- a/src/util/HeaderUtil.ts
+++ b/src/util/HeaderUtil.ts
@@ -416,17 +416,6 @@ export function addHeader(response: HttpResponse, name: string, value: string | 
 }
 
 /**
- * Parses out the first value of an X-Forwarded-* header.
- *
- * @param value - The value of the X-Fowarded-* header.
- *
- * @returns The first value of the X-Fowraded-* header.
- */
-function parseXForwarded(value = ''): string {
-  return value.split(',').map((val): string => val.trim())[0];
-}
-
-/**
  * The Forwarded header from RFC7239
  */
 export interface Forwarded {
@@ -443,7 +432,7 @@ export interface Forwarded {
 /**
  * Parses a Forwarded header value and will fall back to X-Forwarded-* headers.
  *
- * @param headers - The incomming http headers.
+ * @param headers - The incoming http headers.
  *
  * @returns The parsed Forwarded header.
  */
@@ -456,14 +445,14 @@ export function parseForwarded(headers: IncomingHttpHeaders): Forwarded {
         forwarded[components[1]] = components[2];
       }
     }
-  } else if (headers['x-forwarded-host'] ?? headers['x-forwarded-proto']) {
-    const xHost = parseXForwarded(headers['x-forwarded-host'] as string);
-    const xProto = parseXForwarded(headers['x-forwarded-proto'] as string);
-    if (xHost) {
-      forwarded.host = xHost;
-    }
-    if (xProto) {
-      forwarded.proto = xProto;
+  } else {
+    const suffixes = [ 'host', 'proto' ];
+    for (const suffix of suffixes) {
+      let value = (headers[`x-forwarded-${suffix}`]) as string;
+      value = (value ?? '').trim().replace(/\s*,.*/u, '');
+      if (value) {
+        forwarded[suffix] = value;
+      }
     }
   }
   return forwarded;

--- a/src/util/HeaderUtil.ts
+++ b/src/util/HeaderUtil.ts
@@ -432,14 +432,14 @@ export interface Forwarded {
 /**
  * Parses a Forwarded header value and will fall back to X-Forwarded-* headers.
  *
- * @param headers - The incoming http headers.
+ * @param headers - The incoming HTTP headers.
  *
  * @returns The parsed Forwarded header.
  */
 export function parseForwarded(headers: IncomingHttpHeaders): Forwarded {
   const forwarded: Record<string, string> = {};
   if (headers.forwarded) {
-    for (const pair of headers.forwarded.replace(/\s*,.*$/u, '').split(';')) {
+    for (const pair of headers.forwarded.replace(/\s*,.*/u, '').split(';')) {
       const components = /^(by|for|host|proto)=(.+)$/u.exec(pair);
       if (components) {
         forwarded[components[1]] = components[2];

--- a/test/unit/ldp/UnsecureWebSocketsProtocol.test.ts
+++ b/test/unit/ldp/UnsecureWebSocketsProtocol.test.ts
@@ -182,4 +182,20 @@ describe('An UnsecureWebSocketsProtocol', (): void => {
     expect(webSocket.messages).toHaveLength(2);
     expect(webSocket.messages.pop()).toBe('ack https://other.example/protocol/foo');
   });
+
+  it('respects the X-Forwarded-* headers if Forwarded header is not present.', async(): Promise<void> => {
+    const webSocket = new DummySocket();
+    const upgradeRequest = {
+      headers: {
+        'x-forwarded-host': 'other.example',
+        'x-forwarded-proto': 'https',
+        'sec-websocket-protocol': 'solid-0.1',
+      },
+      socket: {},
+    } as any as HttpRequest;
+    await protocol.handle({ webSocket, upgradeRequest } as any);
+    webSocket.emit('message', 'sub https://other.example/protocol/foo');
+    expect(webSocket.messages).toHaveLength(2);
+    expect(webSocket.messages.pop()).toBe('ack https://other.example/protocol/foo');
+  });
 });

--- a/test/unit/util/HeaderUtil.test.ts
+++ b/test/unit/util/HeaderUtil.test.ts
@@ -7,6 +7,7 @@ import {
   parseAcceptEncoding,
   parseAcceptLanguage,
   parseForwarded,
+  parseXForwarded,
 } from '../../../src/util/HeaderUtil';
 
 describe('HeaderUtil', (): void => {
@@ -215,6 +216,20 @@ describe('HeaderUtil', (): void => {
       expect(parseForwarded('host=pod.example, for=192.0.2.43, host=other')).toEqual({
         host: 'pod.example',
       });
+    });
+  });
+
+  describe('#parseXForwardedPart', (): void => {
+    it('should parse an undefined value.', (): void => {
+      expect(parseXForwarded()).toEqual([ '' ]);
+    });
+
+    it('should properly handle a comma separated list of values with varying spaces.', (): void => {
+      expect(parseXForwarded('pod.example,192.0.2.60, 192.0.2.43 ')).toEqual([
+        'pod.example',
+        '192.0.2.60',
+        '192.0.2.43',
+      ]);
     });
   });
 });

--- a/test/unit/util/HeaderUtil.test.ts
+++ b/test/unit/util/HeaderUtil.test.ts
@@ -188,7 +188,7 @@ describe('HeaderUtil', (): void => {
   });
 
   describe('#parseForwarded', (): void => {
-    it('handles undefined values.', (): void => {
+    it('handles an empty set of headers.', (): void => {
       expect(parseForwarded({})).toEqual({});
     });
 
@@ -221,7 +221,7 @@ describe('HeaderUtil', (): void => {
       });
     });
 
-    it('should fallback to X-Forwarded-Host and X-Forwarded-Proto without Forward header.', (): void => {
+    it('should fall back to X-Forwarded-Host and X-Forwarded-Proto without Forward header.', (): void => {
       const headers = { 'x-forwarded-host': 'pod.example', 'x-forwarded-proto': 'https' };
       expect(parseForwarded(headers)).toEqual({
         host: 'pod.example',
@@ -241,7 +241,7 @@ describe('HeaderUtil', (): void => {
       });
     });
 
-    it('should proplery handle multiple values with varying spaces for X-Forwarded-*.', (): void => {
+    it('should properly handle multiple values with varying spaces for X-Forwarded-*.', (): void => {
       const headers = {
         'x-forwarded-host': ' pod.example ,192.0.2.60, 192.0.2.43',
         'x-forwarded-proto': ' https ,http',

--- a/test/unit/util/HeaderUtil.test.ts
+++ b/test/unit/util/HeaderUtil.test.ts
@@ -242,7 +242,10 @@ describe('HeaderUtil', (): void => {
     });
 
     it('should proplery handle multiple values with varying spaces for X-Forwarded-*.', (): void => {
-      const headers = { 'x-forwarded-host': 'pod.example,192.0.2.60, 192.0.2.43', 'x-forwarded-proto': 'https,http' };
+      const headers = {
+        'x-forwarded-host': ' pod.example ,192.0.2.60, 192.0.2.43',
+        'x-forwarded-proto': ' https ,http',
+      };
       expect(parseForwarded(headers)).toEqual({
         host: 'pod.example',
         proto: 'https',


### PR DESCRIPTION
This uses the first value from `X-Forwarded-Host` and `X-Forwarded-Proto` if they're present and the standard `Forwarded` header is not.

Please let me know if I can implement this in a different way. I tried to follow existing patterns and limit the changes required.

Resolves #645