### PR TITLE
Improvements to Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ WORKDIR /community-server
 ## Copy the package.json for audit
 COPY package*.json ./
 
-## Verify if there are known vulnerabilities in the dependencies
-RUN npm audit --production --audit-level=high
-
 ## Copy the dockerfile's context's community server files
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY package*.json ./
 COPY . .
 
 ## Install and build the Solid community server (prepare script cannot run in wd)
-RUN npm ci --ignore-scripts && npm run build
+RUN npm ci && npm run build
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY package*.json ./
 COPY . .
 
 ## Install and build the Solid community server (prepare script cannot run in wd)
-RUN npm ci && npm run build
+RUN npm ci --unsafe-perm && npm run build
 
 
 


### PR DESCRIPTION
I just tried to build the Dockerfile, and noticed 3 problems, which are fixed in this PR.

1. The Dockerfile contained an `npm audit` call, which failed at the time of writing. I removed it in this PR because including it in the Dockerfile feels like a confusion of responsibilities. This is something that should be run earlier in the lifecycle, i.e., during CI.
2. Scripts were ignored during `npm install`, which breaks some dependencies at runtime that require node-gyp, such as `bcrypt`.
3. Since `node_modules` are re-fetched during the build step, they can be excluded from the Docker context, thereby significantly speeding up builds.