### PR TITLE
Expose constant Allow and Accept-Post headers

### DIFF
--- a/config/ldp/metadata-writer/writers/constant.json
+++ b/config/ldp/metadata-writer/writers/constant.json
@@ -11,6 +11,10 @@
           "ConstantMetadataWriter:_headers_value": "application/sparql-update"
         },
         {
+          "ConstantMetadataWriter:_headers_key": "Allow",
+          "ConstantMetadataWriter:_headers_value": "OPTIONS, HEAD, GET, PATCH, POST, PUT, DELETE"
+        },
+        {
           "ConstantMetadataWriter:_headers_key": "MS-Author-Via",
           "ConstantMetadataWriter:_headers_value": "SPARQL"
         }


### PR DESCRIPTION
This PR exposes headers that are required by the [Solid spec](https://solidproject.org/TR/protocol#reading-resources) as to enable client-side libs to know if and how resources can be updated.

This is a temporary solution until #572 and #577 are implemented.

