### PR TITLE
feat: Use ErrorResponseWriter for handling oidc errors

### DIFF
--- a/config/presets/identity/solid-identity-provider.json
+++ b/config/presets/identity/solid-identity-provider.json
@@ -46,6 +46,9 @@
       },
       "IdentityProviderFactory:_configurationFactory": {
         "@id": "urn:solid-server:default:IdpConfigurationGenerator"
+      },
+      "IdentityProviderFactory:_errorResponseWriter": {
+        "@type": "ErrorResponseWriter"
       }
     },
     {


### PR DESCRIPTION
This way we have full control over what gets returned to the user. Currently it used the default error render handler of the oidc library which logged a warning every time (but did have prettier html than printing the error like this I guess 😄 ).