### PR TITLE
Allow file paths to be relative to module root

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Additional recipes for configuring and deploying the server can be found at [sol
 | `--config, -c` | `"config/config-default.json"` | `config-default.json` stores all data in memory. If you would like to persist data to your filesystem, try `config-file.json` |
 | `--mainModulePath, -m` | | Absolute path to the package root from which ComponentJS module resolution should start. |
 | `--loggingLevel, -l` | `"info"`| |
-| `--podTemplateFolder, -t` | `"templates/pod"` | Folder containing the templates used for pod provisioning. |
 | `--rootFilePath, -f` | `"./"` | Folder to start the server in when using a file-based config. |
 | `--sparqlEndpoint, -s` | | Endpoint to call when using a SPARQL-based config. |
 | `--podConfigJson` | `"./pod-config.json"` | JSON file to store pod configuration when using a dynamic config. |

--- a/config/presets/cli-params.json
+++ b/config/presets/cli-params.json
@@ -22,10 +22,6 @@
       "@type": "Variable"
     },
     {
-      "@id": "urn:solid-server:default:variable:podTemplateFolder",
-      "@type": "Variable"
-    },
-    {
       "comment": "Path to the JSON file used to store configuration for dynamic pods.",
       "@id": "urn:solid-server:default:variable:podConfigJson",
       "@type": "Variable"

--- a/config/presets/http.json
+++ b/config/presets/http.json
@@ -51,7 +51,7 @@
       "StaticAssetHandler:_assets": [
         {
           "StaticAssetHandler:_assets_key": "/favicon.ico",
-          "StaticAssetHandler:_assets_value": "./templates/root/favicon.ico"
+          "StaticAssetHandler:_assets_value": "$PACKAGE_ROOT/templates/root/favicon.ico"
         }
       ]
     }

--- a/config/presets/pod-dynamic.json
+++ b/config/presets/pod-dynamic.json
@@ -79,9 +79,7 @@
       "ConfigPodManager:_resourcesGenerator": {
         "@id": "urn:solid-server:default:ResourcesGenerator",
         "@type": "TemplatedResourcesGenerator",
-        "TemplatedResourcesGenerator:_templateFolder": {
-          "@id": "urn:solid-server:default:variable:podTemplateFolder"
-        },
+        "TemplatedResourcesGenerator:_templateFolder": "$PACKAGE_ROOT/templates/pod",
         "TemplatedResourcesGenerator:_factory": {
           "@type": "ExtensionBasedMapperFactory"
         },

--- a/config/presets/pod-management.json
+++ b/config/presets/pod-management.json
@@ -4,9 +4,7 @@
     {
       "@id": "urn:solid-server:default:ResourcesGenerator",
       "@type": "TemplatedResourcesGenerator",
-      "TemplatedResourcesGenerator:_templateFolder": {
-        "@id": "urn:solid-server:default:variable:podTemplateFolder"
-      },
+      "TemplatedResourcesGenerator:_templateFolder": "$PACKAGE_ROOT/templates/pod",
       "TemplatedResourcesGenerator:_factory": {
         "@type": "ExtensionBasedMapperFactory"
       },

--- a/src/init/CliRunner.ts
+++ b/src/init/CliRunner.ts
@@ -58,7 +58,6 @@ export class CliRunner {
         config: { type: 'string', alias: 'c' },
         loggingLevel: { type: 'string', alias: 'l', default: 'info' },
         mainModulePath: { type: 'string', alias: 'm' },
-        podTemplateFolder: { type: 'string', alias: 't' },
         port: { type: 'number', alias: 'p', default: 3000 },
         rootFilePath: { type: 'string', alias: 'f', default: './' },
         sparqlEndpoint: { type: 'string', alias: 's' },
@@ -113,8 +112,6 @@ export class CliRunner {
       'urn:solid-server:default:variable:rootFilePath':
         this.resolveFilePath(params.rootFilePath),
       'urn:solid-server:default:variable:sparqlEndpoint': params.sparqlEndpoint,
-      'urn:solid-server:default:variable:podTemplateFolder':
-         this.resolveFilePath(params.podTemplateFolder, 'templates/pod'),
       'urn:solid-server:default:variable:podConfigJson':
         this.resolveFilePath(params.podConfigJson),
     };

--- a/src/pods/generate/TemplatedResourcesGenerator.ts
+++ b/src/pods/generate/TemplatedResourcesGenerator.ts
@@ -8,7 +8,7 @@ import type {
   FileIdentifierMapperFactory,
   ResourceLink,
 } from '../../storage/mapping/FileIdentifierMapper';
-import { joinFilePath, isContainerIdentifier } from '../../util/PathUtil';
+import { joinFilePath, isContainerIdentifier, resolveAssetPath } from '../../util/PathUtil';
 import type { Resource, ResourcesGenerator } from './ResourcesGenerator';
 import type { TemplateEngine } from './TemplateEngine';
 import Dict = NodeJS.Dict;
@@ -18,6 +18,9 @@ import Dict = NodeJS.Dict;
  * The template folder structure will be kept.
  * Folders will be interpreted as containers and files as documents.
  * A FileIdentifierMapper will be used to generate identifiers that correspond to the relative structure.
+ *
+ * A relative `templateFolder` is resolved relative to cwd,
+ * unless it's preceded by $PACKAGE_ROOT/, e.g. $PACKAGE_ROOT/foo/bar.
  */
 export class TemplatedResourcesGenerator implements ResourcesGenerator {
   private readonly templateFolder: string;
@@ -33,7 +36,7 @@ export class TemplatedResourcesGenerator implements ResourcesGenerator {
    * @param engine - Template engine for generating the resources.
    */
   public constructor(templateFolder: string, factory: FileIdentifierMapperFactory, engine: TemplateEngine) {
-    this.templateFolder = templateFolder;
+    this.templateFolder = resolveAssetPath(templateFolder);
     this.factory = factory;
     this.engine = engine;
   }

--- a/src/util/PathUtil.ts
+++ b/src/util/PathUtil.ts
@@ -165,3 +165,23 @@ export function createSubdomainRegexp(baseUrl: string): RegExp {
   const { scheme, rest } = extractScheme(baseUrl);
   return new RegExp(`^${scheme}(?:([^/]+)\\.)?${rest}`, 'u');
 }
+
+/**
+ * Returns the folder corresponding to the root of the Community Solid Server module
+ */
+export function getModuleRoot(): string {
+  return joinFilePath(__dirname, '../../');
+}
+
+/**
+ * Converts file path inputs into absolute paths.
+ * Works similar to `absoluteFilePath` but paths that start with '$PACKAGE_ROOT/'
+ * will be relative to the module directory instead of the cwd.
+ */
+export function resolveAssetPath(path: string): string {
+  const modulePath = '$PACKAGE_ROOT/';
+  if (path.startsWith(modulePath)) {
+    return joinFilePath(getModuleRoot(), path.slice(modulePath.length));
+  }
+  return absoluteFilePath(path);
+}

--- a/test/integration/DynamicPods.test.ts
+++ b/test/integration/DynamicPods.test.ts
@@ -34,12 +34,11 @@ describe.each(configs)('A dynamic pod server with template config %s', (template
       'urn:solid-server:default:variable:baseUrl': baseUrl,
       'urn:solid-server:default:variable:port': port,
       'urn:solid-server:default:variable:rootFilePath': rootFilePath,
-      'urn:solid-server:default:variable:podTemplateFolder': joinFilePath(__dirname, '../assets/templates'),
       'urn:solid-server:default:variable:podConfigJson': podConfigJson,
     };
 
     // Need to make sure the temp folder exists so the podConfigJson can be written to it
-    mkdirSync(rootFilePath);
+    mkdirSync(rootFilePath, { recursive: true });
 
     // Create and initialize the HTTP handler and related components
     const instances = await instantiateFromConfig(

--- a/test/integration/PodCreation.test.ts
+++ b/test/integration/PodCreation.test.ts
@@ -1,7 +1,6 @@
 import type { Server } from 'http';
 import fetch from 'cross-fetch';
 import type { HttpServerFactory } from '../../src/server/HttpServerFactory';
-import { joinFilePath } from '../../src/util/PathUtil';
 import { readableToString } from '../../src/util/StreamUtil';
 import { instantiateFromConfig } from './Config';
 
@@ -17,7 +16,6 @@ describe('A server with a pod handler', (): void => {
       'urn:solid-server:default:ServerFactory', 'server-without-auth.json', {
         'urn:solid-server:default:variable:port': port,
         'urn:solid-server:default:variable:baseUrl': baseUrl,
-        'urn:solid-server:default:variable:podTemplateFolder': joinFilePath(__dirname, '../assets/templates'),
       },
     ) as HttpServerFactory;
     server = factory.startServer(port);

--- a/test/integration/ServerFetch.test.ts
+++ b/test/integration/ServerFetch.test.ts
@@ -2,7 +2,6 @@ import type { Server } from 'http';
 import fetch from 'cross-fetch';
 import type { Initializer } from '../../src/init/Initializer';
 import type { HttpServerFactory } from '../../src/server/HttpServerFactory';
-import { joinFilePath } from '../../src/util/PathUtil';
 import { instantiateFromConfig } from './Config';
 
 const port = 6004;
@@ -19,7 +18,6 @@ describe('A Solid server', (): void => {
       'urn:solid-server:test:Instances', 'server-memory.json', {
         'urn:solid-server:default:variable:port': port,
         'urn:solid-server:default:variable:baseUrl': baseUrl,
-        'urn:solid-server:default:variable:podTemplateFolder': joinFilePath(__dirname, '../assets/templates'),
       },
     ) as Record<string, any>;
     ({ factory, initializer } = instances);

--- a/test/integration/Subdomains.test.ts
+++ b/test/integration/Subdomains.test.ts
@@ -3,7 +3,6 @@ import fetch from 'cross-fetch';
 import type { Initializer } from '../../src/init/Initializer';
 import type { HttpServerFactory } from '../../src/server/HttpServerFactory';
 import type { ResourceStore } from '../../src/storage/ResourceStore';
-import { joinFilePath } from '../../src/util/PathUtil';
 import { getTestFolder, instantiateFromConfig, removeFolder } from './Config';
 
 const port = 6005;
@@ -35,7 +34,6 @@ describe.each(stores)('A subdomain server with %s', (name, { storeUrn, teardown 
       'urn:solid-server:default:variable:baseUrl': baseUrl,
       'urn:solid-server:default:variable:port': port,
       'urn:solid-server:default:variable:rootFilePath': rootFilePath,
-      'urn:solid-server:default:variable:podTemplateFolder': joinFilePath(__dirname, '../assets/templates'),
     };
     const internalStore = await instantiateFromConfig(
       storeUrn,

--- a/test/integration/WebSocketsProtocol.test.ts
+++ b/test/integration/WebSocketsProtocol.test.ts
@@ -16,7 +16,6 @@ describe('A server with the Solid WebSockets API behind a proxy', (): void => {
       'urn:solid-server:default:ServerFactory', 'server-without-auth.json', {
         'urn:solid-server:default:variable:port': port,
         'urn:solid-server:default:variable:baseUrl': 'https://example.pod/',
-        'urn:solid-server:default:variable:podTemplateFolder': 'templates/pod',
       },
     ) as HttpServerFactory;
     server = factory.startServer(port);

--- a/test/integration/config/server-dynamic-unsafe.json
+++ b/test/integration/config/server-dynamic-unsafe.json
@@ -76,6 +76,10 @@
       "BaseUrlRouterRule:_baseStore": {
         "@id": "urn:solid-server:default:MemoryResourceStore"
       }
+    },
+    {
+      "@id": "urn:solid-server:default:ResourcesGenerator",
+      "TemplatedResourcesGenerator:_templateFolder": "$PACKAGE_ROOT/test/assets/templates"
     }
   ]
 }

--- a/test/integration/config/server-subdomains-unsafe.json
+++ b/test/integration/config/server-subdomains-unsafe.json
@@ -80,6 +80,10 @@
       }
     },
     {
+      "@id": "urn:solid-server:default:ResourcesGenerator",
+      "TemplatedResourcesGenerator:_templateFolder": "$PACKAGE_ROOT/test/assets/templates"
+    },
+    {
       "@id": "urn:solid-server:default:variable:store",
       "@type": "Variable"
     }

--- a/test/integration/config/server-without-auth.json
+++ b/test/integration/config/server-without-auth.json
@@ -48,6 +48,10 @@
       "PassthroughStore:_source": {
         "@id": "urn:solid-server:default:MemoryResourceStore"
       }
+    },
+    {
+      "@id": "urn:solid-server:default:ResourcesGenerator",
+      "TemplatedResourcesGenerator:_templateFolder": "$PACKAGE_ROOT/test/assets/templates"
     }
   ]
 }

--- a/test/unit/init/CliRunner.test.ts
+++ b/test/unit/init/CliRunner.test.ts
@@ -60,7 +60,6 @@ describe('CliRunner', (): void => {
           'urn:solid-server:default:variable:rootFilePath': '/var/cwd/',
           'urn:solid-server:default:variable:sparqlEndpoint': undefined,
           'urn:solid-server:default:variable:loggingLevel': 'info',
-          'urn:solid-server:default:variable:podTemplateFolder': joinFilePath(__dirname, '../../../templates/pod'),
           'urn:solid-server:default:variable:podConfigJson': '/var/cwd/pod-config.json',
         },
       },
@@ -80,7 +79,6 @@ describe('CliRunner', (): void => {
         '-m', 'module/path',
         '-p', '4000',
         '-s', 'http://localhost:5000/sparql',
-        '-t', 'templates',
         '--podConfigJson', '/different-path.json',
       ],
     });
@@ -104,7 +102,6 @@ describe('CliRunner', (): void => {
         variables: {
           'urn:solid-server:default:variable:baseUrl': 'http://pod.example/',
           'urn:solid-server:default:variable:loggingLevel': 'debug',
-          'urn:solid-server:default:variable:podTemplateFolder': '/var/cwd/templates',
           'urn:solid-server:default:variable:port': 4000,
           'urn:solid-server:default:variable:rootFilePath': '/root',
           'urn:solid-server:default:variable:sparqlEndpoint': 'http://localhost:5000/sparql',
@@ -122,7 +119,6 @@ describe('CliRunner', (): void => {
         '--config', 'myconfig.json',
         '--loggingLevel', 'debug',
         '--mainModulePath', 'module/path',
-        '--podTemplateFolder', 'templates',
         '--port', '4000',
         '--rootFilePath', 'root',
         '--sparqlEndpoint', 'http://localhost:5000/sparql',
@@ -149,7 +145,6 @@ describe('CliRunner', (): void => {
         variables: {
           'urn:solid-server:default:variable:baseUrl': 'http://pod.example/',
           'urn:solid-server:default:variable:loggingLevel': 'debug',
-          'urn:solid-server:default:variable:podTemplateFolder': '/var/cwd/templates',
           'urn:solid-server:default:variable:port': 4000,
           'urn:solid-server:default:variable:rootFilePath': '/var/cwd/root',
           'urn:solid-server:default:variable:sparqlEndpoint': 'http://localhost:5000/sparql',
@@ -170,7 +165,6 @@ describe('CliRunner', (): void => {
       '-m', 'module/path',
       '-p', '4000',
       '-s', 'http://localhost:5000/sparql',
-      '-t', 'templates',
       '--podConfigJson', '/different-path.json',
     ];
 
@@ -195,7 +189,6 @@ describe('CliRunner', (): void => {
         variables: {
           'urn:solid-server:default:variable:baseUrl': 'http://pod.example/',
           'urn:solid-server:default:variable:loggingLevel': 'debug',
-          'urn:solid-server:default:variable:podTemplateFolder': '/var/cwd/templates',
           'urn:solid-server:default:variable:port': 4000,
           'urn:solid-server:default:variable:rootFilePath': '/root',
           'urn:solid-server:default:variable:sparqlEndpoint': 'http://localhost:5000/sparql',

--- a/test/unit/pods/generate/TemplatedResourcesGenerator.test.ts
+++ b/test/unit/pods/generate/TemplatedResourcesGenerator.test.ts
@@ -38,7 +38,7 @@ async function genToArray<T>(iterable: AsyncIterable<T>): Promise<T[]> {
 }
 
 describe('A TemplatedResourcesGenerator', (): void => {
-  const rootFilePath = 'templates/pod';
+  const rootFilePath = '/templates/pod';
   // Using handlebars engine since it's smaller than any possible dummy
   const generator = new TemplatedResourcesGenerator(rootFilePath, new DummyFactory(), new HandlebarsTemplateEngine());
   let cache: { data: any };


### PR DESCRIPTION
Closes #650.

I'm still not 100% fan of this solution but I can't think of anything better and it is nice that now it's easier to have paths in configs. Only other option I could think of was passing a boolean along to indicate if a path should be resolved against module root or cwd but that seems worse.

While I was working on the paths I also used this opportunity to remove the `podTemplateFolder` variable. In practice this value is always going to be the same unless an advanced user wants to do something specific. 