### PR TITLE
Remove generated metadata when writing a resource

### DIFF
--- a/src/ldp/auxiliary/AuxiliaryStrategy.ts
+++ b/src/ldp/auxiliary/AuxiliaryStrategy.ts
@@ -34,6 +34,14 @@ export interface AuxiliaryStrategy extends AuxiliaryIdentifierStrategy {
   addMetadata: (metadata: RepresentationMetadata) => Promise<void>;
 
   /**
+   * Removes the metadata that has been added by the `addMetadata` call.
+   * This should be used when writing a resource to make sure we don't store metadata that gets generated.
+   *
+   * @param metadata - Metadata to update.
+   */
+  removeMetadata: (metadata: RepresentationMetadata) => Promise<void>;
+
+  /**
    * Validates if the representation contains valid data for an auxiliary resource.
    * Should throw an error in case the data is invalid.
    * @param identifier - Identifier of the auxiliary resource.

--- a/src/ldp/auxiliary/ComposedAuxiliaryStrategy.ts
+++ b/src/ldp/auxiliary/ComposedAuxiliaryStrategy.ts
@@ -46,7 +46,13 @@ export class ComposedAuxiliaryStrategy implements AuxiliaryStrategy {
 
   public async addMetadata(metadata: RepresentationMetadata): Promise<void> {
     if (this.metadataGenerator) {
-      return this.metadataGenerator.handleSafe(metadata);
+      return this.metadataGenerator.add(metadata);
+    }
+  }
+
+  public async removeMetadata(metadata: RepresentationMetadata): Promise<void> {
+    if (this.metadataGenerator) {
+      return this.metadataGenerator.remove(metadata);
     }
   }
 

--- a/src/ldp/auxiliary/LinkMetadataGenerator.ts
+++ b/src/ldp/auxiliary/LinkMetadataGenerator.ts
@@ -1,7 +1,8 @@
 import { namedNode } from '@rdfjs/data-model';
+import type { NamedNode } from 'rdf-js';
 import type { RepresentationMetadata } from '../representation/RepresentationMetadata';
 import type { AuxiliaryIdentifierStrategy } from './AuxiliaryIdentifierStrategy';
-import { MetadataGenerator } from './MetadataGenerator';
+import type { MetadataGenerator } from './MetadataGenerator';
 
 /**
  * Adds a link to the auxiliary resource when called on the associated resource.
@@ -9,20 +10,33 @@ import { MetadataGenerator } from './MetadataGenerator';
  *
  * In case the input is metadata of an auxiliary resource no metadata will be added
  */
-export class LinkMetadataGenerator extends MetadataGenerator {
+export class LinkMetadataGenerator implements MetadataGenerator {
   private readonly link: string;
   private readonly identifierStrategy: AuxiliaryIdentifierStrategy;
 
   public constructor(link: string, identifierStrategy: AuxiliaryIdentifierStrategy) {
-    super();
     this.link = link;
     this.identifierStrategy = identifierStrategy;
   }
 
-  public async handle(metadata: RepresentationMetadata): Promise<void> {
+  public async add(metadata: RepresentationMetadata): Promise<void> {
+    const object = this.getObject(metadata);
+    if (object) {
+      metadata.add(this.link, object);
+    }
+  }
+
+  public async remove(metadata: RepresentationMetadata): Promise<void> {
+    const object = this.getObject(metadata);
+    if (object) {
+      metadata.remove(this.link, object);
+    }
+  }
+
+  private getObject(metadata: RepresentationMetadata): NamedNode | undefined {
     const identifier = { path: metadata.identifier.value };
     if (!this.identifierStrategy.isAuxiliaryIdentifier(identifier)) {
-      metadata.add(this.link, namedNode(this.identifierStrategy.getAuxiliaryIdentifier(identifier).path));
+      return namedNode(this.identifierStrategy.getAuxiliaryIdentifier(identifier).path);
     }
   }
 }

--- a/src/ldp/auxiliary/MetadataGenerator.ts
+++ b/src/ldp/auxiliary/MetadataGenerator.ts
@@ -1,7 +1,9 @@
-import { AsyncHandler } from '../../util/handlers/AsyncHandler';
 import type { RepresentationMetadata } from '../representation/RepresentationMetadata';
 
 /**
  * Generic interface for classes that add metadata to a RepresentationMetadata.
  */
-export abstract class MetadataGenerator extends AsyncHandler<RepresentationMetadata> { }
+export interface MetadataGenerator {
+  add: (metadata: RepresentationMetadata) => Promise<void>;
+  remove: (metadata: RepresentationMetadata) => Promise<void>;
+}

--- a/src/ldp/auxiliary/RoutingAuxiliaryStrategy.ts
+++ b/src/ldp/auxiliary/RoutingAuxiliaryStrategy.ts
@@ -36,6 +36,19 @@ export class RoutingAuxiliaryStrategy extends RoutingAuxiliaryIdentifierStrategy
     }
   }
 
+  public async removeMetadata(metadata: RepresentationMetadata): Promise<void> {
+    const identifier = { path: metadata.identifier.value };
+    // Make sure only the relevant source gets called if the input is an auxiliary resource
+    const match = this.sources.find((source): boolean => source.isAuxiliaryIdentifier(identifier));
+    if (match) {
+      await match.removeMetadata(metadata);
+    } else {
+      for (const source of this.sources) {
+        await source.removeMetadata(metadata);
+      }
+    }
+  }
+
   public async validate(representation: Representation): Promise<void> {
     const identifier = { path: representation.metadata.identifier.value };
     const source = this.getMatchingSource(identifier);

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -314,6 +314,9 @@ export class DataAccessorBasedStore implements ResourceStore {
       await this.auxiliaryStrategy.validate(representation);
     }
 
+    // Remove auxiliary metadata since it gets added automatically
+    await this.auxiliaryStrategy.removeMetadata(metadata);
+
     // Root container should not have a parent container
     // Solid, §5.3: "Servers MUST create intermediate containers and include corresponding containment triples
     // in container representations derived from the URI path component of PUT and PATCH requests."

--- a/test/unit/ldp/auxiliary/ComposedAuxiliaryStrategy.test.ts
+++ b/test/unit/ldp/auxiliary/ComposedAuxiliaryStrategy.test.ts
@@ -19,7 +19,8 @@ describe('A ComposedAuxiliaryStrategy', (): void => {
       isAuxiliaryIdentifier: jest.fn(),
     };
     metadataGenerator = {
-      handleSafe: jest.fn(),
+      add: jest.fn(),
+      remove: jest.fn(),
     } as any;
     validator = {
       handleSafe: jest.fn(),
@@ -52,8 +53,15 @@ describe('A ComposedAuxiliaryStrategy', (): void => {
   it('adds metadata through the MetadataGenerator.', async(): Promise<void> => {
     const metadata = new RepresentationMetadata();
     await expect(strategy.addMetadata(metadata)).resolves.toBeUndefined();
-    expect(metadataGenerator.handleSafe).toHaveBeenCalledTimes(1);
-    expect(metadataGenerator.handleSafe).toHaveBeenLastCalledWith(metadata);
+    expect(metadataGenerator.add).toHaveBeenCalledTimes(1);
+    expect(metadataGenerator.add).toHaveBeenLastCalledWith(metadata);
+  });
+
+  it('removes metadata through the MetadataGenerator.', async(): Promise<void> => {
+    const metadata = new RepresentationMetadata();
+    await expect(strategy.removeMetadata(metadata)).resolves.toBeUndefined();
+    expect(metadataGenerator.remove).toHaveBeenCalledTimes(1);
+    expect(metadataGenerator.remove).toHaveBeenLastCalledWith(metadata);
   });
 
   it('validates data through the Validator.', async(): Promise<void> => {
@@ -68,11 +76,12 @@ describe('A ComposedAuxiliaryStrategy', (): void => {
     expect(strategy.isRootRequired()).toBe(false);
   });
 
-  it('does not add metadata or validate if the corresponding classes are not injected.', async(): Promise<void> => {
+  it('does not handle metadata or validate if the corresponding classes are not injected.', async(): Promise<void> => {
     strategy = new ComposedAuxiliaryStrategy(identifierStrategy);
 
     const metadata = new RepresentationMetadata();
     await expect(strategy.addMetadata(metadata)).resolves.toBeUndefined();
+    await expect(strategy.removeMetadata(metadata)).resolves.toBeUndefined();
 
     const representation = { data: 'data!' } as any;
     await expect(strategy.validate(representation)).resolves.toBeUndefined();

--- a/test/unit/ldp/auxiliary/LinkMetadataGenerator.test.ts
+++ b/test/unit/ldp/auxiliary/LinkMetadataGenerator.test.ts
@@ -20,20 +20,31 @@ describe('A LinkMetadataGenerator', (): void => {
     generator = new LinkMetadataGenerator(link, strategy);
   });
 
-  it('can handle all metadata.', async(): Promise<void> => {
-    await expect(generator.canHandle(null as any)).resolves.toBeUndefined();
-  });
-
   it('stores no metadata if the input is an associated resource.', async(): Promise<void> => {
     const metadata = new RepresentationMetadata(auxiliaryId);
-    await expect(generator.handle(metadata)).resolves.toBeUndefined();
+    await expect(generator.add(metadata)).resolves.toBeUndefined();
     expect(metadata.quads()).toHaveLength(0);
   });
 
   it('uses the stored link to add metadata for associated resources.', async(): Promise<void> => {
     const metadata = new RepresentationMetadata(associatedId);
-    await expect(generator.handle(metadata)).resolves.toBeUndefined();
+    await expect(generator.add(metadata)).resolves.toBeUndefined();
     expect(metadata.quads()).toHaveLength(1);
     expect(metadata.get(link)?.value).toBe(auxiliaryId.path);
+  });
+
+  it('removes no metadata if the input is an associated resource.', async(): Promise<void> => {
+    const metadata = new RepresentationMetadata(auxiliaryId);
+    metadata.add(link, 'val');
+    await expect(generator.remove(metadata)).resolves.toBeUndefined();
+    expect(metadata.quads()).toHaveLength(1);
+  });
+
+  it('removes metadata that was added by the `add` call.', async(): Promise<void> => {
+    const metadata = new RepresentationMetadata(associatedId);
+    await expect(generator.add(metadata)).resolves.toBeUndefined();
+    expect(metadata.quads()).toHaveLength(1);
+    await expect(generator.remove(metadata)).resolves.toBeUndefined();
+    expect(metadata.quads()).toHaveLength(0);
   });
 });

--- a/test/unit/ldp/auxiliary/RoutingAuxiliaryStrategy.test.ts
+++ b/test/unit/ldp/auxiliary/RoutingAuxiliaryStrategy.test.ts
@@ -35,6 +35,10 @@ class SimpleSuffixStrategy implements AuxiliaryStrategy {
     // Empty fn
   }
 
+  public async removeMetadata(): Promise<void> {
+    // Empty fn
+  }
+
   public async validate(): Promise<void> {
     // Always validates
   }
@@ -75,6 +79,27 @@ describe('A RoutingAuxiliaryStrategy', (): void => {
     expect(sources[0].addMetadata).toHaveBeenCalledTimes(0);
     expect(sources[1].addMetadata).toHaveBeenCalledTimes(1);
     expect(sources[1].addMetadata).toHaveBeenLastCalledWith(metadata);
+  });
+
+  it('#removeMetadata removes the metadata of all sources for the base identifier.', async(): Promise<void> => {
+    sources[0].removeMetadata = jest.fn();
+    sources[1].removeMetadata = jest.fn();
+    const metadata = new RepresentationMetadata(baseId);
+    await expect(strategy.removeMetadata(metadata)).resolves.toBeUndefined();
+    expect(sources[0].removeMetadata).toHaveBeenCalledTimes(1);
+    expect(sources[0].removeMetadata).toHaveBeenLastCalledWith(metadata);
+    expect(sources[1].removeMetadata).toHaveBeenCalledTimes(1);
+    expect(sources[1].removeMetadata).toHaveBeenLastCalledWith(metadata);
+  });
+
+  it('#removeMetadata removes the metadata of the correct source for aux identifiers.', async(): Promise<void> => {
+    sources[0].removeMetadata = jest.fn();
+    sources[1].removeMetadata = jest.fn();
+    const metadata = new RepresentationMetadata(dummy2Id);
+    await expect(strategy.removeMetadata(metadata)).resolves.toBeUndefined();
+    expect(sources[0].removeMetadata).toHaveBeenCalledTimes(0);
+    expect(sources[1].removeMetadata).toHaveBeenCalledTimes(1);
+    expect(sources[1].removeMetadata).toHaveBeenLastCalledWith(metadata);
   });
 
   it('#isRootRequired returns the result of the correct source.', async(): Promise<void> => {

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -21,9 +21,8 @@ import type { Guarded } from '../../../src/util/GuardedStream';
 import { SingleRootIdentifierStrategy } from '../../../src/util/identifiers/SingleRootIdentifierStrategy';
 import { trimTrailingSlashes } from '../../../src/util/PathUtil';
 import { guardedStreamFrom } from '../../../src/util/StreamUtil';
-import { CONTENT_TYPE, SOLID_HTTP, LDP, PIM, RDF } from '../../../src/util/Vocabularies';
-import quad = DataFactory.quad;
-import namedNode = DataFactory.namedNode;
+import { CONTENT_TYPE, SOLID_HTTP, LDP, PIM, RDF, PREFERRED_PREFIX_TERM, DC } from '../../../src/util/Vocabularies';
+const { literal, namedNode, quad } = DataFactory;
 
 class SimpleDataAccessor implements DataAccessor {
   public readonly data: Record<string, Representation> = {};
@@ -179,6 +178,7 @@ describe('A DataAccessorBasedStore', (): void => {
       expect(result).toMatchObject({ binary: false });
       expect(await arrayifyStream(result.data)).toBeRdfIsomorphic(metaMirror.quads());
       expect(result.metadata.contentType).toEqual(INTERNAL_QUADS);
+      expect(result.metadata.quads(DC.terms.namespace, PREFERRED_PREFIX_TERM, literal('dc'))).toHaveLength(1);
       expect(result.metadata.get('AUXILIARY')?.value).toBe(auxStrategy.getAuxiliaryIdentifier(resourceID).path);
     });
 
@@ -383,6 +383,8 @@ describe('A DataAccessorBasedStore', (): void => {
         { path: 'http://test.com/resource' },
       ]);
       await expect(arrayifyStream(accessor.data[resourceID.path].data)).resolves.toEqual([ resourceData ]);
+      expect(accessor.data[resourceID.path].metadata.quads(DC.terms.namespace, PREFERRED_PREFIX_TERM, literal('dc')))
+        .toHaveLength(0);
     });
 
     it('can write containers.', async(): Promise<void> => {

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -111,6 +111,10 @@ class SimpleSuffixStrategy implements AuxiliaryStrategy {
     metadata.add(namedNode('AUXILIARY'), this.getAuxiliaryIdentifier(identifier).path);
   }
 
+  public async removeMetadata(metadata: RepresentationMetadata): Promise<void> {
+    metadata.removeAll(namedNode('AUXILIARY'));
+  }
+
   public async validate(): Promise<void> {
     // Always validates
   }
@@ -480,6 +484,19 @@ describe('A DataAccessorBasedStore', (): void => {
       expect(accessor.data[resourceID.path]).toBeTruthy();
       expect(Object.keys(accessor.data)).toHaveLength(1);
       expect(accessor.data[resourceID.path].metadata.contentType).toBeUndefined();
+    });
+
+    it('getting and setting a resource with the result should not change the metadata.', async(): Promise<void> => {
+      const resourceID = { path: `${root}resource` };
+      representation.metadata.identifier = DataFactory.namedNode(resourceID.path);
+      accessor.data[resourceID.path] = representation;
+      const metadata = new RepresentationMetadata(representation.metadata);
+      const result = await store.getRepresentation(resourceID);
+      await expect(store.setRepresentation(resourceID, result)).resolves.toEqual([
+        { path: `${root}` },
+        resourceID,
+      ]);
+      expect(accessor.data[resourceID.path].metadata.quads()).toEqualRdfQuadArray(metadata.quads());
     });
   });
 

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -182,6 +182,11 @@ describe('A FileDataAccessor', (): void => {
 
     it('does not write metadata that is stored by the file system.', async(): Promise<void> => {
       metadata.add(RDF.type, LDP.terms.Resource);
+      metadata.add(RDF.type, LDP.terms.Container);
+      metadata.add(RDF.type, LDP.terms.BasicContainer);
+      metadata.add(DC.terms.modified, '123');
+      metadata.add(POSIX.terms.mtime, '123');
+      metadata.add(POSIX.terms.size, '123');
       await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata)).resolves.toBeUndefined();
       expect(cache.data.resource).toBe('data');
       expect(cache.data['resource.meta']).toBeUndefined();


### PR DESCRIPTION
Closes #774, depends on #781 .

This solves the problem of writing metadata that we generated ourselves during a PATCH. To solve this we have to make sure that everything that generates metadata also has a similar function to remove that metadata again.

I'm not completely convinced this is the best solution to this problem as it sort of doubles the workload needed to add metadata. Specifically in the third commit the `MetadataGenerator` and `AuxiliaryStrategy` interfaces had to change to also have a function to remove the metadata again.

Another solution could have been to move to only add the metadata in a layer that encapsulates the patching store, that way it would never see that metadata. This would then still cause problems for users who want to update data locally and PUT the results back.