### PR TITLE
Simplify configs using type-scoped contexts

### DIFF
--- a/config/config-default.json
+++ b/config/config-default.json
@@ -27,7 +27,7 @@
       "comment": "Use a memory based store as backend with no additional routing.",
       "@id": "urn:solid-server:default:RoutingResourceStore",
       "@type": "PassthroughStore",
-      "PassthroughStore:_source": {
+      "source": {
         "@id": "urn:solid-server:default:MemoryResourceStore"
       }
     }

--- a/config/config-file-subdomains.json
+++ b/config/config-file-subdomains.json
@@ -27,7 +27,7 @@
       "comment": "Use a file based store as backend with no additional routing.",
       "@id": "urn:solid-server:default:RoutingResourceStore",
       "@type": "PassthroughStore",
-      "PassthroughStore:_source": {
+      "source": {
         "@id": "urn:solid-server:default:FileResourceStore"
       }
     }

--- a/config/config-file.json
+++ b/config/config-file.json
@@ -27,7 +27,7 @@
       "comment": "Use a file based store as backend with no additional routing.",
       "@id": "urn:solid-server:default:RoutingResourceStore",
       "@type": "PassthroughStore",
-      "PassthroughStore:_source": {
+      "source": {
         "@id": "urn:solid-server:default:FileResourceStore"
       }
     }

--- a/config/config-memory-subdomains.json
+++ b/config/config-memory-subdomains.json
@@ -27,7 +27,7 @@
       "comment": "Use a memory based store as backend with no additional routing.",
       "@id": "urn:solid-server:default:RoutingResourceStore",
       "@type": "PassthroughStore",
-      "PassthroughStore:_source": {
+      "source": {
         "@id": "urn:solid-server:default:MemoryResourceStore"
       }
     }

--- a/config/config-sparql-endpoint.json
+++ b/config/config-sparql-endpoint.json
@@ -27,7 +27,7 @@
       "comment": "Use a SPARQL based store as backend with no additional routing.",
       "@id": "urn:solid-server:default:RoutingResourceStore",
       "@type": "PassthroughStore",
-      "PassthroughStore:_source": {
+      "source": {
         "@id": "urn:solid-server:default:SparqlResourceStore"
       }
     }

--- a/config/presets/acl.json
+++ b/config/presets/acl.json
@@ -4,38 +4,38 @@
     {
       "@id": "urn:solid-server:default:AclIdentifierStrategy",
       "@type": "SuffixAuxiliaryIdentifierStrategy",
-      "SuffixAuxiliaryIdentifierStrategy:_suffix": ".acl"
+      "suffix": ".acl"
     },
     {
       "@id": "urn:solid-server:default:AclStrategy",
       "@type": "ComposedAuxiliaryStrategy",
-      "ComposedAuxiliaryStrategy:_identifierStrategy": {
+      "identifierStrategy": {
         "@id": "urn:solid-server:default:AclIdentifierStrategy"
       },
-      "ComposedAuxiliaryStrategy:_metadataGenerator": {
+      "metadataGenerator": {
         "@type": "LinkMetadataGenerator",
-        "LinkMetadataGenerator:_link": "http://www.w3.org/ns/auth/acl#accessControl",
-        "LinkMetadataGenerator:_identifierStrategy": {
+        "link": "http://www.w3.org/ns/auth/acl#accessControl",
+        "identifierStrategy": {
           "@id": "urn:solid-server:default:AclIdentifierStrategy"
         }
       },
-      "ComposedAuxiliaryStrategy:_validator": {
+      "validator": {
         "@id": "urn:solid-server:default:RdfValidator"
       },
-      "ComposedAuxiliaryStrategy:_isRootRequired": true
+      "isRootRequired": true
     },
 
     {
       "@id": "urn:solid-server:default:AclBasedAuthorizer",
       "@type": "WaterfallHandler",
-      "WaterfallHandler:_handlers": [
+      "handlers": [
         {
           "comment": "This authorizer makes sure that for auxiliary resources, the main authorizer gets called with the associated identifier.",
           "@type": "AuxiliaryAuthorizer",
-          "AuxiliaryAuthorizer:_resourceAuthorizer": {
+          "resourceAuthorizer": {
             "@id": "urn:solid-server:default:WebAclAuthorizer"
           },
-          "AuxiliaryAuthorizer:_auxStrategy": {
+          "auxStrategy": {
             "@id": "urn:solid-server:default:AuxiliaryStrategy"
           }
         },
@@ -48,13 +48,13 @@
     {
       "@id": "urn:solid-server:default:WebAclAuthorizer",
       "@type": "WebAclAuthorizer",
-      "WebAclAuthorizer:_aclStrategy": {
+      "aclStrategy": {
         "@id": "urn:solid-server:default:AclIdentifierStrategy"
       },
-      "WebAclAuthorizer:_resourceStore": {
+      "resourceStore": {
         "@id": "urn:solid-server:default:ResourceStore"
       },
-      "WebAclAuthorizer:_identifierStrategy": {
+      "identifierStrategy": {
         "@id": "urn:solid-server:default:IdentifierStrategy"
       }
     }

--- a/config/presets/http.json
+++ b/config/presets/http.json
@@ -4,30 +4,30 @@
     {
       "@id": "urn:solid-server:default:ServerFactory",
       "@type": "WebSocketServerFactory",
-      "WebSocketServerFactory:_baseServerFactory": {
+      "baseServerFactory": {
         "@id": "urn:solid-server:default:HttpServerFactory"
       },
-      "WebSocketServerFactory:_webSocketHandler": {
+      "webSocketHandler": {
         "@id": "urn:solid-server:default:WebSocketHandler"
       }
     },
     {
       "@id": "urn:solid-server:default:HttpServerFactory",
       "@type": "BaseHttpServerFactory",
-      "BaseHttpServerFactory:_handler": {
+      "handler": {
         "@id": "urn:solid-server:default:HttpHandler"
       }
     },
     {
       "@id": "urn:solid-server:default:HttpHandler",
       "@type": "SequenceHandler",
-      "SequenceHandler:_handlers": [
+      "handlers": [
         {
           "@id": "urn:solid-server:default:Middleware"
         },
         {
           "@type": "WaterfallHandler",
-          "WaterfallHandler:_handlers": [
+          "handlers": [
             {
               "@id": "urn:solid-server:default:FaviconHandler"
             },
@@ -48,7 +48,7 @@
       "@id": "urn:solid-server:default:FaviconHandler",
       "@type": "StaticAssetHandler",
       "comment": "Serves the favicon",
-      "StaticAssetHandler:_assets": [
+      "assets": [
         {
           "StaticAssetHandler:_assets_key": "/favicon.ico",
           "StaticAssetHandler:_assets_value": "$PACKAGE_ROOT/templates/root/favicon.ico"

--- a/config/presets/identifiers/subdomain-identifiers.json
+++ b/config/presets/identifiers/subdomain-identifiers.json
@@ -4,14 +4,14 @@
     {
       "@id": "urn:solid-server:default:IdentifierStrategy",
       "@type": "SubdomainIdentifierStrategy",
-      "SubdomainIdentifierStrategy:_baseUrl": {
+      "baseUrl": {
         "@id": "urn:solid-server:default:variable:baseUrl"
       }
     },
     {
       "@id": "urn:solid-server:default:IdentifierGenerator",
       "@type": "SubdomainIdentifierGenerator",
-      "SubdomainIdentifierGenerator:_baseUrl": {
+      "baseUrl": {
         "@id": "urn:solid-server:default:variable:baseUrl"
       }
     }

--- a/config/presets/identifiers/suffix-identifiers.json
+++ b/config/presets/identifiers/suffix-identifiers.json
@@ -4,14 +4,14 @@
     {
       "@id": "urn:solid-server:default:IdentifierStrategy",
       "@type": "SingleRootIdentifierStrategy",
-      "SingleRootIdentifierStrategy:_baseUrl": {
+      "baseUrl": {
         "@id": "urn:solid-server:default:variable:baseUrl"
       }
     },
     {
       "@id": "urn:solid-server:default:IdentifierGenerator",
       "@type": "SuffixIdentifierGenerator",
-      "SuffixIdentifierGenerator:_base": {
+      "base": {
         "@id": "urn:solid-server:default:variable:baseUrl"
       }
     }

--- a/config/presets/init.json
+++ b/config/presets/init.json
@@ -4,44 +4,44 @@
     {
       "@id": "urn:solid-server:default:Initializer",
       "@type": "SequenceHandler",
-      "SequenceHandler:_handlers": [
+      "handlers": [
         {
           "@id": "urn:solid-server:default:LoggerInitializer",
           "@type": "LoggerInitializer",
-          "LoggerInitializer:_loggerFactory": {
+          "loggerFactory": {
             "@id": "urn:solid-server:default:LoggerFactory"
           }
         },
         {
           "@id": "urn:solid-server:default:RootContainerInitializer",
           "@type": "RootContainerInitializer",
-          "RootContainerInitializer:_settings_store": {
+          "settings_store": {
             "@id": "urn:solid-server:default:ResourceStore"
           },
-          "RootContainerInitializer:_settings_baseUrl": {
+          "settings_baseUrl": {
             "@id": "urn:solid-server:default:variable:baseUrl"
           }
         },
         {
           "@id": "urn:solid-server:default:AclInitializer",
           "@type": "AclInitializer",
-          "AclInitializer:_settings_store": {
+          "settings_store": {
             "@id": "urn:solid-server:default:ResourceStore"
           },
-          "AclInitializer:_settings_aclStrategy": {
+          "settings_aclStrategy": {
             "@id": "urn:solid-server:default:AclIdentifierStrategy"
           },
-          "AclInitializer:_settings_baseUrl": {
+          "settings_baseUrl": {
             "@id": "urn:solid-server:default:variable:baseUrl"
           }
         },
         {
           "@id": "urn:solid-server:default:ServerInitializer",
           "@type": "ServerInitializer",
-          "ServerInitializer:_serverFactory": {
+          "serverFactory": {
             "@id": "urn:solid-server:default:ServerFactory"
           },
-          "ServerInitializer:_port": {
+          "port": {
             "@id": "urn:solid-server:default:variable:port"
           }
         }

--- a/config/presets/ldp.json
+++ b/config/presets/ldp.json
@@ -4,22 +4,22 @@
     {
       "@id": "urn:solid-server:default:LdpHandler",
       "@type": "AuthenticatedLdpHandler",
-      "AuthenticatedLdpHandler:_args_requestParser": {
+      "args_requestParser": {
         "@id": "urn:solid-server:default:RequestParser"
       },
-      "AuthenticatedLdpHandler:_args_credentialsExtractor": {
+      "args_credentialsExtractor": {
         "@id": "urn:solid-server:default:CredentialsExtractor"
       },
-      "AuthenticatedLdpHandler:_args_permissionsExtractor": {
+      "args_permissionsExtractor": {
         "@id": "urn:solid-server:default:PermissionsExtractor"
       },
-      "AuthenticatedLdpHandler:_args_authorizer": {
+      "args_authorizer": {
         "@id": "urn:solid-server:default:AclBasedAuthorizer"
       },
-      "AuthenticatedLdpHandler:_args_operationHandler": {
+      "args_operationHandler": {
         "@id": "urn:solid-server:default:OperationHandler"
       },
-      "AuthenticatedLdpHandler:_args_responseWriter": {
+      "args_responseWriter": {
         "@id": "urn:solid-server:default:ResponseWriter"
       }
     }

--- a/config/presets/ldp/credentials-extractor.json
+++ b/config/presets/ldp/credentials-extractor.json
@@ -4,10 +4,10 @@
     {
       "@id": "urn:solid-server:default:CredentialsExtractor",
       "@type": "WaterfallHandler",
-      "WaterfallHandler:_handlers": [
+      "handlers": [
         {
           "@type": "DPoPWebIdExtractor",
-          "DPoPWebIdExtractor:_originalUrlExtractor": {
+          "originalUrlExtractor": {
             "@type": "OriginalUrlExtractor"
           }
         },

--- a/config/presets/ldp/metadata-handler.json
+++ b/config/presets/ldp/metadata-handler.json
@@ -4,7 +4,7 @@
     {
       "@id": "urn:solid-server:default:MetadataExtractor",
       "@type": "BasicMetadataExtractor",
-      "BasicMetadataExtractor:_parsers": [
+      "parsers": [
         {
           "@type": "ContentTypeParser"
         },

--- a/config/presets/ldp/operation-handler.json
+++ b/config/presets/ldp/operation-handler.json
@@ -4,40 +4,40 @@
     {
       "@id": "urn:solid-server:default:OperationHandler",
       "@type": "WaterfallHandler",
-      "WaterfallHandler:_handlers": [
+      "handlers": [
         {
           "@type": "DeleteOperationHandler",
-          "DeleteOperationHandler:_store": {
+          "store": {
             "@id": "urn:solid-server:default:ResourceStore"
           }
         },
         {
           "@type": "GetOperationHandler",
-          "GetOperationHandler:_store": {
+          "store": {
             "@id": "urn:solid-server:default:ResourceStore"
           }
         },
         {
           "@type": "HeadOperationHandler",
-          "HeadOperationHandler:_store": {
+          "store": {
             "@id": "urn:solid-server:default:ResourceStore"
           }
         },
         {
           "@type": "PatchOperationHandler",
-          "PatchOperationHandler:_store": {
+          "store": {
             "@id": "urn:solid-server:default:ResourceStore"
           }
         },
         {
           "@type": "PostOperationHandler",
-          "PostOperationHandler:_store": {
+          "store": {
             "@id": "urn:solid-server:default:ResourceStore"
           }
         },
         {
           "@type": "PutOperationHandler",
-          "PutOperationHandler:_store": {
+          "store": {
             "@id": "urn:solid-server:default:ResourceStore"
           }
         }

--- a/config/presets/ldp/permissions-extractor.json
+++ b/config/presets/ldp/permissions-extractor.json
@@ -4,10 +4,10 @@
     {
       "@id": "urn:solid-server:default:PermissionsExtractor",
       "@type": "WaterfallHandler",
-      "WaterfallHandler:_handlers": [
+      "handlers": [
         {
           "@type": "AclPermissionsExtractor",
-          "AclPermissionsExtractor:_aclStrategy": {
+          "aclStrategy": {
             "@id": "urn:solid-server:default:AclIdentifierStrategy"
           }
         },

--- a/config/presets/ldp/request-parser.json
+++ b/config/presets/ldp/request-parser.json
@@ -4,18 +4,18 @@
     {
       "@id": "urn:solid-server:default:RequestParser",
       "@type": "BasicRequestParser",
-      "BasicRequestParser:_args_targetExtractor": {
+      "args_targetExtractor": {
         "@id": "urn:solid-server:default:TargetExtractor"
       },
-      "BasicRequestParser:_args_preferenceParser": {
+      "args_preferenceParser": {
         "@type": "AcceptPreferenceParser"
       },
-      "BasicRequestParser:_args_metadataExtractor": {
+      "args_metadataExtractor": {
         "@id": "urn:solid-server:default:MetadataExtractor"
       },
-      "BasicRequestParser:_args_bodyParser": {
+      "args_bodyParser": {
         "@type": "WaterfallHandler",
-        "WaterfallHandler:_handlers": [
+        "handlers": [
           {
             "@type": "SparqlUpdateBodyParser"
           },
@@ -28,7 +28,7 @@
     {
       "@id": "urn:solid-server:default:TargetExtractor",
       "@type": "OriginalUrlExtractor",
-      "OriginalUrlExtractor:_options_includeQueryString": false
+      "options_includeQueryString": false
     }
   ]
 }

--- a/config/presets/ldp/response-writer.json
+++ b/config/presets/ldp/response-writer.json
@@ -4,10 +4,10 @@
     {
       "@id": "urn:solid-server:default:MetadataSerializer",
       "@type": "ParallelHandler",
-      "ParallelHandler:_handlers": [
+      "handlers": [
         {
           "@type": "ConstantMetadataWriter",
-          "ConstantMetadataWriter:_headers": [
+          "headers": [
             {
               "ConstantMetadataWriter:_headers_key": "Accept-Patch",
               "ConstantMetadataWriter:_headers_value": "application/sparql-update"
@@ -20,7 +20,7 @@
         },
         {
           "@type": "MappedMetadataWriter",
-          "MappedMetadataWriter:_headerMap": [
+          "headerMap": [
             {
               "MappedMetadataWriter:_headerMap_key": "http://www.w3.org/ns/ma-ont#format",
               "MappedMetadataWriter:_headerMap_value": "Content-Type"
@@ -33,7 +33,7 @@
         },
         {
           "@type": "LinkRelMetadataWriter",
-          "LinkRelMetadataWriter:_linkRelMap": [
+          "linkRelMap": [
             {
               "LinkRelMetadataWriter:_linkRelMap_key": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
               "LinkRelMetadataWriter:_linkRelMap_value": "type"
@@ -52,13 +52,13 @@
     {
       "@id": "urn:solid-server:default:ResponseWriter",
       "@type": "WaterfallHandler",
-      "WaterfallHandler:_handlers": [
+      "handlers": [
         {
           "@type": "ErrorResponseWriter"
         },
         {
           "@type": "BasicResponseWriter",
-          "BasicResponseWriter:_metadataWriter": {
+          "metadataWriter": {
             "@id": "urn:solid-server:default:MetadataSerializer"
           }
         }

--- a/config/presets/ldp/websockets.json
+++ b/config/presets/ldp/websockets.json
@@ -4,7 +4,7 @@
     {
       "@id": "urn:solid-server:default:WebSocketHandler",
       "@type": "UnsecureWebSocketsProtocol",
-      "UnsecureWebSocketsProtocol:_source": {
+      "source": {
         "@id": "urn:solid-server:default:ResourceStore"
       }
     }

--- a/config/presets/logging.json
+++ b/config/presets/logging.json
@@ -4,7 +4,7 @@
     {
       "@id": "urn:solid-server:default:LoggerFactory",
       "@type": "WinstonLoggerFactory",
-      "WinstonLoggerFactory:_level": {
+      "level": {
         "@id": "urn:solid-server:default:variable:loggingLevel"
       }
     }

--- a/config/presets/middleware.json
+++ b/config/presets/middleware.json
@@ -4,10 +4,10 @@
     {
       "@id": "urn:solid-server:default:Middleware",
       "@type": "SequenceHandler",
-      "SequenceHandler:_handlers": [
+      "handlers": [
         {
           "@type": "HeaderHandler",
-          "HeaderHandler:_headers": [
+          "headers": [
             {
               "HeaderHandler:_headers_key": "Vary",
               "HeaderHandler:_headers_value": "Accept,Authorization,Origin"
@@ -20,13 +20,13 @@
         },
         {
           "@type": "WebSocketAdvertiser",
-          "WebSocketAdvertiser:_baseUrl": {
+          "baseUrl": {
             "@id": "urn:solid-server:default:variable:baseUrl"
           }
         },
         {
           "@type": "CorsHandler",
-          "CorsHandler:_options_methods": [
+          "options_methods": [
             "GET",
             "HEAD",
             "OPTIONS",
@@ -35,8 +35,8 @@
             "PATCH",
             "DELETE"
           ],
-          "CorsHandler:_options_credentials": true,
-          "CorsHandler:_options_exposedHeaders": [
+          "options_credentials": true,
+          "options_exposedHeaders": [
             "Accept-Patch",
             "Location",
             "MS-Author-Via",

--- a/config/presets/pod-dynamic.json
+++ b/config/presets/pod-dynamic.json
@@ -8,17 +8,17 @@
     {
       "@id": "urn:solid-server:default:PodConfigurationStorage",
       "@type": "JsonFileStorage",
-      "JsonFileStorage:_filePath": {
+      "filePath": {
         "@id": "urn:solid-server:default:variable:podConfigJson"
       },
-      "JsonFileStorage:_locker": {
+      "locker": {
         "@id": "urn:solid-server:default:ResourceLocker"
       }
     },
     {
       "@id": "urn:solid-server:default:PodRoutingStorage",
       "@type": "ResourceIdentifierStorage",
-      "ResourceIdentifierStorage:_source": {
+      "source": {
         "@type": "MemoryMapStorage"
       }
     },
@@ -31,32 +31,32 @@
     {
       "@id": "urn:solid-server:default:PodGenerator",
       "@type": "TemplatedPodGenerator",
-      "TemplatedPodGenerator:_storeFactory": {
+      "storeFactory": {
         "@id": "urn:solid-server:default:StoreFactory"
       },
-      "TemplatedPodGenerator:_variableHandler": {
+      "variableHandler": {
         "@type": "ParallelHandler",
-        "ParallelHandler:_handlers": [
+        "handlers": [
           {
             "@type": "BaseUrlHandler"
           },
           {
             "@type": "RootFilePathHandler",
-            "RootFilePathHandler:_fileMapper": {
+            "fileMapper": {
               "@type": "ExtensionBasedMapper",
-              "ExtensionBasedMapper:_base": {
+              "base": {
                 "@id": "urn:solid-server:default:variable:baseUrl"
               },
-              "ExtensionBasedMapper:_rootFilepath": {
+              "rootFilepath": {
                 "@id": "urn:solid-server:default:variable:rootFilePath"
               },
-              "ExtensionBasedMapper:_overrideTypes_acl": "text/turtle",
-              "ExtensionBasedMapper:_overrideTypes_meta": "text/turtle"
+              "overrideTypes_acl": "text/turtle",
+              "overrideTypes_meta": "text/turtle"
             }
           }
         ]
       },
-      "TemplatedPodGenerator:_configStorage": {
+      "configStorage": {
         "@id": "urn:solid-server:default:PodConfigurationStorage"
       }
     },
@@ -64,26 +64,26 @@
     {
       "@id": "urn:solid-server:default:PodManager",
       "@type": "ConfigPodManager",
-      "ConfigPodManager:_idGenerator": {
+      "idGenerator": {
         "@type": "SuffixIdentifierGenerator",
-        "SuffixIdentifierGenerator:_base": {
+        "base": {
           "@id": "urn:solid-server:default:variable:baseUrl"
         }
       },
-      "ConfigPodManager:_podGenerator": {
+      "podGenerator": {
         "@id": "urn:solid-server:default:PodGenerator"
       },
-      "ConfigPodManager:_routingStorage": {
+      "routingStorage": {
         "@id": "urn:solid-server:default:PodRoutingStorage"
       },
-      "ConfigPodManager:_resourcesGenerator": {
+      "resourcesGenerator": {
         "@id": "urn:solid-server:default:ResourcesGenerator",
         "@type": "TemplatedResourcesGenerator",
-        "TemplatedResourcesGenerator:_templateFolder": "$PACKAGE_ROOT/templates/pod",
-        "TemplatedResourcesGenerator:_factory": {
+        "templateFolder": "$PACKAGE_ROOT/templates/pod",
+        "factory": {
           "@type": "ExtensionBasedMapperFactory"
         },
-        "TemplatedResourcesGenerator:_engine": {
+        "engine": {
           "@type": "HandlebarsTemplateEngine"
         }
       }
@@ -92,17 +92,17 @@
     {
       "@id": "urn:solid-server:default:PodManagerHandler",
       "@type": "PodManagerHttpHandler",
-      "PodManagerHttpHandler:_args_requestPath": "/pods",
-      "PodManagerHttpHandler:_args_requestParser": {
+      "args_requestPath": "/pods",
+      "args_requestParser": {
         "@id": "urn:solid-server:default:RequestParser"
       },
-      "PodManagerHttpHandler:_args_podSettingsParser": {
+      "args_podSettingsParser": {
         "@type": "PodSettingsJsonParser"
       },
-      "PodManagerHttpHandler:_args_manager": {
+      "args_manager": {
         "@id": "urn:solid-server:default:PodManager"
       },
-      "PodManagerHttpHandler:_args_responseWriter": {
+      "args_responseWriter": {
         "@id": "urn:solid-server:default:ResponseWriter"
       }
     },
@@ -112,13 +112,13 @@
       "comment": "Add entry to initializer list",
       "SequenceHandler:_handlers": {
         "@type": "ConfigPodInitializer",
-        "ConfigPodInitializer:_storeFactory": {
+        "storeFactory": {
           "@id": "urn:solid-server:default:StoreFactory"
         },
-        "ConfigPodInitializer:_configStorage": {
+        "configStorage": {
           "@id": "urn:solid-server:default:PodConfigurationStorage"
         },
-        "ConfigPodInitializer:_routingStorage": {
+        "routingStorage": {
           "@id": "urn:solid-server:default:PodRoutingStorage"
         }
       }
@@ -127,7 +127,7 @@
     {
       "@id": "urn:solid-server:default:BaseUrlRouterRule",
       "@type": "BaseUrlRouterRule",
-      "BaseUrlRouterRule:_stores": {
+      "stores": {
         "@id": "urn:solid-server:default:PodRoutingStorage"
       }
     },
@@ -135,7 +135,7 @@
     {
       "@id": "urn:solid-server:default:RoutingResourceStore",
       "@type": "RoutingResourceStore",
-      "RoutingResourceStore:_rule": {
+      "rule": {
         "@id": "urn:solid-server:default:BaseUrlRouterRule"
       }
     }

--- a/config/presets/pod-management.json
+++ b/config/presets/pod-management.json
@@ -4,41 +4,41 @@
     {
       "@id": "urn:solid-server:default:ResourcesGenerator",
       "@type": "TemplatedResourcesGenerator",
-      "TemplatedResourcesGenerator:_templateFolder": "$PACKAGE_ROOT/templates/pod",
-      "TemplatedResourcesGenerator:_factory": {
+      "templateFolder": "$PACKAGE_ROOT/templates/pod",
+      "factory": {
         "@type": "ExtensionBasedMapperFactory"
       },
-      "TemplatedResourcesGenerator:_engine": {
+      "engine": {
         "@type": "HandlebarsTemplateEngine"
       }
     },
     {
       "@id": "urn:solid-server:default:PodManager",
       "@type": "GeneratedPodManager",
-      "GeneratedPodManager:_store": {
+      "store": {
         "@id": "urn:solid-server:default:ResourceStore"
       },
-      "GeneratedPodManager:_idGenerator": {
+      "idGenerator": {
         "@id": "urn:solid-server:default:IdentifierGenerator"
       },
-      "GeneratedPodManager:_resourcesGenerator": {
+      "resourcesGenerator": {
         "@id": "urn:solid-server:default:ResourcesGenerator"
       }
     },
     {
       "@id": "urn:solid-server:default:PodManagerHandler",
       "@type": "PodManagerHttpHandler",
-      "PodManagerHttpHandler:_args_requestPath": "/pods",
-      "PodManagerHttpHandler:_args_requestParser": {
+      "args_requestPath": "/pods",
+      "args_requestParser": {
         "@id": "urn:solid-server:default:RequestParser"
       },
-      "PodManagerHttpHandler:_args_podSettingsParser": {
+      "args_podSettingsParser": {
         "@type": "PodSettingsJsonParser"
       },
-      "PodManagerHttpHandler:_args_manager": {
+      "args_manager": {
         "@id": "urn:solid-server:default:PodManager"
       },
-      "PodManagerHttpHandler:_args_responseWriter": {
+      "args_responseWriter": {
         "@id": "urn:solid-server:default:ResponseWriter"
       }
     }

--- a/config/presets/representation-conversion.json
+++ b/config/presets/representation-conversion.json
@@ -9,7 +9,7 @@
     {
       "@id": "urn:solid-server:default:QuadToRdfConverter",
       "@type": "QuadToRdfConverter",
-      "QuadToRdfConverter:_options_outputPreferences": [
+      "options_outputPreferences": [
         {
           "QuadToRdfConverter:_options_outputPreferences_key": "text/turtle",
           "QuadToRdfConverter:_options_outputPreferences_value": 1
@@ -40,7 +40,7 @@
     {
       "@id": "urn:solid-server:default:ContentTypeReplacer",
       "@type": "ContentTypeReplacer",
-      "ContentTypeReplacer:_replacements": [
+      "replacements": [
         {
           "ContentTypeReplacer:_replacements_key": "application/n-triples",
           "ContentTypeReplacer:_replacements_value": "text/turtle"
@@ -67,7 +67,7 @@
     {
       "@id": "urn:solid-server:default:RdfRepresentationConverter",
       "@type": "ChainedConverter",
-      "ChainedConverter:_converters": [
+      "converters": [
         {
           "@id": "urn:solid-server:default:RdfToQuadConverter"
         },
@@ -80,7 +80,7 @@
     {
       "@id": "urn:solid-server:default:RepresentationConverter",
       "@type": "WaterfallHandler",
-      "WaterfallHandler:_handlers": [
+      "handlers": [
         {
           "@id": "urn:solid-server:default:IndexConverter"
         },
@@ -106,7 +106,7 @@
     {
       "@id": "urn:solid-server:default:RdfValidator",
       "@type": "RdfValidator",
-      "RdfValidator:_converter": {
+      "converter": {
         "@id": "urn:solid-server:default:RepresentationConverter"
       }
     }

--- a/config/presets/storage-wrapper.json
+++ b/config/presets/storage-wrapper.json
@@ -4,7 +4,7 @@
     {
       "@id": "urn:solid-server:default:ResourceStore",
       "@type": "MonitoringStore",
-      "MonitoringStore:_source": {
+      "source": {
         "@id": "urn:solid-server:default:ResourceStore_Locking"
       }
     },
@@ -12,7 +12,7 @@
     {
       "@id": "urn:solid-server:default:AuxiliaryStrategy",
       "@type": "RoutingAuxiliaryStrategy",
-      "RoutingAuxiliaryStrategy:_sources": [
+      "sources": [
         {
           "@id": "urn:solid-server:default:AclStrategy"
         }
@@ -22,13 +22,13 @@
     {
       "@id": "urn:solid-server:default:ResourceStore_Locking",
       "@type": "LockingResourceStore",
-      "LockingResourceStore:_source": {
+      "source": {
         "@id": "urn:solid-server:default:ResourceStore_Patching"
       },
-      "LockingResourceStore:_locks": {
+      "locks": {
         "@id": "urn:solid-server:default:ResourceLocker"
       },
-      "LockingResourceStore:_strategy": {
+      "strategy": {
         "@id": "urn:solid-server:default:AuxiliaryStrategy"
       }
     },
@@ -36,13 +36,13 @@
     {
       "@id": "urn:solid-server:default:ResourceStore_Patching",
       "@type": "PatchingStore",
-      "PatchingStore:_source": {
+      "source": {
         "@id": "urn:solid-server:default:ResourceStore_Converting"
       },
-      "PatchingStore:_patcher": {
+      "patcher": {
         "@id": "urn:solid-server:default:PatchHandler",
         "@type": "SparqlUpdatePatchHandler",
-        "SparqlUpdatePatchHandler:_source": {
+        "source": {
           "@id": "urn:solid-server:default:ResourceStore_ToTurtle"
         }
       }
@@ -51,47 +51,47 @@
     {
       "@id": "urn:solid-server:default:ResourceLocker",
       "@type": "WrappedExpiringReadWriteLocker",
-      "WrappedExpiringReadWriteLocker:_locker": {
+      "locker": {
         "@type": "GreedyReadWriteLocker",
-        "GreedyReadWriteLocker:_locker": {
+        "locker": {
           "@type": "SingleThreadedResourceLocker"
         },
-        "GreedyReadWriteLocker:_storage": {
+        "storage": {
           "@type": "ResourceIdentifierStorage",
-          "ResourceIdentifierStorage:_source": {
+          "source": {
             "@type": "MemoryMapStorage"
           }
         },
-        "GreedyReadWriteLocker:_suffixes_count": "count",
-        "GreedyReadWriteLocker:_suffixes_read": "read",
-        "GreedyReadWriteLocker:_suffixes_write": "write"
+        "suffixes_count": "count",
+        "suffixes_read": "read",
+        "suffixes_write": "write"
       },
-      "WrappedExpiringReadWriteLocker:_expiration": 3000
+      "expiration": 3000
     },
 
 
     {
       "@id": "urn:solid-server:default:ResourceStore_ToTurtle",
       "@type": "RepresentationConvertingStore",
-      "RepresentationConvertingStore:_source": {
+      "source": {
         "@id": "urn:solid-server:default:RoutingResourceStore"
       },
-      "RepresentationConvertingStore:_options_outConverter": {
+      "options_outConverter": {
         "@id": "urn:solid-server:default:RepresentationConverter"
       },
-      "RepresentationConvertingStore:_options_inConverter": {
+      "options_inConverter": {
         "@id": "urn:solid-server:default:RepresentationConverter"
       },
-      "RepresentationConvertingStore:_options_inType": "text/turtle"
+      "options_inType": "text/turtle"
     },
 
     {
       "@id": "urn:solid-server:default:ResourceStore_Converting",
       "@type": "RepresentationConvertingStore",
-      "RepresentationConvertingStore:_source": {
+      "source": {
         "@id": "urn:solid-server:default:RoutingResourceStore"
       },
-      "RepresentationConvertingStore:_options_outConverter": {
+      "options_outConverter": {
         "@id": "urn:solid-server:default:RepresentationConverter"
       }
     }

--- a/config/presets/storage/backend/storage-filesystem-subdomains.json
+++ b/config/presets/storage/backend/storage-filesystem-subdomains.json
@@ -4,33 +4,33 @@
     {
       "@id": "urn:solid-server:default:FileIdentifierMapper",
       "@type": "SubdomainExtensionBasedMapper",
-      "SubdomainExtensionBasedMapper:_base": {
+      "base": {
         "@id": "urn:solid-server:default:variable:baseUrl"
       },
-      "SubdomainExtensionBasedMapper:_rootFilepath": {
+      "rootFilepath": {
         "@id": "urn:solid-server:default:variable:rootFilePath"
       },
-      "SubdomainExtensionBasedMapper:_baseSubdomain": "www",
-      "SubdomainExtensionBasedMapper:_overrideTypes_acl": "text/turtle",
-      "SubdomainExtensionBasedMapper:_overrideTypes_meta": "text/turtle"
+      "baseSubdomain": "www",
+      "overrideTypes_acl": "text/turtle",
+      "overrideTypes_meta": "text/turtle"
     },
     {
       "@id": "urn:solid-server:default:FileDataAccessor",
       "@type": "FileDataAccessor",
-      "FileDataAccessor:_resourceMapper": {
+      "resourceMapper": {
         "@id": "urn:solid-server:default:FileIdentifierMapper"
       }
     },
     {
       "@id": "urn:solid-server:default:FileResourceStore",
       "@type": "DataAccessorBasedStore",
-      "DataAccessorBasedStore:_accessor": {
+      "accessor": {
         "@id": "urn:solid-server:default:FileDataAccessor"
       },
-      "DataAccessorBasedStore:_identifierStrategy": {
+      "identifierStrategy": {
         "@id": "urn:solid-server:default:IdentifierStrategy"
       },
-      "DataAccessorBasedStore:_auxiliaryStrategy": {
+      "auxiliaryStrategy": {
         "@id": "urn:solid-server:default:AuxiliaryStrategy"
       }
     }

--- a/config/presets/storage/backend/storage-filesystem.json
+++ b/config/presets/storage/backend/storage-filesystem.json
@@ -4,32 +4,32 @@
     {
       "@id": "urn:solid-server:default:FileIdentifierMapper",
       "@type": "ExtensionBasedMapper",
-      "ExtensionBasedMapper:_base": {
+      "base": {
         "@id": "urn:solid-server:default:variable:baseUrl"
       },
-      "ExtensionBasedMapper:_rootFilepath": {
+      "rootFilepath": {
         "@id": "urn:solid-server:default:variable:rootFilePath"
       },
-      "ExtensionBasedMapper:_overrideTypes_acl": "text/turtle",
-      "ExtensionBasedMapper:_overrideTypes_meta": "text/turtle"
+      "overrideTypes_acl": "text/turtle",
+      "overrideTypes_meta": "text/turtle"
     },
     {
       "@id": "urn:solid-server:default:FileDataAccessor",
       "@type": "FileDataAccessor",
-      "FileDataAccessor:_resourceMapper": {
+      "resourceMapper": {
         "@id": "urn:solid-server:default:FileIdentifierMapper"
       }
     },
     {
       "@id": "urn:solid-server:default:FileResourceStore",
       "@type": "DataAccessorBasedStore",
-      "DataAccessorBasedStore:_accessor": {
+      "accessor": {
         "@id": "urn:solid-server:default:FileDataAccessor"
       },
-      "DataAccessorBasedStore:_identifierStrategy": {
+      "identifierStrategy": {
         "@id": "urn:solid-server:default:IdentifierStrategy"
       },
-      "DataAccessorBasedStore:_auxiliaryStrategy": {
+      "auxiliaryStrategy": {
         "@id": "urn:solid-server:default:AuxiliaryStrategy"
       }
     }

--- a/config/presets/storage/backend/storage-memory.json
+++ b/config/presets/storage/backend/storage-memory.json
@@ -4,20 +4,20 @@
     {
       "@id": "urn:solid-server:default:MemoryDataAccessor",
       "@type": "InMemoryDataAccessor",
-      "InMemoryDataAccessor:_strategy": {
+      "strategy": {
         "@id": "urn:solid-server:default:IdentifierStrategy"
       }
     },
     {
       "@id": "urn:solid-server:default:MemoryResourceStore",
       "@type": "DataAccessorBasedStore",
-      "DataAccessorBasedStore:_accessor": {
+      "accessor": {
         "@id": "urn:solid-server:default:MemoryDataAccessor"
       },
-      "DataAccessorBasedStore:_identifierStrategy": {
+      "identifierStrategy": {
         "@id": "urn:solid-server:default:IdentifierStrategy"
       },
-      "DataAccessorBasedStore:_auxiliaryStrategy": {
+      "auxiliaryStrategy": {
         "@id": "urn:solid-server:default:AuxiliaryStrategy"
       }
     }

--- a/config/presets/storage/backend/storage-sparql-endpoint.json
+++ b/config/presets/storage/backend/storage-sparql-endpoint.json
@@ -4,10 +4,10 @@
     {
       "@id": "urn:solid-server:default:SparqlDataAccessor",
       "@type": "SparqlDataAccessor",
-      "SparqlDataAccessor:_endpoint": {
+      "endpoint": {
         "@id": "urn:solid-server:default:variable:sparqlEndpoint"
       },
-      "SparqlDataAccessor:_identifierStrategy": {
+      "identifierStrategy": {
         "@id": "urn:solid-server:default:IdentifierStrategy"
       }
     },
@@ -15,13 +15,13 @@
     {
       "@id": "urn:solid-server:default:DataAccessorBasedStore",
       "@type": "DataAccessorBasedStore",
-      "DataAccessorBasedStore:_accessor": {
+      "accessor": {
         "@id": "urn:solid-server:default:SparqlDataAccessor"
       },
-      "DataAccessorBasedStore:_identifierStrategy": {
+      "identifierStrategy": {
         "@id": "urn:solid-server:default:IdentifierStrategy"
       },
-      "DataAccessorBasedStore:_auxiliaryStrategy": {
+      "auxiliaryStrategy": {
         "@id": "urn:solid-server:default:AuxiliaryStrategy"
       }
     },
@@ -29,13 +29,13 @@
     {
       "@id": "urn:solid-server:default:SparqlResourceStore",
       "@type": "RepresentationConvertingStore",
-      "RepresentationConvertingStore:_source": {
+      "source": {
         "@id": "urn:solid-server:default:DataAccessorBasedStore"
       },
-      "RepresentationConvertingStore:_options_inConverter": {
+      "options_inConverter": {
         "@id": "urn:solid-server:default:RepresentationConverter"
       },
-      "RepresentationConvertingStore:_options_inType": "internal/quads"
+      "options_inType": "internal/quads"
     }
   ]
 }

--- a/config/presets/storage/routing/quad-type-routing.json
+++ b/config/presets/storage/routing/quad-type-routing.json
@@ -4,25 +4,25 @@
     {
       "@id": "urn:solid-server:default:PreferenceSupport",
       "@type": "PreferenceSupport",
-      "PreferenceSupport:_type": "internal/quads",
-      "PreferenceSupport:_converter": {
+      "type": "internal/quads",
+      "converter": {
         "@id": "urn:solid-server:default:RepresentationConverter"
       }
     },
     {
       "@id": "urn:solid-server:default:ConvertingRouterRule",
       "@type": "ConvertingRouterRule",
-      "ConvertingRouterRule:_store": {
+      "store": {
         "@id": "urn:solid-server:default:SparqlResourceStore"
       },
-      "ConvertingRouterRule:_supportChecker": {
+      "supportChecker": {
         "@id": "urn:solid-server:default:PreferenceSupport"
       }
     },
     {
       "@id": "urn:solid-server:default:RoutingResourceStore",
       "@type": "RoutingResourceStore",
-      "RoutingResourceStore:_rule": {
+      "rule": {
         "@id": "urn:solid-server:default:ConvertingRouterRule"
       }
     }

--- a/config/presets/storage/routing/regex-routing.json
+++ b/config/presets/storage/routing/regex-routing.json
@@ -4,14 +4,14 @@
     {
       "@id": "urn:solid-server:default:RegexRouterRule",
       "@type": "RegexRouterRule",
-      "RegexRouterRule:_base": {
+      "base": {
         "@id": "urn:solid-server:default:variable:baseUrl"
       }
     },
     {
       "@id": "urn:solid-server:default:RoutingResourceStore",
       "@type": "RoutingResourceStore",
-      "RoutingResourceStore:_rule": {
+      "rule": {
         "@id": "urn:solid-server:default:RegexRouterRule"
       }
     }

--- a/config/templates/storage-defaults.json
+++ b/config/templates/storage-defaults.json
@@ -14,7 +14,7 @@
       "@id": "urn:solid-server:default:AuxiliaryStrategy",
       "comment": "Copied from storage-wrapper.json since a variable is required in there",
       "@type": "RoutingAuxiliaryStrategy",
-      "RoutingAuxiliaryStrategy:_sources": [
+      "sources": [
         {
           "@id": "urn:solid-server:default:AclStrategy"
         }
@@ -24,7 +24,7 @@
     {
       "@id": "urn:solid-server:template:IdentifierStrategy",
       "@type": "SingleRootIdentifierStrategy",
-      "SingleRootIdentifierStrategy:_baseUrl": {
+      "baseUrl": {
         "@id": "urn:solid-server:template:variable:baseUrl"
       }
     },
@@ -32,13 +32,13 @@
     {
       "@id": "urn:solid-server:template:ResourceStore",
       "@type": "DataAccessorBasedStore",
-      "DataAccessorBasedStore:_accessor": {
+      "accessor": {
         "@id": "urn:solid-server:template:DataAccessor"
       },
-      "DataAccessorBasedStore:_identifierStrategy": {
+      "identifierStrategy": {
         "@id": "urn:solid-server:template:IdentifierStrategy"
       },
-      "DataAccessorBasedStore:_auxiliaryStrategy": {
+      "auxiliaryStrategy": {
         "@id": "urn:solid-server:default:AuxiliaryStrategy"
       }
     },

--- a/config/templates/storage-filesystem.json
+++ b/config/templates/storage-filesystem.json
@@ -11,20 +11,20 @@
     {
       "@id": "urn:solid-server:template:FileIdentifierMapper",
       "@type": "ExtensionBasedMapper",
-      "ExtensionBasedMapper:_base": {
+      "base": {
         "@id": "urn:solid-server:template:variable:baseUrl"
       },
-      "ExtensionBasedMapper:_rootFilepath": {
+      "rootFilepath": {
         "@id": "urn:solid-server:template:variable:rootFilePath"
       },
-      "ExtensionBasedMapper:_overrideTypes_acl": "text/turtle",
-      "ExtensionBasedMapper:_overrideTypes_meta": "text/turtle"
+      "overrideTypes_acl": "text/turtle",
+      "overrideTypes_meta": "text/turtle"
     },
 
     {
       "@id": "urn:solid-server:template:DataAccessor",
       "@type": "FileDataAccessor",
-      "FileDataAccessor:_resourceMapper": {
+      "resourceMapper": {
         "@id": "urn:solid-server:template:FileIdentifierMapper"
       }
     },

--- a/config/templates/storage-memory.json
+++ b/config/templates/storage-memory.json
@@ -11,7 +11,7 @@
     {
       "@id": "urn:solid-server:template:DataAccessor",
       "@type": "InMemoryDataAccessor",
-      "InMemoryDataAccessor:_strategy": {
+      "strategy": {
         "@id": "urn:solid-server:template:IdentifierStrategy"
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -482,9 +482,9 @@
       }
     },
     "@comunica/actor-rdf-parse-html-microdata": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-1.18.1.tgz",
-      "integrity": "sha512-ErW0ngwOnEXbGr2fskQYBvau1ZsvB3IbQimAcNAx9m+pIeoDF51+qjpTTZpcckgbTN9wUsNfGCwxk9jbKH2nTQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-1.21.1.tgz",
+      "integrity": "sha512-50EjJ0HYiCdKEb2nebULLGkqLk9XZeLLSPCMDo+4Est65dGXcLkFPerBPTIlcrpOMmVXLry8F7m+fAtDQxUcmw==",
       "requires": {
         "microdata-rdf-streaming-parser": "^1.1.0"
       }
@@ -617,6 +617,11 @@
         }
       }
     },
+    "@comunica/context-entries": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-1.21.1.tgz",
+      "integrity": "sha512-7wBb+J+YLg4hcRQLFeP6/2b/xyK+lnQlc71OSjVMinQx1OO6tsjqlqHvQ6py56uVFs3cYduASgFuHTRVuoe1xA=="
+    },
     "@comunica/core": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.19.2.tgz",
@@ -639,6 +644,17 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.19.2.tgz",
       "integrity": "sha512-F+PxeAWTrMEW0s48oaV5h3YrywoO3vPqCgSKyDfRx2YtjJX3SjJduGVNsKKCK4oWNG/NINOg3eUaTG8p4JMbWQ=="
+    },
+    "@comunica/types": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-1.21.1.tgz",
+      "integrity": "sha512-Sdp8m9yvKbcCSx31L4nLe0tORCRc1TvUXSgpIUVGBXunqZpoWAhxcn2PZn7//xb6xnYUjHqrQZhYQbMdDIqONQ==",
+      "requires": {
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "immutable": "^3.8.2",
+        "sparqlalgebrajs": "^2.4.0"
+      }
     },
     "@dabh/diagnostics": {
       "version": "2.0.2",
@@ -1916,6 +1932,11 @@
       "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.2.4.tgz",
       "integrity": "sha512-UBQJC2pbeyGutIfYmErGc9RaJYnpZ1FHaxuKwb0ahvGiiCkPUf3p67Io+YLPmmv3RHY+mF6JEtNW8FlHsraAaA=="
     },
+    "asynciterator": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.1.0.tgz",
+      "integrity": "sha512-+iDz8roOCGT+hvhhJ+GsQliEEB4Qd1QL1RIsllssZ3MkrtBGqc5Uwi3n5LcLp2f3rXRK07+qJPZQO+YvFCQzug=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2512,9 +2533,9 @@
       "dev": true
     },
     "componentsjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-4.0.1.tgz",
-      "integrity": "sha512-cIY0LmLvC2kWDIWucdFEH4ifVDYteCP1PANxcaJTtEXHibylxjzDpi33BLnd0P4TSpz4cUC0yEBdfi54lmpBGw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-4.1.0.tgz",
+      "integrity": "sha512-be2lA5zYdV1eMSV38MFNifClD+VpRgWLgCKSUp1/hEqa5df3nA951SlO8oifeCv/6zHJY69GgkFinDV5Gl+Tvw==",
       "requires": {
         "@types/minimist": "^1.2.0",
         "@types/node": "^14.14.7",
@@ -2524,7 +2545,7 @@
         "minimist": "^1.2.0",
         "rdf-data-factory": "^1.0.4",
         "rdf-object": "^1.8.0",
-        "rdf-parse": "^1.6.0",
+        "rdf-parse": "^1.8.0",
         "rdf-quad": "^1.5.0",
         "rdf-terms": "^1.6.2",
         "semver": "^7.3.2",
@@ -2532,15 +2553,16 @@
       },
       "dependencies": {
         "@comunica/actor-abstract-mediatyped": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.18.1.tgz",
-          "integrity": "sha512-pjAf0agOpADEVBKp11XhFGH33FML4LTxO08JJmr6Qf6FlbMAhU3KFBrK34nYZ/5QNdhZwE2i8eFmjNC/2CbOKA=="
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.21.1.tgz",
+          "integrity": "sha512-5LzWccqId3AfAeCPGqPkOiDATXrooXYLn58sNXDRdDUsRpL/jZ6be+7F000ZLTHnDRVCiLCXtb5P7984bBIzaA=="
         },
         "@comunica/actor-http-native": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.18.1.tgz",
-          "integrity": "sha512-nQ7dlB3GkP46h28XVyOi43Q4fuc1pUaYWFz6YQeTOgyJMnm/fgNvu9ECsFdG4rYVo3377VVxpvCylGx936S+wQ==",
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.21.1.tgz",
+          "integrity": "sha512-dJlBz8/nQgxH5ARkh8/092BbvQ8vaJ38hjWinLXXakmdj8WsVHnhUJ7/D4YtqY61bjwCBFekOLSPjfxKCEMRgA==",
           "requires": {
+            "@comunica/context-entries": "^1.21.1",
             "@types/parse-link-header": "^1.0.0",
             "cross-fetch": "^3.0.5",
             "follow-redirects": "^1.5.1",
@@ -2548,161 +2570,208 @@
           }
         },
         "@comunica/actor-rdf-parse-html": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.18.1.tgz",
-          "integrity": "sha512-Wx5c/4bN7ohJjsp397JeX8YTDZXMp3VWEFilIjl4/CtAoGV4BzYlHPFo3ZCuRjRpn2EPyJF0Itxedio0b30u3A==",
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.21.1.tgz",
+          "integrity": "sha512-eZUExtLtC28nEMrECL2g3kmZjLmuY/Nu7S9p5NyvI60cwEjj1Rbf0aM9xqWLG5vuCiSKQz7MUobQ92WxtG6RHA==",
           "requires": {
-            "@comunica/bus-rdf-parse-html": "^1.18.1",
+            "@comunica/bus-rdf-parse-html": "^1.21.1",
             "@types/rdf-js": "*",
-            "htmlparser2": "^5.0.0"
+            "htmlparser2": "^6.0.0"
           }
         },
         "@comunica/actor-rdf-parse-html-rdfa": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.18.1.tgz",
-          "integrity": "sha512-c1ae+6F+ohTIAscItsVI/+dKY5tKx7sJwKrrznwgXoPlkFxk7aI9W03Du8X1FsT+spNlk3+CIA/lUPrZ53Lhhw==",
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.21.1.tgz",
+          "integrity": "sha512-37whUUn3LsvCV/kj37/ztAnBjGqKdGP8fLUpD3z8vDOg3ArhktPvWn+cB0ssU0DKSzsCTnCNujS7QoVyINPxJQ==",
           "requires": {
             "rdfa-streaming-parser": "^1.4.0"
           }
         },
         "@comunica/actor-rdf-parse-html-script": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.18.1.tgz",
-          "integrity": "sha512-KI3h3Qb+/IibzFJjLWYVFn43pM0oyRaDovm9VzyGass4wbxmMUVm69lgOLTEcsmOVmTPNcvNI4dYa03g/zjwjA==",
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.21.1.tgz",
+          "integrity": "sha512-cM06ZEVpgj4/fLFrM8alRi0a4kh1XVY3vwWOyZXnkjVkIKp36Nc17Pw4+vM10z7D+x5VI/mZc0tGMohr8u7dcw==",
           "requires": {
-            "@comunica/bus-rdf-parse-html": "^1.18.1",
+            "@comunica/bus-rdf-parse-html": "^1.21.1",
             "@types/rdf-js": "*",
             "relative-to-absolute-iri": "^1.0.5"
           }
         },
         "@comunica/actor-rdf-parse-jsonld": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.18.1.tgz",
-          "integrity": "sha512-3X3REVIqRTgjzWUsfVgJQsyZ75J/SSl7mHfFchNncxRdm14hq67RApO0gztdSLj4t4Kv1HtciEm/zs+nEuKmNw==",
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.21.1.tgz",
+          "integrity": "sha512-0pnZJUQ5bhaUwM7pQNr1afmoVKMmnYhJHdub9j/l2jAJWJFbVWucZI9z/g7r9Tek4SBS6PcM2+2sx8U9+WiiIA==",
           "requires": {
+            "@comunica/context-entries": "^1.21.1",
             "@types/rdf-js": "*",
-            "jsonld-context-parser": "^2.1.1",
-            "jsonld-streaming-parser": "^2.1.1",
+            "jsonld-context-parser": "^2.1.2",
+            "jsonld-streaming-parser": "^2.3.0",
             "stream-to-string": "^1.2.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "13.13.50",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.50.tgz",
+              "integrity": "sha512-y7kkh+hX/0jZNxMyBR/6asG0QMSaPSzgeVK63dhWHl4QAXCQB8lExXmzLL6SzmOgKHydtawpMnNhlDbv7DXPEA=="
+            },
+            "jsonld-context-parser": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.1.2.tgz",
+              "integrity": "sha512-zAhus+dz4IrXiYAiYf6M1PSdYkILVWPg4bqqGfim+rGrmVc3d0drFAriLOU2RMwQFKljM+41lJTau47sxt6YWA==",
+              "requires": {
+                "@types/http-link-header": "^1.0.1",
+                "@types/node": "^13.1.0",
+                "canonicalize": "^1.0.1",
+                "cross-fetch": "^3.0.6",
+                "http-link-header": "^1.0.2",
+                "relative-to-absolute-iri": "^1.0.5"
+              }
+            }
           }
         },
         "@comunica/actor-rdf-parse-n3": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.18.1.tgz",
-          "integrity": "sha512-5GQ+PaabjXSgu3mR8tN2ZWyy+pSaq6rIyHDNKAbh3AkG70j6tQWxfa4OZIk2+ImDEjtPVofYsJZnY5VSZhZEwg==",
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.21.1.tgz",
+          "integrity": "sha512-SFx/hkY0yr/TxfVdEecVg3DY2KOWPeGfM288CjDQjogx6Sxb6JuF9JaipNX8/twKVdBefGS9b1S9EyKpcr99Zg==",
           "requires": {
             "@types/n3": "^1.4.4",
             "n3": "^1.6.3"
           }
         },
         "@comunica/actor-rdf-parse-rdfxml": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.18.1.tgz",
-          "integrity": "sha512-qCn8UovKW6xNCoYgR13MBPi8mOOSorRxPLpSOt7eVFEADFMkjzVJAbyExN+8EzHgrJj2DIwQixD2kYnGaEkz+Q==",
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.21.1.tgz",
+          "integrity": "sha512-fv5+DF5LagSJUayyQm7a917XQ9PNUfJVh2bqO/NlVfESXO8OFUAIySefW+j1y1JA0fpa5v1OnWTGAfdxGKnrUg==",
           "requires": {
             "rdfxml-streaming-parser": "^1.4.0"
           }
         },
         "@comunica/actor-rdf-parse-xml-rdfa": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.18.1.tgz",
-          "integrity": "sha512-99g5zw57ZbxSKiv0daZiEWhu70Efs0dqKQsf4hIHl+1mZJ7gjYdXrA1gSb2h/bnvezZKyiqjkc9VxzD+J7dv0A==",
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.21.1.tgz",
+          "integrity": "sha512-+9qyKJS+Ab3BWqrWnFU5CSgEDGtoGJpe19TzpymSXDP0aSAM6lnkZpCvT3EKi/Y8Bmw9xRXJZwemtxQK2y4SSQ==",
           "requires": {
             "rdfa-streaming-parser": "^1.3.0"
           }
         },
         "@comunica/bus-http": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.18.1.tgz",
-          "integrity": "sha512-ovEy1HEagq2cla3WSCLyrA6LGMsfNyc7sm9UBJUnaX4KnYlOoombibsCwqiJhGfvHHV019yFj1l7NDICF3ZD3Q==",
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.21.1.tgz",
+          "integrity": "sha512-M6gi128ME+7uSnLPz4Bx3jgXhIb5/O7tODVHAtw9gt0z/9AAuYfmW9jqmcZ5Uwv3CCvJSvEc/m+dooCv35dTsA==",
           "requires": {
+            "@comunica/context-entries": "^1.21.1",
             "is-stream": "^2.0.0",
             "web-streams-node": "^0.4.0"
           }
         },
         "@comunica/bus-init": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.18.1.tgz",
-          "integrity": "sha512-eXIfQM4cl3dKwSd5GVt2lxcTxiSqxZZ/u8rjQeS/vncdRDfIAY7WS1qBHARUXEgeLRu5LX5W4Bq13TGwn+dkNQ=="
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.21.1.tgz",
+          "integrity": "sha512-h8Gp/iJiyY8mbqhrbfLySwTXasjxmCX6kpM9RyXWqCBJzdx8Bfq6F/nYg2N+zpEJgyrn5zLdNgbBkcDetdeAmA=="
         },
         "@comunica/bus-rdf-parse": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.18.1.tgz",
-          "integrity": "sha512-GNNCd1cEp+mjVeUG8eHI3u1x8+ic6MatHRET/ujMeouC0kI1jX31R57PoX9QWzopOx73tueI2i9E+5xLQDa29A==",
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.21.1.tgz",
+          "integrity": "sha512-JQD9Cgml/W+PCSEX3WulwxiQOdULFxAFDipLk69/J9WZxOj6emufxStM8M9R+pavbLaLYRcBQWgO0KLhEn/Rnw==",
           "requires": {
-            "@comunica/actor-abstract-mediatyped": "^1.18.1",
+            "@comunica/actor-abstract-mediatyped": "^1.21.1",
             "@types/rdf-js": "*"
           }
         },
         "@comunica/bus-rdf-parse-html": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.18.1.tgz",
-          "integrity": "sha512-bV4N7ABCshWi0S4VliibGLtazYGiToVyeMqhFBMyl/v8IaPOW+2QbE4JfXcen8+ieHqonFt28W/x9gbh7VEZeA==",
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.21.1.tgz",
+          "integrity": "sha512-DJDFB8lxTJ1Pt+AhjOqe9hvj2nKtC23fJfEihU7DYIbz67O5pXAFgFtp9gn3gefoGB7T/CKoB8y8DcZy8N5u0A==",
           "requires": {
             "@types/rdf-js": "*"
           }
         },
         "@comunica/core": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.18.1.tgz",
-          "integrity": "sha512-wXLOu/Wkt0zUy6XwI4W7IaXkcLmEkxs0P/xWY3huMdG5ixvFxVlOz+EuKz5sNCpeGiqZsMON4I9YvgiUlnZv0Q==",
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.21.1.tgz",
+          "integrity": "sha512-5lY/HkyOCorY2CtxQiKUKEOcUGjIKf/YG/txJrz84SKuy+zC91zq1Zt8qWfzNihCcWrgfmk0oZuvjbYvZGK4EA==",
           "requires": {
+            "@comunica/context-entries": "^1.21.1",
+            "@comunica/types": "^1.21.1",
             "immutable": "^3.8.2"
           }
         },
         "@comunica/mediator-combine-union": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.18.1.tgz",
-          "integrity": "sha512-w4S4WNwjh+8zjz154YaEL1p4VWYYD5yNhPTH/mIvk5IS2R6TLqTQ0qlk5JvOvDA5aL8IiOndG0rTPXxFS8dhxw=="
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.21.1.tgz",
+          "integrity": "sha512-wp2lbViVOOeNKTBRD+6sze7TKVX71T2RD324/1Syb8vOpwT3mtaDNJYFg0Mrwer/Xs54d7nA7JGZA2wC2HaXow=="
         },
         "@comunica/mediator-number": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.18.1.tgz",
-          "integrity": "sha512-nJNrMi01l9eLEttWlcIvabLoOEr31Dw19VoOClYvPC315e60DYuX4b5PTZNIuTTjv5x39DVRQ2qjFVMdFjn3sQ=="
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.21.1.tgz",
+          "integrity": "sha512-OeuGx0R/mWI1uMMXM2V1vcR8J1DPhYXPR+Ncg4/qKHl7tSCQH1tlCgZu0+fovY2Qmc14f1tmw5YgnsE8lsikSQ=="
         },
         "@comunica/mediator-race": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.18.1.tgz",
-          "integrity": "sha512-UN9yT62mHTbIvCxyMyMx63wbYVB2Z7tq0pzHrVOUTlx09QMHkyIr8wVkaAiTzXfm/PKTX9awNNpmXrAz9Sw8kA=="
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.21.1.tgz",
+          "integrity": "sha512-SgdtF1JmqDyhZJsAOiVMPuV1qgdXqv/hbsFCxcmDQ+8q1ObmQ+0DZvdUe5Ymf2IyFaevsOHHG7hF5hJbLZmdmQ=="
         },
         "@types/node": {
-          "version": "14.14.20",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
-          "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A=="
+          "version": "14.14.42",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.42.tgz",
+          "integrity": "sha512-88QoObqn9WYIUMRzOx92GmSHmU3JCyukC2ulEv8tFjUG9VeV2FQ/cA7VQ1gi+rB/+gBMVvzVFcTnz8RdMDVIWw=="
         },
-        "htmlparser2": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
-          "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
+        "jsonld-streaming-parser": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.3.0.tgz",
+          "integrity": "sha512-IJiFhX9GQ/uLugd3BSYgJDaisAc22fV2Ij7tH0yWG8KZpriSGadRVvxUkfglzRKSjqxYBsZ+qAQ+UR7YGwiHRQ==",
           "requires": {
-            "domelementtype": "^2.0.1",
-            "domhandler": "^3.3.0",
-            "domutils": "^2.4.2",
-            "entities": "^2.0.0"
+            "@types/http-link-header": "^1.0.1",
+            "@types/rdf-js": "*",
+            "canonicalize": "^1.0.1",
+            "http-link-header": "^1.0.2",
+            "jsonld-context-parser": "^2.1.2",
+            "jsonparse": "^1.3.1",
+            "rdf-data-factory": "^1.0.4"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "13.13.50",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.50.tgz",
+              "integrity": "sha512-y7kkh+hX/0jZNxMyBR/6asG0QMSaPSzgeVK63dhWHl4QAXCQB8lExXmzLL6SzmOgKHydtawpMnNhlDbv7DXPEA=="
+            },
+            "jsonld-context-parser": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.1.2.tgz",
+              "integrity": "sha512-zAhus+dz4IrXiYAiYf6M1PSdYkILVWPg4bqqGfim+rGrmVc3d0drFAriLOU2RMwQFKljM+41lJTau47sxt6YWA==",
+              "requires": {
+                "@types/http-link-header": "^1.0.1",
+                "@types/node": "^13.1.0",
+                "canonicalize": "^1.0.1",
+                "cross-fetch": "^3.0.6",
+                "http-link-header": "^1.0.2",
+                "relative-to-absolute-iri": "^1.0.5"
+              }
+            }
           }
         },
         "rdf-parse": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-1.6.1.tgz",
-          "integrity": "sha512-WBylJN11cuvo2GAvS/drqus+94tb9evl1QvUSbkNAVxYWUc5chnyV9ZpWPZW/F2pXJlPLqet9kE8U52eXKMo3Q==",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-1.8.0.tgz",
+          "integrity": "sha512-Pc6jvqjlJpY/ivVPbfbCJw372VhUx1dTMGLGGU/bHz6srjLL9Q4scn655afAuDI89KamDBRTDN+ZzlfiWfgbfg==",
           "requires": {
-            "@comunica/actor-http-native": "~1.18.0",
-            "@comunica/actor-rdf-parse-html": "~1.18.0",
-            "@comunica/actor-rdf-parse-html-microdata": "~1.18.0",
-            "@comunica/actor-rdf-parse-html-rdfa": "~1.18.0",
-            "@comunica/actor-rdf-parse-html-script": "~1.18.0",
-            "@comunica/actor-rdf-parse-jsonld": "~1.18.0",
-            "@comunica/actor-rdf-parse-n3": "~1.18.0",
-            "@comunica/actor-rdf-parse-rdfxml": "~1.18.0",
-            "@comunica/actor-rdf-parse-xml-rdfa": "~1.18.0",
-            "@comunica/bus-http": "~1.18.0",
-            "@comunica/bus-init": "~1.18.0",
-            "@comunica/bus-rdf-parse": "~1.18.0",
-            "@comunica/bus-rdf-parse-html": "~1.18.0",
-            "@comunica/core": "~1.18.0",
-            "@comunica/mediator-combine-union": "~1.18.0",
-            "@comunica/mediator-number": "~1.18.0",
-            "@comunica/mediator-race": "~1.18.0",
+            "@comunica/actor-http-native": "~1.21.1",
+            "@comunica/actor-rdf-parse-html": "~1.21.1",
+            "@comunica/actor-rdf-parse-html-microdata": "~1.21.1",
+            "@comunica/actor-rdf-parse-html-rdfa": "~1.21.1",
+            "@comunica/actor-rdf-parse-html-script": "~1.21.1",
+            "@comunica/actor-rdf-parse-jsonld": "~1.21.1",
+            "@comunica/actor-rdf-parse-n3": "~1.21.1",
+            "@comunica/actor-rdf-parse-rdfxml": "~1.21.1",
+            "@comunica/actor-rdf-parse-xml-rdfa": "~1.21.1",
+            "@comunica/bus-http": "~1.21.1",
+            "@comunica/bus-init": "~1.21.1",
+            "@comunica/bus-rdf-parse": "~1.21.1",
+            "@comunica/bus-rdf-parse-html": "~1.21.1",
+            "@comunica/core": "~1.21.1",
+            "@comunica/mediator-combine-union": "~1.21.1",
+            "@comunica/mediator-number": "~1.21.1",
+            "@comunica/mediator-race": "~1.21.1",
             "@types/rdf-js": "*",
             "stream-to-string": "^1.2.0"
           }
@@ -5563,7 +5632,8 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yargs": {
@@ -7727,9 +7797,9 @@
       }
     },
     "rdf-object": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.8.0.tgz",
-      "integrity": "sha512-/yq5vk8eqspZwIcK1BS3wPcmv4kinooaPX5SRDpCnthCjOcDiyNgPnfXqMt5OpDWhykDkNJeTCvqQifFqZRPyw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.10.2.tgz",
+      "integrity": "sha512-IvppylbhVlcbyxDuwJDLNYgUsX4m7Kztfa1B2zZzl7M8V6edmQqKglCFHZ93ZveQ6m9q1V1VTYLaGaB7p9no8Q==",
       "requires": {
         "jsonld-context-parser": "^2.0.2",
         "rdf-data-factory": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/solid/community-server#readme",
   "scripts": {
     "build": "npm run build:ts && npm run build:components",
-    "build:components": "componentsjs-generator -s src -c dist/components -i .componentsignore",
+    "build:components": "componentsjs-generator -s src -c dist/components -i .componentsignore --typeScopedContexts",
     "build:ts": "tsc",
     "docker": "npm run docker:setup && npm run docker:start",
     "docker:clean": "./test/docker/docker-clean.sh",
@@ -95,7 +95,7 @@
     "@types/yargs": "^16.0.0",
     "arrayify-stream": "^1.0.0",
     "async-lock": "^1.2.4",
-    "componentsjs": "^4.0.1",
+    "componentsjs": "^4.1.0",
     "cors": "^2.8.5",
     "end-of-stream": "^1.4.4",
     "escape-string-regexp": "^4.0.0",


### PR DESCRIPTION
This PR basically just enables the `typeScopedContexts` option in the Components.js generator, and simplifies all configs accordingly.

Note that this change is backwards-compatible, so people can still make use of their old, more verbose configs.

There are also a couple places where this compaction can not be done yet (such as `ConstantMetadataWriter:_headers_key`) due to a bug in the generator. I will look into this at a later point in time via a separate PR.