### PR TITLE
fix: Prevent HttpRequest from being closed when downstream stream fails

### DIFF
--- a/src/server/HttpRequest.ts
+++ b/src/server/HttpRequest.ts
@@ -5,3 +5,10 @@ import type { Guarded } from '../util/GuardedStream';
  * An incoming HTTP request;
  */
 export type HttpRequest = Guarded<IncomingMessage>;
+
+/**
+ * Checks if the given stream is an HttpRequest.
+ */
+export function isHttpRequest(stream: any): stream is HttpRequest {
+  return typeof stream.socket === 'object' && typeof stream.url === 'string' && typeof stream.method === 'string';
+}

--- a/test/integration/ServerFetch.test.ts
+++ b/test/integration/ServerFetch.test.ts
@@ -68,6 +68,18 @@ describe('A Solid server', (): void => {
     expect(res.status).toBe(205);
   });
 
+  it('can handle PUT errors.', async(): Promise<void> => {
+    // There was a specific case where the following request caused the connection to close instead of error
+    const res = await fetch(baseUrl, {
+      method: 'PUT',
+      headers: {
+        'content-type': 'text/plain',
+      },
+      body: '"test"',
+    });
+    expect(res.status).toBe(400);
+  });
+
   it('can POST to create a container.', async(): Promise<void> => {
     const res = await fetch(baseUrl, {
       method: 'POST',

--- a/test/unit/server/HttpRequest.test.ts
+++ b/test/unit/server/HttpRequest.test.ts
@@ -1,0 +1,10 @@
+import { isHttpRequest } from '../../../src/server/HttpRequest';
+
+describe('HttpRequest', (): void => {
+  describe('#isHttpRequest', (): void => {
+    it('can identify HttpRequests.', async(): Promise<void> => {
+      expect(isHttpRequest({})).toBe(false);
+      expect(isHttpRequest({ socket: {}, method: 'GET', url: '/url' })).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #646.

This PR is mostly comments and tests and not that much code. The code change is that the `pipeSafely` function now no longer calls the `pump` library to pipe when the source stream is an `HttpRequest`. Reason being that the `pump` library destroys the source stream if the destination stream errors. We want this behaviour, but not for the incoming request since that also closes the outgoing response.

I actually expected this to be a problem when the `pump` library got added to handle piping streams, but everything seemed to work so no change was needed. But apparently this does happen in specific cases so it's probably a timing issue where some errors are handled fast enough by our server and some aren't.