### PR TITLE
Use AsyncHandler when possible

### DIFF
--- a/src/identity/configuration/IdpConfigurationGenerator.ts
+++ b/src/identity/configuration/IdpConfigurationGenerator.ts
@@ -4,6 +4,6 @@ import type { Configuration } from 'oidc-provider';
  * Creates an IdP Configuration to be used in
  * panva/node-oidc-provider
  */
-export abstract class IdpConfigurationGenerator {
-  abstract createConfiguration(): Promise<Configuration>;
+export interface IdpConfigurationGenerator {
+  createConfiguration: () => Promise<Configuration>;
 }

--- a/src/identity/configuration/KeyGeneratingIdpConfigurationGenerator.ts
+++ b/src/identity/configuration/KeyGeneratingIdpConfigurationGenerator.ts
@@ -6,24 +6,23 @@ import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdenti
 import { getLoggerFor } from '../../logging/LogUtil';
 import type { KeyValueStorage } from '../../storage/keyvalue/KeyValueStorage';
 import type { StorageAdapterFactory } from '../storage/StorageAdapterFactory';
-import { IdpConfigurationGenerator } from './IdpConfigurationGenerator';
+import type { IdpConfigurationGenerator } from './IdpConfigurationGenerator';
 
 /**
  * An IdP Configuration Factory that generates and saves keys
  * to the provided key value store.
  */
-export class KeyGeneratingIdpConfigurationGenerator extends IdpConfigurationGenerator {
+export class KeyGeneratingIdpConfigurationGenerator implements IdpConfigurationGenerator {
   private readonly storageAdapterFactory: StorageAdapterFactory;
   private readonly baseUrl: string;
-  private readonly storage: KeyValueStorage<ResourceIdentifier, any>;
+  private readonly storage: KeyValueStorage<ResourceIdentifier, unknown>;
   private readonly logger = getLoggerFor(this);
 
   public constructor(
     storageAdapterFactory: StorageAdapterFactory,
     baseUrl: string,
-    storage: KeyValueStorage<ResourceIdentifier, any>,
+    storage: KeyValueStorage<ResourceIdentifier, unknown>,
   ) {
-    super();
     this.storageAdapterFactory = storageAdapterFactory;
     this.baseUrl = baseUrl;
     this.storage = storage;

--- a/src/identity/interaction/IdpInteractionHttpHandler.ts
+++ b/src/identity/interaction/IdpInteractionHttpHandler.ts
@@ -6,5 +6,4 @@ export type IdpInteractionHttpHandlerInput = HttpHandlerInput & {
   provider: Provider;
 };
 
-export abstract class IdpInteractionHttpHandler
-  extends AsyncHandler<IdpInteractionHttpHandlerInput> {}
+export abstract class IdpInteractionHttpHandler extends AsyncHandler<IdpInteractionHttpHandlerInput> {}

--- a/src/identity/interaction/email-password/handler/EmailPasswordForgotPasswordHandler.ts
+++ b/src/identity/interaction/email-password/handler/EmailPasswordForgotPasswordHandler.ts
@@ -82,7 +82,7 @@ export class EmailPasswordForgotPasswordHandler extends IdpInteractionHttpHandle
 
       // Send email
       this.logger.info(`Sending password reset to ${email}`);
-      const renderedEmail = await this.emailTemplateRenderer.render({ resetLink });
+      const renderedEmail = await this.emailTemplateRenderer.handleSafe({ resetLink });
       await this.emailSender.sendEmail(email, {
         subject: 'Reset your password',
         text: `To reset your password, go to this link: ${resetLink}`,

--- a/src/identity/interaction/email-password/handler/EmailPasswordRegistrationHandler.ts
+++ b/src/identity/interaction/email-password/handler/EmailPasswordRegistrationHandler.ts
@@ -52,7 +52,7 @@ export class EmailPasswordRegistrationHandler extends IdpInteractionHttpHandler 
       // Qualify WebId
       assert(webId && typeof webId === 'string', 'WebId required');
       prefilledWebId = webId;
-      await this.webIdOwnershipValidator.assertWebIdOwnership(webId, interactionDetails.uid);
+      await this.webIdOwnershipValidator.handleSafe({ webId, interactionId: interactionDetails.uid });
 
       // Qualify password
       assertPassword(password, confirmPassword);

--- a/src/identity/interaction/email-password/storage/EmailPasswordStore.ts
+++ b/src/identity/interaction/email-password/storage/EmailPasswordStore.ts
@@ -1,7 +1,7 @@
 /**
  * A storage adapter needed for the email-password interaction
  */
-export abstract class EmailPasswordStore {
+export interface EmailPasswordStore {
   /**
    * Authenticate if the username and password are correct and return the webId
    * if it is. Return an error if it is not.
@@ -9,25 +9,29 @@ export abstract class EmailPasswordStore {
    * @param password - this user's password
    * @returns The user's WebId
    */
-  abstract authenticate(email: string, password: string): Promise<string>;
+  authenticate: (email: string, password: string) => Promise<string>;
+
   /**
    * Creates a new account
    * @param email - the account email
    * @param webId - account webId
    * @param password - account password
    */
-  abstract create(email: string, webId: string, password: string): Promise<void>;
+  create: (email: string, webId: string, password: string) => Promise<void>;
+
   /**
    * Changes the password
    * @param email - the user's email
    * @param password - the user's password
    */
-  abstract changePassword(email: string, password: string): Promise<void>;
+  changePassword: (email: string, password: string) => Promise<void>;
+
   /**
    * Delete the account
    * @param email - the user's email
    */
-  abstract deleteAccount(email: string): Promise<void>;
+  deleteAccount: (email: string) => Promise<void>;
+
   /**
    * Creates a Forgot Password Confirmation Record. This will be to remember that
    * a user has made a request to reset a password. Throws an error if the email doesn't
@@ -35,17 +39,19 @@ export abstract class EmailPasswordStore {
    * @param email - the user's email
    * @returns the record id. This should be included in the reset password link
    */
-  abstract generateForgotPasswordRecord(email: string): Promise<string>;
+  generateForgotPasswordRecord: (email: string) => Promise<string>;
+
   /**
    * Gets the email associated with the forgot password confirmation record or undefined
    * if it's not present
    * @param recordId - the record id retrieved from the link
    * @returns the user's email
    */
-  abstract getForgotPasswordRecord(recordId: string): Promise<string | undefined>;
+  getForgotPasswordRecord: (recordId: string) => Promise<string | undefined>;
+
   /**
    * Deletes the Forgot Password Confirmation Record
    * @param recordId - the record id of the forgot password confirmation record
    */
-  abstract deleteForgotPasswordRecord(recordId: string): Promise<void>;
+  deleteForgotPasswordRecord: (recordId: string) => Promise<void>;
 }

--- a/src/identity/interaction/email-password/storage/KeyValueEmailPasswordStore.ts
+++ b/src/identity/interaction/email-password/storage/KeyValueEmailPasswordStore.ts
@@ -4,7 +4,7 @@ import { v4 } from 'uuid';
 import type { ResourceIdentifier } from '../../../../ldp/representation/ResourceIdentifier';
 import type { KeyValueStorage } from '../../../../storage/keyvalue/KeyValueStorage';
 import { trimTrailingSlashes } from '../../../../util/PathUtil';
-import { EmailPasswordStore } from './EmailPasswordStore';
+import type { EmailPasswordStore } from './EmailPasswordStore';
 
 /**
  * A payload to persist a user account
@@ -37,13 +37,12 @@ export interface ResourceStoreEmailPasswordStoreArgs {
  * A EmailPasswordStore that uses a KeyValueStorage
  * to persist its information.
  */
-export class KeyValueEmailPasswordStore extends EmailPasswordStore {
+export class KeyValueEmailPasswordStore implements EmailPasswordStore {
   private readonly baseUrl: string;
   private readonly storage: KeyValueStorage<ResourceIdentifier, EmailPasswordData>;
   private readonly saltRounds: number;
 
   public constructor(args: ResourceStoreEmailPasswordStoreArgs) {
-    super();
     if (!args.storagePathName.startsWith('/')) {
       throw new Error('storagePathName should start with a slash.');
     }

--- a/src/identity/interaction/util/BasicIssuerReferenceWebIdOwnershipValidator.ts
+++ b/src/identity/interaction/util/BasicIssuerReferenceWebIdOwnershipValidator.ts
@@ -2,19 +2,18 @@ import { DataFactory } from 'n3';
 import { getLoggerFor } from '../../../logging/LogUtil';
 import { SOLID } from '../../../util/Vocabularies';
 import { fetchDataset } from '../../util/FetchUtil';
-import { WebIdOwnershipValidator } from './WebIdOwnershipValidator';
+import type { WebIdOwnershipValidator } from './WebIdOwnershipValidator';
 const { literal, namedNode, quad } = DataFactory;
 
 /**
  * Validates whether a WebId is okay to register based on if it
  * references this as an issuer.
  */
-export class BasicIssuerReferenceWebIdOwnershipValidator extends WebIdOwnershipValidator {
+export class BasicIssuerReferenceWebIdOwnershipValidator implements WebIdOwnershipValidator {
   private readonly issuer: string;
   private readonly logger = getLoggerFor(this);
 
   public constructor(issuer: string) {
-    super();
     this.issuer = issuer;
   }
 

--- a/src/identity/interaction/util/BasicIssuerReferenceWebIdOwnershipValidator.ts
+++ b/src/identity/interaction/util/BasicIssuerReferenceWebIdOwnershipValidator.ts
@@ -2,22 +2,23 @@ import { DataFactory } from 'n3';
 import { getLoggerFor } from '../../../logging/LogUtil';
 import { SOLID } from '../../../util/Vocabularies';
 import { fetchDataset } from '../../util/FetchUtil';
-import type { WebIdOwnershipValidator } from './WebIdOwnershipValidator';
+import { WebIdOwnershipValidator } from './WebIdOwnershipValidator';
 const { literal, namedNode, quad } = DataFactory;
 
 /**
  * Validates whether a WebId is okay to register based on if it
  * references this as an issuer.
  */
-export class BasicIssuerReferenceWebIdOwnershipValidator implements WebIdOwnershipValidator {
+export class BasicIssuerReferenceWebIdOwnershipValidator extends WebIdOwnershipValidator {
   private readonly issuer: string;
   private readonly logger = getLoggerFor(this);
 
   public constructor(issuer: string) {
+    super();
     this.issuer = issuer;
   }
 
-  public async assertWebIdOwnership(webId: string, interactionId: string): Promise<void> {
+  public async handle({ webId, interactionId }: { webId: string; interactionId: string }): Promise<void> {
     const dataset = await fetchDataset(webId);
     const hasIssuer = dataset.has(
       quad(namedNode(webId), SOLID.terms.oidcIssuer, namedNode(this.issuer)),

--- a/src/identity/interaction/util/EjsTemplateRenderer.ts
+++ b/src/identity/interaction/util/EjsTemplateRenderer.ts
@@ -1,18 +1,17 @@
 import { renderFile } from 'ejs';
 import { joinFilePath } from '../../../util/PathUtil';
-import { TemplateRenderer } from './TemplateRenderer';
+import type { TemplateRenderer } from './TemplateRenderer';
 
 /**
  * Renders options using a given EJS template location and
  * returns the result as a string. This is good for rendering
  * emails.
  */
-export class EjsTemplateRenderer<T> extends TemplateRenderer<T> {
+export class EjsTemplateRenderer<T> implements TemplateRenderer<T> {
   private readonly templatePath: string;
   private readonly templateFile: string;
 
   public constructor(templatePath: string, templateFile: string) {
-    super();
     this.templatePath = templatePath;
     this.templateFile = templateFile;
   }

--- a/src/identity/interaction/util/EjsTemplateRenderer.ts
+++ b/src/identity/interaction/util/EjsTemplateRenderer.ts
@@ -1,22 +1,23 @@
 import { renderFile } from 'ejs';
 import { joinFilePath } from '../../../util/PathUtil';
-import type { TemplateRenderer } from './TemplateRenderer';
+import { TemplateRenderer } from './TemplateRenderer';
 
 /**
  * Renders options using a given EJS template location and
  * returns the result as a string. This is good for rendering
  * emails.
  */
-export class EjsTemplateRenderer<T> implements TemplateRenderer<T> {
+export class EjsTemplateRenderer<T> extends TemplateRenderer<T> {
   private readonly templatePath: string;
   private readonly templateFile: string;
 
   public constructor(templatePath: string, templateFile: string) {
+    super();
     this.templatePath = templatePath;
     this.templateFile = templateFile;
   }
 
-  public async render(options: T): Promise<string> {
+  public async handle(options: T): Promise<string> {
     return renderFile(
       joinFilePath(this.templatePath, this.templateFile),
       options,

--- a/src/identity/interaction/util/TemplateRenderer.ts
+++ b/src/identity/interaction/util/TemplateRenderer.ts
@@ -1,6 +1,6 @@
+import { AsyncHandler } from '../../../util/handlers/AsyncHandler';
+
 /**
  * Renders given options
  */
-export interface TemplateRenderer<T> {
-  render: (options: T) => Promise<string>;
-}
+export abstract class TemplateRenderer<T> extends AsyncHandler<T, string> {}

--- a/src/identity/interaction/util/TemplateRenderer.ts
+++ b/src/identity/interaction/util/TemplateRenderer.ts
@@ -1,6 +1,6 @@
 /**
  * Renders given options
  */
-export abstract class TemplateRenderer<T> {
-  abstract render(options: T): Promise<string>;
+export interface TemplateRenderer<T> {
+  render: (options: T) => Promise<string>;
 }

--- a/src/identity/interaction/util/WebIdOwnershipValidator.ts
+++ b/src/identity/interaction/util/WebIdOwnershipValidator.ts
@@ -2,6 +2,6 @@
  * A class that validates if a someone owns a WebId. Will
  * throw an error if the WebId is not valid.
  */
-export abstract class WebIdOwnershipValidator {
-  abstract assertWebIdOwnership(webId: string, interactionId: string): Promise<void>;
+export interface WebIdOwnershipValidator {
+  assertWebIdOwnership: (webId: string, interactionId: string) => Promise<void>;
 }

--- a/src/identity/interaction/util/WebIdOwnershipValidator.ts
+++ b/src/identity/interaction/util/WebIdOwnershipValidator.ts
@@ -1,7 +1,7 @@
+import { AsyncHandler } from '../../../util/handlers/AsyncHandler';
+
 /**
  * A class that validates if a someone owns a WebId. Will
  * throw an error if the WebId is not valid.
  */
-export interface WebIdOwnershipValidator {
-  assertWebIdOwnership: (webId: string, interactionId: string) => Promise<void>;
-}
+export abstract class WebIdOwnershipValidator extends AsyncHandler<{ webId: string; interactionId: string }> {}

--- a/src/identity/storage/ClientWebIdFetchingStorageAdapterFactory.ts
+++ b/src/identity/storage/ClientWebIdFetchingStorageAdapterFactory.ts
@@ -3,7 +3,7 @@ import type { Adapter, AdapterPayload } from 'oidc-provider';
 import type { Dataset, Quad } from 'rdf-js';
 import { SOLID } from '../../util/Vocabularies';
 import { fetchDataset } from '../util/FetchUtil';
-import { StorageAdapterFactory } from './StorageAdapterFactory';
+import type { StorageAdapterFactory } from './StorageAdapterFactory';
 import namedNode = DataFactory.namedNode;
 
 /**
@@ -100,11 +100,10 @@ export class ClientWebIdFetchingStorageAdapter implements Adapter {
   }
 }
 
-export class ClientWebIdFetchingStorageAdapterFactory extends StorageAdapterFactory {
+export class ClientWebIdFetchingStorageAdapterFactory implements StorageAdapterFactory {
   private readonly adapterFactory: StorageAdapterFactory;
 
   public constructor(wrappedAdapterFactory: StorageAdapterFactory) {
-    super();
     this.adapterFactory = wrappedAdapterFactory;
   }
 

--- a/src/identity/storage/ExpiringStorageAdapterFactory.ts
+++ b/src/identity/storage/ExpiringStorageAdapterFactory.ts
@@ -2,7 +2,7 @@ import type { Adapter, AdapterPayload } from 'oidc-provider';
 import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
 import type { ExpiringStorage } from '../../storage/keyvalue/ExpiringStorage';
 import { trimTrailingSlashes } from '../../util/PathUtil';
-import { StorageAdapterFactory } from './StorageAdapterFactory';
+import type { StorageAdapterFactory } from './StorageAdapterFactory';
 
 export interface ExpiringStorageAdapterArgs {
   baseUrl: string;
@@ -111,11 +111,10 @@ export class ExpiringStorageAdapter implements Adapter {
 /**
  * The factory for a ExpiringStorageAdapter
  */
-export class ExpiringStorageAdapterFactory extends StorageAdapterFactory {
+export class ExpiringStorageAdapterFactory implements StorageAdapterFactory {
   private readonly args: ExpiringStorageAdapterArgs;
 
   public constructor(args: ExpiringStorageAdapterArgs) {
-    super();
     this.args = args;
   }
 

--- a/src/identity/storage/StorageAdapterFactory.ts
+++ b/src/identity/storage/StorageAdapterFactory.ts
@@ -4,6 +4,6 @@ import type { Adapter } from 'oidc-provider';
  * A factory that generates a StorageAdapter to be used
  * by the IdP to persist information.
  */
-export abstract class StorageAdapterFactory {
-  abstract createStorageAdapter(name: string): Adapter;
+export interface StorageAdapterFactory {
+  createStorageAdapter: (name: string) => Adapter;
 }

--- a/test/unit/identity/interaction/email-password/handler/EmailPasswordForgotPasswordHandler.test.ts
+++ b/test/unit/identity/interaction/email-password/handler/EmailPasswordForgotPasswordHandler.test.ts
@@ -40,8 +40,8 @@ describe('An EmailPasswordForgotPasswordHandler', (): void => {
     } as any;
 
     emailTemplateRenderer = {
-      render: jest.fn().mockResolvedValue('html!'),
-    };
+      handleSafe: jest.fn().mockResolvedValue('html!'),
+    } as any;
 
     emailSender = {
       sendEmail: jest.fn(),

--- a/test/unit/identity/interaction/email-password/handler/EmailPasswordRegistrationHandler.test.ts
+++ b/test/unit/identity/interaction/email-password/handler/EmailPasswordRegistrationHandler.test.ts
@@ -28,8 +28,8 @@ describe('An EmailPasswordRegistrationHandler', (): void => {
     } as any;
 
     webIdOwnershipValidator = {
-      assertWebIdOwnership: jest.fn(),
-    };
+      handleSafe: jest.fn(),
+    } as any;
 
     emailPasswordStorageAdapter = {
       create: jest.fn(),

--- a/test/unit/identity/interaction/util/BasicIssuerReferenceWebIdOwnershipValidator.test.ts
+++ b/test/unit/identity/interaction/util/BasicIssuerReferenceWebIdOwnershipValidator.test.ts
@@ -48,25 +48,25 @@ describe('A BasicIssuerReferenceWebIdOwnershipValidator', (): void => {
   });
 
   it('errors if the expected triples are missing.', async(): Promise<void> => {
-    const prom = validator.assertWebIdOwnership(webId, interactionId);
+    const prom = validator.handle({ webId, interactionId });
     await expect(prom).rejects.toThrow(quadToString(issuerTriple));
     await expect(prom).rejects.toThrow(quadToString(tokenTriple));
   });
 
   it('only requests the needed triples.', async(): Promise<void> => {
     triples = [ issuerTriple ];
-    let prom = validator.assertWebIdOwnership(webId, interactionId);
+    let prom = validator.handle({ webId, interactionId });
     await expect(prom).rejects.not.toThrow(quadToString(issuerTriple));
     await expect(prom).rejects.toThrow(quadToString(tokenTriple));
 
     triples = [ tokenTriple ];
-    prom = validator.assertWebIdOwnership(webId, interactionId);
+    prom = validator.handle({ webId, interactionId });
     await expect(prom).rejects.toThrow(quadToString(issuerTriple));
     await expect(prom).rejects.not.toThrow(quadToString(tokenTriple));
   });
 
   it('resolves if all required triples are present.', async(): Promise<void> => {
     triples = [ issuerTriple, tokenTriple ];
-    await expect(validator.assertWebIdOwnership(webId, interactionId)).resolves.toBeUndefined();
+    await expect(validator.handle({ webId, interactionId })).resolves.toBeUndefined();
   });
 });

--- a/test/unit/identity/interaction/util/EjsTemplateRenderer.test.ts
+++ b/test/unit/identity/interaction/util/EjsTemplateRenderer.test.ts
@@ -12,7 +12,7 @@ describe('An EjsTemplateRenderer', (): void => {
   const renderer = new EjsTemplateRenderer<string>(templatePath, templateFile);
 
   it('renders the given file with the given options.', async(): Promise<void> => {
-    await expect(renderer.render(options)).resolves.toBeUndefined();
+    await expect(renderer.handle(options)).resolves.toBeUndefined();
     expect(renderFile).toHaveBeenCalledTimes(1);
     expect(renderFile).toHaveBeenLastCalledWith('/var/templates/template.ejs', options);
   });


### PR DESCRIPTION
Used interfaces instead of abstract classes for consistency.

Changed WebIdOwnershipValidator and TemplateRenderer to be AsyncHandlers since they only had a singular function anyway. This way we could chain multiple validators in the future (e.g., have a separate one for local identifiers).

Might cause merge conflicts with other IdP PR.