### PR TITLE
feat: Make idp parameter dynamic

### DIFF
--- a/config/presets/identity/email-password-interaction-policy.json
+++ b/config/presets/identity/email-password-interaction-policy.json
@@ -169,6 +169,7 @@
             "EmailPasswordForgotPasswordHandler:_args_baseUrl": {
               "@id": "urn:solid-server:default:variable:baseUrl"
             },
+            "EmailPasswordForgotPasswordHandler:_args_idpPathName": "idp",
             "EmailPasswordForgotPasswordHandler:_args_emailTemplateRenderer": {
               "@type": "EjsTemplateRenderer",
               "EjsTemplateRenderer:_templatePath": {
@@ -225,7 +226,8 @@
     {
       "comment": "Sets up the email password interaction policy",
       "@id": "urn:solid-server:email-password-interaction:EmailPasswordInteractionPolicy",
-      "@type": "EmailPasswordInteractionPolicy"
+      "@type": "EmailPasswordInteractionPolicy",
+      "EmailPasswordInteractionPolicy:_idpPathName": "idp"
     }
   ]
 }

--- a/config/presets/identity/solid-identity-provider.json
+++ b/config/presets/identity/solid-identity-provider.json
@@ -34,6 +34,7 @@
       "KeyGeneratingIdpConfigurationGenerator:_baseUrl": {
         "@id": "urn:solid-server:default:variable:baseUrl"
       },
+      "KeyGeneratingIdpConfigurationGenerator:_idpPathName": "idp",
       "KeyGeneratingIdpConfigurationGenerator:_storage": {
         "@id": "urn:solid-server:default:IdpStorage"
       }

--- a/src/identity/interaction/email-password/EmailPasswordInteractionPolicy.ts
+++ b/src/identity/interaction/email-password/EmailPasswordInteractionPolicy.ts
@@ -13,10 +13,12 @@ import type {
  * is /idp/interaction/:uid
  */
 export class EmailPasswordInteractionPolicy implements IdpInteractionPolicy {
-  public readonly policy: interactionPolicy.Prompt[];
   private readonly logger = getLoggerFor(this);
 
-  public constructor() {
+  public readonly policy: interactionPolicy.Prompt[];
+  public readonly url: (ctx: KoaContextWithOIDC) => string;
+
+  public constructor(idpPathName: string) {
     const interactions = interactionPolicy.base();
     const selectAccount = new interactionPolicy.Prompt({
       name: 'select_account',
@@ -24,9 +26,14 @@ export class EmailPasswordInteractionPolicy implements IdpInteractionPolicy {
     });
     interactions.add(selectAccount, 0);
     this.policy = interactions;
+    this.url = this.createUrlFunction(idpPathName);
   }
 
-  public async url(ctx: KoaContextWithOIDC): Promise<string> {
-    return `/idp/interaction/${ctx.oidc.uid}`;
+  /**
+   * Helper function to create the function that will be put in `url`.
+   * Needs to be done like this since the `this` reference is lost when passing this value along.
+   */
+  private createUrlFunction(idpPathName: string): (ctx: KoaContextWithOIDC) => string {
+    return (ctx: KoaContextWithOIDC): string => `/${idpPathName}/interaction/${ctx.oidc.uid}`;
   }
 }

--- a/src/identity/interaction/email-password/handler/EmailPasswordForgotPasswordHandler.ts
+++ b/src/identity/interaction/email-password/handler/EmailPasswordForgotPasswordHandler.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
 import { getLoggerFor } from '../../../../logging/LogUtil';
 import type { HttpResponse } from '../../../../server/HttpResponse';
-import { trimTrailingSlashes } from '../../../../util/PathUtil';
 import type { IdpInteractionHttpHandlerInput } from '../../IdpInteractionHttpHandler';
 import { IdpInteractionHttpHandler } from '../../IdpInteractionHttpHandler';
 import type { EmailSender } from '../../util/EmailSender';
@@ -15,6 +14,7 @@ export interface EmailPasswordForgotPasswordHandlerArgs {
   messageRenderHandler: IdpRenderHandler;
   emailPasswordStorageAdapter: EmailPasswordStore;
   baseUrl: string;
+  idpPathName: string;
   emailTemplateRenderer: TemplateRenderer<{ resetLink: string }>;
   emailSender: EmailSender;
 }
@@ -26,6 +26,7 @@ export class EmailPasswordForgotPasswordHandler extends IdpInteractionHttpHandle
   private readonly messageRenderHandler: IdpRenderHandler;
   private readonly emailPasswordStorageAdapter: EmailPasswordStore;
   private readonly baseUrl: string;
+  private readonly idpPathName: string;
   private readonly logger = getLoggerFor(this);
   private readonly emailTemplateRenderer: TemplateRenderer<{ resetLink: string }>;
   private readonly emailSender: EmailSender;
@@ -35,6 +36,7 @@ export class EmailPasswordForgotPasswordHandler extends IdpInteractionHttpHandle
     this.messageRenderHandler = args.messageRenderHandler;
     this.emailPasswordStorageAdapter = args.emailPasswordStorageAdapter;
     this.baseUrl = args.baseUrl;
+    this.idpPathName = args.idpPathName;
     this.emailTemplateRenderer = args.emailTemplateRenderer;
     this.emailSender = args.emailSender;
   }
@@ -78,7 +80,7 @@ export class EmailPasswordForgotPasswordHandler extends IdpInteractionHttpHandle
         await this.sendResponse(input.response, interactionDetails, email);
         return;
       }
-      const resetLink = `${trimTrailingSlashes(this.baseUrl)}/idp/resetpassword?rid=${recordId}`;
+      const resetLink = new URL(`${this.idpPathName}/resetpassword?rid=${recordId}`, this.baseUrl).href;
 
       // Send email
       this.logger.info(`Sending password reset to ${email}`);

--- a/test/unit/identity/configuration/KeyGeneratingIdpConfigurationGenerator.test.ts
+++ b/test/unit/identity/configuration/KeyGeneratingIdpConfigurationGenerator.test.ts
@@ -33,18 +33,18 @@ function getExpected(adapter: any, cookieKeys: any, jwks: any): any {
     },
     subjectTypes: [ 'public', 'pairwise' ],
     routes: {
-      authorization: '/idp/auth',
-      check_session: '/idp/session/check',
-      code_verification: '/idp/device',
-      device_authorization: '/idp/device/auth',
-      end_session: '/idp/session/end',
-      introspection: '/idp/token/introspection',
-      jwks: '/idp/jwks',
-      pushed_authorization_request: '/idp/request',
-      registration: '/idp/reg',
-      revocation: '/idp/token/revocation',
-      token: '/idp/token',
-      userinfo: '/idp/me',
+      authorization: '/foo/idp/auth',
+      check_session: '/foo/idp/session/check',
+      code_verification: '/foo/idp/device',
+      device_authorization: '/foo/idp/device/auth',
+      end_session: '/foo/idp/session/end',
+      introspection: '/foo/idp/token/introspection',
+      jwks: '/foo/idp/jwks',
+      pushed_authorization_request: '/foo/idp/request',
+      registration: '/foo/idp/reg',
+      revocation: '/foo/idp/token/revocation',
+      token: '/foo/idp/token',
+      userinfo: '/foo/idp/me',
     },
   };
 }
@@ -52,6 +52,7 @@ function getExpected(adapter: any, cookieKeys: any, jwks: any): any {
 describe('A KeyGeneratingIdpConfigurationGenerator', (): void => {
   let storageAdapterFactory: StorageAdapterFactory;
   const baseUrl = 'http://test.com/foo/';
+  const idpPathName = 'idp';
   let storage: KeyValueStorage<ResourceIdentifier, any>;
   let generator: KeyGeneratingIdpConfigurationGenerator;
 
@@ -66,7 +67,7 @@ describe('A KeyGeneratingIdpConfigurationGenerator', (): void => {
       set: jest.fn((id: ResourceIdentifier, value: any): any => map.set(id.path, value)),
     } as any;
 
-    generator = new KeyGeneratingIdpConfigurationGenerator(storageAdapterFactory, baseUrl, storage);
+    generator = new KeyGeneratingIdpConfigurationGenerator(storageAdapterFactory, baseUrl, idpPathName, storage);
   });
 
   it('creates a correct configuration.', async(): Promise<void> => {

--- a/test/unit/identity/interaction/email-password/EmailPasswordInteractionPolicy.test.ts
+++ b/test/unit/identity/interaction/email-password/EmailPasswordInteractionPolicy.test.ts
@@ -3,14 +3,14 @@ import {
 } from '../../../../../src/identity/interaction/email-password/EmailPasswordInteractionPolicy';
 
 describe('An EmailPasswordInteractionPolicy', (): void => {
-  const interactionPolicy = new EmailPasswordInteractionPolicy();
+  const idpPathName = 'idp';
+  const interactionPolicy = new EmailPasswordInteractionPolicy(idpPathName);
 
   it('has a select_account policy at index 0.', async(): Promise<void> => {
     expect(interactionPolicy.policy[0].name).toBe('select_account');
   });
 
   it('creates URLs by prepending /idp/interaction/.', async(): Promise<void> => {
-    await expect(interactionPolicy.url({ oidc: { uid: 'valid-uid' }} as any))
-      .resolves.toBe('/idp/interaction/valid-uid');
+    expect(interactionPolicy.url({ oidc: { uid: 'valid-uid' }} as any)).toBe('/idp/interaction/valid-uid');
   });
 });

--- a/test/unit/identity/interaction/email-password/handler/EmailPasswordForgotPasswordHandler.test.ts
+++ b/test/unit/identity/interaction/email-password/handler/EmailPasswordForgotPasswordHandler.test.ts
@@ -20,6 +20,7 @@ describe('An EmailPasswordForgotPasswordHandler', (): void => {
   let messageRenderHandler: IdpRenderHandler;
   let emailPasswordStorageAdapter: EmailPasswordStore;
   const baseUrl = 'http://test.com/base/';
+  const idpPathName = 'idp';
   let emailTemplateRenderer: TemplateRenderer<{ resetLink: string }>;
   let emailSender: EmailSender;
   let handler: EmailPasswordForgotPasswordHandler;
@@ -51,6 +52,7 @@ describe('An EmailPasswordForgotPasswordHandler', (): void => {
       messageRenderHandler,
       emailPasswordStorageAdapter,
       baseUrl,
+      idpPathName,
       emailTemplateRenderer,
       emailSender,
     });


### PR DESCRIPTION
This way the `idp` part of the URL is no longer hardcoded in the code. It still is in the config but that will be more complex to solve since it's also part of some regexes in there.

As an added bonus `KeyGeneratingIdpConfigurationGenerator` now also works with base URLs that are non-root.