### PR TITLE
Create handler for the confirm page

### DIFF
--- a/config/presets/identity/email-password-interaction-policy.json
+++ b/config/presets/identity/email-password-interaction-policy.json
@@ -143,6 +143,18 @@
           }
         },
         {
+          "comment": "Handles confirm requests",
+          "@type": "RouterHandler",
+          "RouterHandler:_allowedMethods": [ "POST" ],
+          "RouterHandler:_allowedPathNames": [ "^/idp/interaction/[-_A-Za-z0-9]+/confirm/?$" ],
+          "RouterHandler:_handler": {
+            "@type": "IdpSessionHttpHandler",
+            "IdpSessionHttpHandler:_oidcInteractionCompleter": {
+              "@id": "urn:solid-server:email-password-interaction:OidcInteractionCompleter"
+            }
+          }
+        },
+        {
           "comment": "Handles all functionality on the forgot password page",
           "@type": "IdpRouteController",
           "IdpRouteController:_pathName": "^/idp/interaction/[-_A-Za-z0-9]+/forgotpassword/?$",

--- a/src/identity/interaction/IdpSessionHttpHandler.ts
+++ b/src/identity/interaction/IdpSessionHttpHandler.ts
@@ -1,0 +1,24 @@
+import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
+import type { IdpInteractionHttpHandlerInput } from './IdpInteractionHttpHandler';
+import { IdpInteractionHttpHandler } from './IdpInteractionHttpHandler';
+import type { OidcInteractionCompleter } from './util/OidcInteractionCompleter';
+
+/**
+ * Simple IdpInteractionHttpHandler that sends the session accountId to the OidcInteractionCompleter as webId.
+ */
+export class IdpSessionHttpHandler extends IdpInteractionHttpHandler {
+  private readonly oidcInteractionCompleter: OidcInteractionCompleter;
+
+  public constructor(oidcInteractionCompleter: OidcInteractionCompleter) {
+    super();
+    this.oidcInteractionCompleter = oidcInteractionCompleter;
+  }
+
+  public async handle(input: IdpInteractionHttpHandlerInput): Promise<void> {
+    const details = await input.provider.interactionDetails(input.request, input.response);
+    if (!details.session || !details.session.accountId) {
+      throw new NotImplementedHttpError('Only confirm actions with a session and accountId are supported');
+    }
+    await this.oidcInteractionCompleter.handleSafe({ ...input, webId: details.session.accountId as string });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export * from './identity/interaction/util/WebIdOwnershipValidator';
 // Identity/Interaction
 export * from './identity/interaction/IdpInteractionHttpHandler';
 export * from './identity/interaction/IdpInteractionPolicy';
+export * from './identity/interaction/IdpSessionHttpHandler';
 
 // Identity/Storage
 export * from './identity/storage/ClientWebIdFetchingStorageAdapterFactory';

--- a/test/integration/Identity.test.ts
+++ b/test/integration/Identity.test.ts
@@ -86,10 +86,10 @@ describe('A Solid server with IdP', (): void => {
     });
 
     it('initializes the session and finds the registration URL.', async(): Promise<void> => {
-      const { register } = await state.startSession();
+      const url = await state.startSession();
+      const { register } = await state.parseLoginPage(url);
       expect(typeof register).toBe('string');
-      const { url } = await state.extractFormUrl(register);
-      nextUrl = url;
+      nextUrl = (await state.extractFormUrl(register)).url;
     });
 
     it('sends the form once to receive the registration triple.', async(): Promise<void> => {
@@ -149,7 +149,8 @@ describe('A Solid server with IdP', (): void => {
     });
 
     it('initializes the session and logs in.', async(): Promise<void> => {
-      const { login } = await state.startSession();
+      const url = await state.startSession();
+      const { login } = await state.parseLoginPage(url);
       expect(typeof login).toBe('string');
       await state.login(login, email, password);
       expect(state.session.info?.webId).toBe(webId);
@@ -168,6 +169,16 @@ describe('A Solid server with IdP', (): void => {
       const res = await state.session.fetch(container);
       expect(res.status).toBe(401);
     });
+
+    it('can log in again.', async(): Promise<void> => {
+      const url = await state.startSession();
+
+      // For the following part it is debatable if this is correct but this might be a consequence of the authn client
+      const form = await state.extractFormUrl(url);
+      expect(form.url.endsWith('/confirm')).toBe(true);
+
+      // TODO: the next step can't happen until we have a handler
+    });
   });
 
   describe('resetting password', (): void => {
@@ -179,10 +190,10 @@ describe('A Solid server with IdP', (): void => {
     });
 
     it('initializes the session and finds the forgot password URL.', async(): Promise<void> => {
-      const { forgotPassword } = await state.startSession();
+      const url = await state.startSession();
+      const { forgotPassword } = await state.parseLoginPage(url);
       expect(typeof forgotPassword).toBe('string');
-      const { url } = await state.extractFormUrl(forgotPassword);
-      nextUrl = url;
+      nextUrl = (await state.extractFormUrl(forgotPassword)).url;
     });
 
     it('sends the corresponding email address through the form to get a mail.', async(): Promise<void> => {
@@ -221,7 +232,8 @@ describe('A Solid server with IdP', (): void => {
     });
 
     it('initializes the session.', async(): Promise<void> => {
-      const { login } = await state.startSession();
+      const url = await state.startSession();
+      const { login } = await state.parseLoginPage(url);
       expect(typeof login).toBe('string');
       nextUrl = login;
     });

--- a/test/integration/Identity.test.ts
+++ b/test/integration/Identity.test.ts
@@ -177,7 +177,12 @@ describe('A Solid server with IdP', (): void => {
       const form = await state.extractFormUrl(url);
       expect(form.url.endsWith('/confirm')).toBe(true);
 
-      // TODO: the next step can't happen until we have a handler
+      const res = await state.fetchIdp(form.url, 'POST');
+      const nextUrl = res.headers.get('location');
+      expect(typeof nextUrl).toBe('string');
+
+      await state.handleLoginRedirect(nextUrl!);
+      expect(state.session.info?.webId).toBe(webId);
     });
   });
 

--- a/test/unit/identity/interaction/IdpSessionHttpHandler.test.ts
+++ b/test/unit/identity/interaction/IdpSessionHttpHandler.test.ts
@@ -1,0 +1,50 @@
+import type { Provider } from 'oidc-provider';
+import { IdpSessionHttpHandler } from '../../../../src/identity/interaction/IdpSessionHttpHandler';
+import type { OidcInteractionCompleter } from '../../../../src/identity/interaction/util/OidcInteractionCompleter';
+import type { HttpRequest } from '../../../../src/server/HttpRequest';
+import type { HttpResponse } from '../../../../src/server/HttpResponse';
+import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
+
+describe('An IdpSessionHttpHandler', (): void => {
+  const request: HttpRequest = 'request!' as any;
+  const response: HttpResponse = 'response!' as any;
+  const webId = 'http://test.com/id#me';
+  let details: any = {};
+  let provider: Provider;
+  let oidcInteractionCompleter: OidcInteractionCompleter;
+  let handler: IdpSessionHttpHandler;
+
+  beforeEach(async(): Promise<void> => {
+    details = { session: { accountId: webId }};
+    provider = {
+      interactionDetails: jest.fn().mockResolvedValue(details),
+    } as any;
+
+    oidcInteractionCompleter = {
+      handleSafe: jest.fn(),
+    } as any;
+
+    handler = new IdpSessionHttpHandler(oidcInteractionCompleter);
+  });
+
+  it('requires a session and accountId.', async(): Promise<void> => {
+    details.session = undefined;
+    await expect(handler.handle({ request, response, provider })).rejects.toThrow(NotImplementedHttpError);
+
+    details.session = { accountId: undefined };
+    await expect(handler.handle({ request, response, provider })).rejects.toThrow(NotImplementedHttpError);
+  });
+
+  it('calls the oidc completer with the webId in the session.', async(): Promise<void> => {
+    await expect(handler.handle({ request, response, provider })).resolves.toBeUndefined();
+    expect(provider.interactionDetails).toHaveBeenCalledTimes(1);
+    expect(provider.interactionDetails).toHaveBeenLastCalledWith(request, response);
+    expect(oidcInteractionCompleter.handleSafe).toHaveBeenCalledTimes(1);
+    expect(oidcInteractionCompleter.handleSafe).toHaveBeenLastCalledWith({
+      request,
+      response,
+      provider,
+      webId,
+    });
+  });
+});


### PR DESCRIPTION
This was needed to log in again after logging out (context: https://gist.github.com/joachimvh/e430b8e9023f2ac602a92e95c9b5e5d8 )

This is the same way it happened in the old Idp. I do wonder if we should not take different actions based on the prompt reasons because it does feel weird that this just logs the user in again.

Also added relevant integration test.