### PR TITLE
fix: Correctly render internal IDP errors

### DIFF
--- a/src/identity/IdentityProviderFactory.ts
+++ b/src/identity/IdentityProviderFactory.ts
@@ -84,6 +84,8 @@ export class IdentityProviderFactory {
       },
       renderError:
         async(ctx: KoaContextWithOIDC, out: ErrorOut, error: Error): Promise<void> => {
+          // This allows us to stream directly to to the response object, see https://github.com/koajs/koa/issues/944
+          ctx.respond = false;
           const preferences: RepresentationPreferences = { type: { 'text/plain': 1 }};
           const result = await this.errorHandler.handleSafe({ error, preferences });
           await this.responseWriter.handleSafe({ response: ctx.res, result });

--- a/test/integration/Identity.test.ts
+++ b/test/integration/Identity.test.ts
@@ -335,13 +335,20 @@ describe('A Solid server with IDP', (): void => {
     });
   });
 
-  describe('openid-configuration', (): void => {
-    it('should contain solid_oidc_supported key.', async(): Promise<void> => {
+  describe('setup', (): void => {
+    it('should contain the required configuration keys.', async(): Promise<void> => {
       const res = await fetch(`${baseUrl}.well-known/openid-configuration`);
       const jsonBody = await res.json();
 
       expect(res.status).toBe(200);
+      // https://solid.github.io/authentication-panel/solid-oidc/#discovery
       expect(jsonBody.solid_oidc_supported).toEqual('https://solidproject.org/TR/solid-oidc');
+    });
+
+    it('should return correct error output.', async(): Promise<void> => {
+      const res = await fetch(`${baseUrl}idp/auth`);
+      expect(res.status).toBe(400);
+      await expect(res.text()).resolves.toContain('InvalidRequest: invalid_request');
     });
   });
 });


### PR DESCRIPTION
Accidentally stumbled upon this. Due to the oidc library using koa internally there was an issue piping the error output since we switched to the new error writing. The new integration test fails before this change (the error text isn't written).