### PR TITLE
Prevent metadata of auxiliary resources in container metadata

### DIFF
--- a/src/init/RootContainerInitializer.ts
+++ b/src/init/RootContainerInitializer.ts
@@ -1,4 +1,3 @@
-import { DataFactory } from 'n3';
 import { BasicRepresentation } from '../ldp/representation/BasicRepresentation';
 import { RepresentationMetadata } from '../ldp/representation/RepresentationMetadata';
 import type { ResourceIdentifier } from '../ldp/representation/ResourceIdentifier';
@@ -6,10 +5,9 @@ import { getLoggerFor } from '../logging/LogUtil';
 import type { ResourceStore } from '../storage/ResourceStore';
 import { TEXT_TURTLE } from '../util/ContentTypes';
 import { ensureTrailingSlash } from '../util/PathUtil';
-import { generateResourceQuads } from '../util/ResourceUtil';
+import { addResourceMetadata } from '../util/ResourceUtil';
 import { PIM, RDF } from '../util/Vocabularies';
 import { Initializer } from './Initializer';
-import namedNode = DataFactory.namedNode;
 
 /**
  * Initializes ResourceStores by creating a root container if it didn't exist yet.
@@ -43,7 +41,7 @@ export class RootContainerInitializer extends Initializer {
    */
   protected async createRootContainer(): Promise<void> {
     const metadata = new RepresentationMetadata(this.baseId, TEXT_TURTLE);
-    metadata.addQuads(generateResourceQuads(namedNode(this.baseId.path), true));
+    addResourceMetadata(metadata, true);
 
     // Make sure the root container is a pim:Storage
     // This prevents deletion of the root container as storage root containers can not be deleted

--- a/src/ldp/representation/RepresentationMetadata.ts
+++ b/src/ldp/representation/RepresentationMetadata.ts
@@ -63,7 +63,7 @@ export class RepresentationMetadata {
   public constructor(contentType?: string);
 
   /**
-   * @param overrides - Metadata values (defaulting to content type if a string)
+   * @param metadata - Metadata values (defaulting to content type if a string)
    */
   public constructor(metadata?: RepresentationMetadata | MetadataRecord | string);
 

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -25,7 +25,7 @@ import {
   toCanonicalUriPath,
 } from '../util/PathUtil';
 import { parseQuads } from '../util/QuadUtil';
-import { generateResourceQuads } from '../util/ResourceUtil';
+import { addResourceMetadata } from '../util/ResourceUtil';
 import { CONTENT_TYPE, DC, HTTP, LDP, POSIX, PIM, RDF, VANN, XSD } from '../util/Vocabularies';
 import type { DataAccessor } from './accessors/DataAccessor';
 import type { ResourceStore } from './ResourceStore';
@@ -293,7 +293,7 @@ export class DataAccessorBasedStore implements ResourceStore {
     // Need to do this before handling container data to have the correct identifier
     const { metadata } = representation;
     metadata.identifier = DataFactory.namedNode(identifier.path);
-    metadata.addQuads(generateResourceQuads(metadata.identifier, isContainer));
+    addResourceMetadata(metadata, isContainer);
 
     // Validate container data
     if (isContainer) {

--- a/src/storage/accessors/DataAccessor.ts
+++ b/src/storage/accessors/DataAccessor.ts
@@ -11,7 +11,7 @@ import type { Guarded } from '../../util/GuardedStream';
  *  * If the input identifier ends with a slash, it should be assumed the identifier is targeting a container.
  *  * Similarly, if there is no trailing slash it should assume a document.
  *  * It should always throw a NotFoundHttpError if it does not have data matching the input identifier.
- *  * DataAccessors are responsible for generating the relevant containment triples for containers.
+ *  * DataAccessors should not generate containment triples. This will be done externally using `getChildren`.
  */
 export interface DataAccessor {
   /**
@@ -35,6 +35,20 @@ export interface DataAccessor {
    * @param identifier - Identifier for which the metadata is requested.
    */
   getMetadata: (identifier: ResourceIdentifier) => Promise<RepresentationMetadata>;
+
+  /**
+   * Returns metadata for all resources in the requested container.
+   * This should not be all metadata of those resources (but it can be),
+   * but instead the main metadata you want to show in situations
+   * where all these resources are presented simultaneously.
+   * Generally this would be metadata that is present for all of these resources,
+   * such as resource type or last modified date.
+   *
+   * It can be safely assumed that the incoming identifier will always correspond to a container.
+   *
+   * @param identifier - Identifier of the parent container.
+   */
+  getChildren: (identifier: ResourceIdentifier) => AsyncIterableIterator<RepresentationMetadata>;
 
   /**
    * Writes data and metadata for a document.

--- a/src/util/QuadUtil.ts
+++ b/src/util/QuadUtil.ts
@@ -1,32 +1,12 @@
 import type { Readable } from 'stream';
 import arrayifyStream from 'arrayify-stream';
 import type { ParserOptions } from 'n3';
-import { DataFactory, StreamParser, StreamWriter } from 'n3';
-import type { Literal, NamedNode, Quad } from 'rdf-js';
+import { StreamParser, StreamWriter } from 'n3';
+import type { Quad } from 'rdf-js';
 import streamifyArray from 'streamify-array';
 import type { Guarded } from './GuardedStream';
 import { pipeSafely } from './StreamUtil';
-import { toSubjectTerm, toPredicateTerm, toObjectTerm } from './TermUtil';
 
-/**
- * Generates a quad with the given subject/predicate/object and pushes it to the given array.
- */
-export function pushQuad(
-  quads: Quad[] | Readable,
-  subject: string | NamedNode,
-  predicate: string | NamedNode,
-  object: string | NamedNode | Literal,
-): void {
-  quads.push(DataFactory.quad(toSubjectTerm(subject), toPredicateTerm(predicate), toObjectTerm(object)));
-}
-
-/**
- * Helper function for serializing an array of quads, with as result a Readable object.
- * @param quads - The array of quads.
- * @param contentType - The content-type to serialize to.
- *
- * @returns The Readable object.
- */
 export function serializeQuads(quads: Quad[], contentType?: string): Guarded<Readable> {
   return pipeSafely(streamifyArray(quads), new StreamWriter({ format: contentType }));
 }

--- a/src/util/ResourceUtil.ts
+++ b/src/util/ResourceUtil.ts
@@ -1,5 +1,4 @@
 import arrayifyStream from 'arrayify-stream';
-import { DataFactory } from 'n3';
 import type { NamedNode, Quad } from 'rdf-js';
 import { BasicRepresentation } from '../ldp/representation/BasicRepresentation';
 import type { Representation } from '../ldp/representation/Representation';
@@ -25,18 +24,6 @@ export function generateResourceQuads(subject: NamedNode, isContainer: boolean):
   pushQuad(quads, subject, RDF.terms.type, LDP.terms.Resource);
 
   return quads;
-}
-
-/**
- * Helper function to generate the quads describing that the resource URIs are children of the container URI.
- * @param containerURI - The URI of the container.
- * @param childURIs - The URI of the child resources.
- *
- * @returns The generated quads.
- */
-export function generateContainmentQuads(containerURI: NamedNode, childURIs: string[]): Quad[] {
-  return new RepresentationMetadata(containerURI,
-    { [LDP.contains]: childURIs.map(DataFactory.namedNode) }).quads();
 }
 
 /**

--- a/src/util/ResourceUtil.ts
+++ b/src/util/ResourceUtil.ts
@@ -1,29 +1,24 @@
 import arrayifyStream from 'arrayify-stream';
-import type { NamedNode, Quad } from 'rdf-js';
 import { BasicRepresentation } from '../ldp/representation/BasicRepresentation';
 import type { Representation } from '../ldp/representation/Representation';
 import { RepresentationMetadata } from '../ldp/representation/RepresentationMetadata';
-import { pushQuad } from './QuadUtil';
 import { guardedStreamFrom } from './StreamUtil';
 
 import { LDP, RDF } from './Vocabularies';
 
 /**
  * Helper function to generate type quads for a Container or Resource.
- * @param subject - Subject for the new quads.
+ * @param metadata - Metadata to add to.
  * @param isContainer - If the identifier corresponds to a container.
  *
  * @returns The generated quads.
  */
-export function generateResourceQuads(subject: NamedNode, isContainer: boolean): Quad[] {
-  const quads: Quad[] = [];
+export function addResourceMetadata(metadata: RepresentationMetadata, isContainer: boolean): void {
   if (isContainer) {
-    pushQuad(quads, subject, RDF.terms.type, LDP.terms.Container);
-    pushQuad(quads, subject, RDF.terms.type, LDP.terms.BasicContainer);
+    metadata.add(RDF.terms.type, LDP.terms.Container);
+    metadata.add(RDF.terms.type, LDP.terms.BasicContainer);
   }
-  pushQuad(quads, subject, RDF.terms.type, LDP.terms.Resource);
-
-  return quads;
+  metadata.add(RDF.terms.type, LDP.terms.Resource);
 }
 
 /**

--- a/test/unit/util/QuadUtil.test.ts
+++ b/test/unit/util/QuadUtil.test.ts
@@ -1,28 +1,9 @@
 import 'jest-rdf';
 import { literal, namedNode, quad } from '@rdfjs/data-model';
-import type { Quad } from 'rdf-js';
-import { parseQuads, pushQuad, serializeQuads } from '../../../src/util/QuadUtil';
+import { parseQuads, serializeQuads } from '../../../src/util/QuadUtil';
 import { guardedStreamFrom, readableToString } from '../../../src/util/StreamUtil';
 
 describe('QuadUtil', (): void => {
-  describe('#pushQuad', (): void => {
-    it('creates a quad and adds it to the given array.', async(): Promise<void> => {
-      const quads: Quad[] = [];
-      pushQuad(quads, namedNode('sub'), namedNode('pred'), literal('obj'));
-      expect(quads).toEqualRdfQuadArray([
-        quad(namedNode('sub'), namedNode('pred'), literal('obj')),
-      ]);
-    });
-
-    it('creates a quad from strings and adds it to the given array.', async(): Promise<void> => {
-      const quads: Quad[] = [];
-      pushQuad(quads, 'sub', 'pred', 'obj');
-      expect(quads).toEqualRdfQuadArray([
-        quad(namedNode('sub'), namedNode('pred'), namedNode('obj')),
-      ]);
-    });
-  });
-
   describe('#serializeQuads', (): void => {
     it('converts quads to the requested format.', async(): Promise<void> => {
       const quads = [ quad(

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -1,4 +1,5 @@
-import type { Stats } from 'fs';
+import type { Dirent, Stats } from 'fs';
+
 import { PassThrough } from 'stream';
 import streamifyArray from 'streamify-array';
 import type { SystemError } from '../../src/util/errors/SystemError';
@@ -148,6 +149,19 @@ export function mockFs(rootFilepath?: string, time?: Date): { data: any } {
           throwSystemError('ENOENT');
         }
         return Object.keys(folder[name]);
+      },
+      async* opendir(path: string): AsyncIterableIterator<Dirent> {
+        const { folder, name } = getFolder(path);
+        if (!folder[name]) {
+          throwSystemError('ENOENT');
+        }
+        for (const child of Object.keys(folder[name])) {
+          yield {
+            name: child,
+            isFile: (): boolean => typeof folder[name][child] === 'string',
+            isDirectory: (): boolean => typeof folder[name][child] === 'object',
+          } as Dirent;
+        }
       },
       mkdir(path: string): void {
         const { folder, name } = getFolder(path);


### PR DESCRIPTION
Closes #385 (again).

This reduces the performance for SPARQL backends due to the extra calls. This might actually increase the performance in some situations for file/memory backends.