### PR TITLE
fix: Allow owners to edit their own profile

### DIFF
--- a/templates/pod/profile/card.acl
+++ b/templates/pod/profile/card.acl
@@ -11,11 +11,9 @@
     acl:accessTo <./card>;
     acl:mode acl:Read.
 
-# The owner has full access to the entire
-# profile directory.
+# The owner has full access to the profile
 <#owner>
     a acl:Authorization;
     acl:agent <{{webId}}>;
-    acl:accessTo <./>;
-    acl:default <./>;
+    acl:accessTo <./card>;
     acl:mode acl:Read, acl:Write, acl:Control.


### PR DESCRIPTION
Closes #657 . Actually that one should have already been closed but it still being open made me discover that the second part of the acl file was still that of the container instead of the document.