### PR TITLE
fix: Support BGPs with variables in SPARQL UPDATE queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1221,10 +1221,97 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@comunica/actor-abstract-bindings-hash": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.21.1.tgz",
+      "integrity": "sha512-+EmT/v5hB7La9yXotDZRp7GchYLGO/acg0h9NttZQN8+qp1Llyln+3WriqcVxbbRe1Wqc3DL8Hd9eKAOkAVT7w==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "canonicalize": "^1.0.1",
+        "hash.js": "^1.1.7",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
     "@comunica/actor-abstract-mediatyped": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.20.0.tgz",
       "integrity": "sha512-GcPhuxLYrLU526nqoCYE1ddFNNDu6xcOkxlUGNqgs/HqkfQ4+8OaC2N7NfVGPsYZ+N+iRExQa4qND6uLL+tJxQ=="
+    },
+    "@comunica/actor-abstract-path": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.21.1.tgz",
+      "integrity": "sha512-9hehsgOSaLDAH4oZccGMEScAiE+4DayTXkjaiQkOobSiHp6dbXgS46vIkWUaSYQGikmgYfkM+j4qwDT33Wl28w==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-context-preprocess-source-to-destination": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-1.21.1.tgz",
+      "integrity": "sha512-yGfNEAJo90XvIMbGZtoip4rR2t28ArfIZmkXo1+E50/Hkp5KFeBwJO/f7ZwH0Svy/5C0wbmCMZpQm+IFV2Cxbg=="
+    },
+    "@comunica/actor-http-memento": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.21.1.tgz",
+      "integrity": "sha512-FRG5CgeOzu8GyaSLtwkLPWX26WWcYKbLx1EpSGJJUq5MBn8Blrcji6G/dwn6hADn4rBI8MErwiA52SJX/p89yw==",
+      "requires": {
+        "@comunica/context-entries": "^1.21.1",
+        "@types/parse-link-header": "^1.0.0",
+        "cross-fetch": "^3.0.5",
+        "parse-link-header": "^1.0.1"
+      }
     },
     "@comunica/actor-http-native": {
       "version": "1.19.2",
@@ -1242,6 +1329,1679 @@
       "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.19.2.tgz",
       "integrity": "sha512-b/yP6TbpEBOac5gtX+4lxF6cd+/mI0WQiYUZGhRQZ2gUEcU0js0Gte9uqz1wCVxIQJnMbOryso3tCVFw/CZNJg=="
     },
+    "@comunica/actor-init-sparql": {
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.21.3.tgz",
+      "integrity": "sha512-R7auYy7gppLt0nUAc+Y+3mjYmwaLzr02PTx9XGO/ojUi/LnCuU2lrS2Fik90b9N3kg5kDJYN/znT/XHpy5vdGg==",
+      "requires": {
+        "@comunica/actor-abstract-bindings-hash": "^1.21.1",
+        "@comunica/actor-abstract-mediatyped": "^1.21.1",
+        "@comunica/actor-context-preprocess-source-to-destination": "^1.21.1",
+        "@comunica/actor-http-memento": "^1.21.1",
+        "@comunica/actor-http-native": "^1.21.3",
+        "@comunica/actor-http-proxy": "^1.21.1",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^1.21.1",
+        "@comunica/actor-query-operation-ask": "^1.21.1",
+        "@comunica/actor-query-operation-bgp-empty": "^1.21.1",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.21.2",
+        "@comunica/actor-query-operation-bgp-single": "^1.21.1",
+        "@comunica/actor-query-operation-construct": "^1.21.1",
+        "@comunica/actor-query-operation-describe-subject": "^1.21.1",
+        "@comunica/actor-query-operation-distinct-hash": "^1.21.1",
+        "@comunica/actor-query-operation-extend": "^1.21.2",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.21.2",
+        "@comunica/actor-query-operation-from-quad": "^1.21.1",
+        "@comunica/actor-query-operation-group": "^1.21.1",
+        "@comunica/actor-query-operation-join": "^1.21.1",
+        "@comunica/actor-query-operation-leftjoin-left-deep": "^1.21.1",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.21.2",
+        "@comunica/actor-query-operation-minus": "^1.21.1",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.21.2",
+        "@comunica/actor-query-operation-path-alt": "^1.21.1",
+        "@comunica/actor-query-operation-path-inv": "^1.21.1",
+        "@comunica/actor-query-operation-path-link": "^1.21.1",
+        "@comunica/actor-query-operation-path-nps": "^1.21.1",
+        "@comunica/actor-query-operation-path-one-or-more": "^1.21.1",
+        "@comunica/actor-query-operation-path-seq": "^1.21.1",
+        "@comunica/actor-query-operation-path-zero-or-more": "^1.21.1",
+        "@comunica/actor-query-operation-path-zero-or-one": "^1.21.1",
+        "@comunica/actor-query-operation-project": "^1.21.1",
+        "@comunica/actor-query-operation-quadpattern": "^1.21.1",
+        "@comunica/actor-query-operation-reduced-hash": "^1.21.1",
+        "@comunica/actor-query-operation-service": "^1.21.1",
+        "@comunica/actor-query-operation-slice": "^1.21.1",
+        "@comunica/actor-query-operation-sparql-endpoint": "^1.21.2",
+        "@comunica/actor-query-operation-union": "^1.21.1",
+        "@comunica/actor-query-operation-update-add-rewrite": "^1.21.1",
+        "@comunica/actor-query-operation-update-clear": "^1.21.1",
+        "@comunica/actor-query-operation-update-compositeupdate": "^1.21.1",
+        "@comunica/actor-query-operation-update-copy-rewrite": "^1.21.1",
+        "@comunica/actor-query-operation-update-create": "^1.21.1",
+        "@comunica/actor-query-operation-update-deleteinsert": "^1.21.1",
+        "@comunica/actor-query-operation-update-drop": "^1.21.1",
+        "@comunica/actor-query-operation-update-load": "^1.21.1",
+        "@comunica/actor-query-operation-update-move-rewrite": "^1.21.1",
+        "@comunica/actor-query-operation-values": "^1.21.1",
+        "@comunica/actor-rdf-dereference-fallback": "^1.21.1",
+        "@comunica/actor-rdf-dereference-http-parse": "^1.21.2",
+        "@comunica/actor-rdf-join-multi-smallest": "^1.21.1",
+        "@comunica/actor-rdf-join-nestedloop": "^1.21.1",
+        "@comunica/actor-rdf-join-symmetrichash": "^1.21.1",
+        "@comunica/actor-rdf-metadata-all": "^1.21.1",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.21.1",
+        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.21.1",
+        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^1.21.1",
+        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.21.2",
+        "@comunica/actor-rdf-metadata-primary-topic": "^1.21.1",
+        "@comunica/actor-rdf-parse-html": "^1.21.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^1.21.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^1.21.1",
+        "@comunica/actor-rdf-parse-html-script": "^1.21.1",
+        "@comunica/actor-rdf-parse-jsonld": "^1.21.2",
+        "@comunica/actor-rdf-parse-n3": "^1.21.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^1.21.1",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^1.21.1",
+        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.21.1",
+        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.21.1",
+        "@comunica/actor-rdf-resolve-hypermedia-none": "^1.21.1",
+        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.21.1",
+        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.21.2",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.21.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.21.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.21.1",
+        "@comunica/actor-rdf-serialize-jsonld": "^1.21.1",
+        "@comunica/actor-rdf-serialize-n3": "^1.21.1",
+        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^1.21.1",
+        "@comunica/actor-rdf-update-quads-hypermedia": "^1.21.1",
+        "@comunica/actor-rdf-update-quads-rdfjs-store": "^1.21.1",
+        "@comunica/actor-sparql-parse-algebra": "^1.21.1",
+        "@comunica/actor-sparql-parse-graphql": "^1.21.1",
+        "@comunica/actor-sparql-serialize-json": "^1.21.1",
+        "@comunica/actor-sparql-serialize-rdf": "^1.21.1",
+        "@comunica/actor-sparql-serialize-simple": "^1.21.1",
+        "@comunica/actor-sparql-serialize-sparql-csv": "^1.21.1",
+        "@comunica/actor-sparql-serialize-sparql-json": "^1.21.1",
+        "@comunica/actor-sparql-serialize-sparql-tsv": "^1.21.1",
+        "@comunica/actor-sparql-serialize-sparql-xml": "^1.21.1",
+        "@comunica/actor-sparql-serialize-stats": "^1.21.1",
+        "@comunica/actor-sparql-serialize-table": "^1.21.1",
+        "@comunica/actor-sparql-serialize-tree": "^1.21.1",
+        "@comunica/bus-context-preprocess": "^1.21.1",
+        "@comunica/bus-http": "^1.21.1",
+        "@comunica/bus-http-invalidate": "^1.21.1",
+        "@comunica/bus-init": "^1.21.1",
+        "@comunica/bus-optimize-query-operation": "^1.21.1",
+        "@comunica/bus-query-operation": "^1.21.1",
+        "@comunica/bus-rdf-dereference": "^1.21.1",
+        "@comunica/bus-rdf-dereference-paged": "^1.21.1",
+        "@comunica/bus-rdf-join": "^1.21.1",
+        "@comunica/bus-rdf-metadata": "^1.21.1",
+        "@comunica/bus-rdf-metadata-extract": "^1.21.1",
+        "@comunica/bus-rdf-parse": "^1.21.1",
+        "@comunica/bus-rdf-parse-html": "^1.21.1",
+        "@comunica/bus-rdf-resolve-hypermedia": "^1.21.1",
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.21.1",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^1.21.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
+        "@comunica/bus-rdf-serialize": "^1.21.1",
+        "@comunica/bus-rdf-update-hypermedia": "^1.21.1",
+        "@comunica/bus-rdf-update-quads": "^1.21.1",
+        "@comunica/bus-sparql-parse": "^1.21.1",
+        "@comunica/bus-sparql-serialize": "^1.21.1",
+        "@comunica/context-entries": "^1.21.1",
+        "@comunica/core": "^1.21.1",
+        "@comunica/logger-pretty": "^1.21.1",
+        "@comunica/logger-void": "^1.21.1",
+        "@comunica/mediator-all": "^1.21.1",
+        "@comunica/mediator-combine-pipeline": "^1.21.1",
+        "@comunica/mediator-combine-union": "^1.21.1",
+        "@comunica/mediator-number": "^1.21.1",
+        "@comunica/mediator-race": "^1.21.1",
+        "@comunica/runner": "^1.21.1",
+        "@comunica/runner-cli": "^1.21.1",
+        "@types/minimist": "^1.2.0",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "minimist": "^1.2.0",
+        "negotiate": "^1.0.1",
+        "rdf-quad": "^1.4.0",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.5.5",
+        "streamify-string": "^1.0.1"
+      },
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.21.1.tgz",
+          "integrity": "sha512-5LzWccqId3AfAeCPGqPkOiDATXrooXYLn58sNXDRdDUsRpL/jZ6be+7F000ZLTHnDRVCiLCXtb5P7984bBIzaA=="
+        },
+        "@comunica/actor-http-native": {
+          "version": "1.21.3",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.21.3.tgz",
+          "integrity": "sha512-DX/IECNsUpMXNgZyz8e5d/Bpq9PSmlABs7rUqkMVXgqhnOO0KvJOEuWu4P9+ONlkbzqK4O7DKMi6gw3GkKI3OA==",
+          "requires": {
+            "@comunica/context-entries": "^1.21.1",
+            "@types/parse-link-header": "^1.0.0",
+            "cross-fetch": "^3.0.5",
+            "follow-redirects": "^1.5.1",
+            "parse-link-header": "^1.0.1"
+          }
+        },
+        "@comunica/actor-http-proxy": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.21.1.tgz",
+          "integrity": "sha512-Z3NvOzZeffZ+aRBZVg3apbVSNjYvAUE49oOL+BrBtT5CuEf+RUOCcSOV/UhpITIFg21/uuyaxvJaT5RmfH+xzw=="
+        },
+        "@comunica/actor-rdf-dereference-http-parse": {
+          "version": "1.21.2",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.21.2.tgz",
+          "integrity": "sha512-TLQLw6rKkcslHyyYFpELy+Oc9KuLZbqxiOpMUQQqfi1/yLT/8C0dvQSTl0dOtKombSn4N3aFsA0ycbjuPWi01w==",
+          "requires": {
+            "cross-fetch": "^3.0.5",
+            "relative-to-absolute-iri": "^1.0.5"
+          }
+        },
+        "@comunica/actor-rdf-parse-html": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.21.1.tgz",
+          "integrity": "sha512-eZUExtLtC28nEMrECL2g3kmZjLmuY/Nu7S9p5NyvI60cwEjj1Rbf0aM9xqWLG5vuCiSKQz7MUobQ92WxtG6RHA==",
+          "requires": {
+            "@comunica/bus-rdf-parse-html": "^1.21.1",
+            "@types/rdf-js": "*",
+            "htmlparser2": "^6.0.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-html-rdfa": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.21.1.tgz",
+          "integrity": "sha512-37whUUn3LsvCV/kj37/ztAnBjGqKdGP8fLUpD3z8vDOg3ArhktPvWn+cB0ssU0DKSzsCTnCNujS7QoVyINPxJQ==",
+          "requires": {
+            "rdfa-streaming-parser": "^1.4.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-html-script": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.21.1.tgz",
+          "integrity": "sha512-cM06ZEVpgj4/fLFrM8alRi0a4kh1XVY3vwWOyZXnkjVkIKp36Nc17Pw4+vM10z7D+x5VI/mZc0tGMohr8u7dcw==",
+          "requires": {
+            "@comunica/bus-rdf-parse-html": "^1.21.1",
+            "@types/rdf-js": "*",
+            "relative-to-absolute-iri": "^1.0.5"
+          }
+        },
+        "@comunica/actor-rdf-parse-jsonld": {
+          "version": "1.21.2",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.21.2.tgz",
+          "integrity": "sha512-YUiYo2EJ9T1oUGgBwzzPRjXT+cd/xckWbtfYBzr7RugXeKjrVai8atnV1OsPc0u5iPZCTkiVCO9sI/Q6M7ig2w==",
+          "requires": {
+            "@comunica/context-entries": "^1.21.1",
+            "@types/rdf-js": "*",
+            "jsonld-context-parser": "^2.1.2",
+            "jsonld-streaming-parser": "^2.3.2",
+            "stream-to-string": "^1.2.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-n3": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.21.1.tgz",
+          "integrity": "sha512-SFx/hkY0yr/TxfVdEecVg3DY2KOWPeGfM288CjDQjogx6Sxb6JuF9JaipNX8/twKVdBefGS9b1S9EyKpcr99Zg==",
+          "requires": {
+            "@types/n3": "^1.4.4",
+            "n3": "^1.6.3"
+          }
+        },
+        "@comunica/actor-rdf-parse-rdfxml": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.21.1.tgz",
+          "integrity": "sha512-fv5+DF5LagSJUayyQm7a917XQ9PNUfJVh2bqO/NlVfESXO8OFUAIySefW+j1y1JA0fpa5v1OnWTGAfdxGKnrUg==",
+          "requires": {
+            "rdfxml-streaming-parser": "^1.4.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-xml-rdfa": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.21.1.tgz",
+          "integrity": "sha512-+9qyKJS+Ab3BWqrWnFU5CSgEDGtoGJpe19TzpymSXDP0aSAM6lnkZpCvT3EKi/Y8Bmw9xRXJZwemtxQK2y4SSQ==",
+          "requires": {
+            "rdfa-streaming-parser": "^1.3.0"
+          }
+        },
+        "@comunica/actor-rdf-serialize-jsonld": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.21.1.tgz",
+          "integrity": "sha512-qQhLt00drQMJRlOkuPOjhPdgDQtezRW53LQ5cGa3otnFU1t7e6l9+PnKjjniXGaXLlxBLJV7tdkcDkqVL0XRww==",
+          "requires": {
+            "jsonld-streaming-serializer": "^1.2.0"
+          }
+        },
+        "@comunica/actor-rdf-serialize-n3": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.21.1.tgz",
+          "integrity": "sha512-NGiczuyG9rNiY3F3cs8U1kT8EWWGxz50rmtWBnsMgHPNfXHk9Aztc1rWS8SEHTSK/PH0NK/fRe4p65Iq4TDfCA==",
+          "requires": {
+            "@types/n3": "^1.4.4",
+            "@types/rdf-js": "*",
+            "n3": "^1.6.3",
+            "rdf-string": "^1.5.0"
+          }
+        },
+        "@comunica/bus-http": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.21.1.tgz",
+          "integrity": "sha512-M6gi128ME+7uSnLPz4Bx3jgXhIb5/O7tODVHAtw9gt0z/9AAuYfmW9jqmcZ5Uwv3CCvJSvEc/m+dooCv35dTsA==",
+          "requires": {
+            "@comunica/context-entries": "^1.21.1",
+            "is-stream": "^2.0.0",
+            "web-streams-node": "^0.4.0"
+          }
+        },
+        "@comunica/bus-init": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.21.1.tgz",
+          "integrity": "sha512-h8Gp/iJiyY8mbqhrbfLySwTXasjxmCX6kpM9RyXWqCBJzdx8Bfq6F/nYg2N+zpEJgyrn5zLdNgbBkcDetdeAmA=="
+        },
+        "@comunica/bus-rdf-dereference": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.21.1.tgz",
+          "integrity": "sha512-gejQdUmWCtXzlrSIVwVBuTtijLncO88hpqZjqkNo+WKTilCT9GdXSqRw137GX6ZPsBXKf/Pztupid3oUPG+2xg==",
+          "requires": {
+            "@comunica/context-entries": "^1.21.1",
+            "@types/rdf-js": "*"
+          }
+        },
+        "@comunica/bus-rdf-parse": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.21.1.tgz",
+          "integrity": "sha512-JQD9Cgml/W+PCSEX3WulwxiQOdULFxAFDipLk69/J9WZxOj6emufxStM8M9R+pavbLaLYRcBQWgO0KLhEn/Rnw==",
+          "requires": {
+            "@comunica/actor-abstract-mediatyped": "^1.21.1",
+            "@types/rdf-js": "*"
+          }
+        },
+        "@comunica/bus-rdf-parse-html": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.21.1.tgz",
+          "integrity": "sha512-DJDFB8lxTJ1Pt+AhjOqe9hvj2nKtC23fJfEihU7DYIbz67O5pXAFgFtp9gn3gefoGB7T/CKoB8y8DcZy8N5u0A==",
+          "requires": {
+            "@types/rdf-js": "*"
+          }
+        },
+        "@comunica/bus-rdf-serialize": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.21.1.tgz",
+          "integrity": "sha512-W0UPwMQbsINBHC1/JKFZLAyIXHW/gXhQFF/YqSvAvK9N38BkhQiBIz5+pZli+NgWz9g7nNUq5A2Jbg5Xmldj8w==",
+          "requires": {
+            "@comunica/actor-abstract-mediatyped": "^1.21.1",
+            "@types/rdf-js": "*"
+          }
+        },
+        "@comunica/core": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.21.1.tgz",
+          "integrity": "sha512-5lY/HkyOCorY2CtxQiKUKEOcUGjIKf/YG/txJrz84SKuy+zC91zq1Zt8qWfzNihCcWrgfmk0oZuvjbYvZGK4EA==",
+          "requires": {
+            "@comunica/context-entries": "^1.21.1",
+            "@comunica/types": "^1.21.1",
+            "immutable": "^3.8.2"
+          }
+        },
+        "@comunica/mediator-combine-union": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.21.1.tgz",
+          "integrity": "sha512-wp2lbViVOOeNKTBRD+6sze7TKVX71T2RD324/1Syb8vOpwT3mtaDNJYFg0Mrwer/Xs54d7nA7JGZA2wC2HaXow=="
+        },
+        "@comunica/mediator-number": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.21.1.tgz",
+          "integrity": "sha512-OeuGx0R/mWI1uMMXM2V1vcR8J1DPhYXPR+Ncg4/qKHl7tSCQH1tlCgZu0+fovY2Qmc14f1tmw5YgnsE8lsikSQ=="
+        },
+        "@comunica/mediator-race": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.21.1.tgz",
+          "integrity": "sha512-SgdtF1JmqDyhZJsAOiVMPuV1qgdXqv/hbsFCxcmDQ+8q1ObmQ+0DZvdUe5Ymf2IyFaevsOHHG7hF5hJbLZmdmQ=="
+        },
+        "@types/node": {
+          "version": "13.13.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
+          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
+        },
+        "jsonld-context-parser": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.1.2.tgz",
+          "integrity": "sha512-zAhus+dz4IrXiYAiYf6M1PSdYkILVWPg4bqqGfim+rGrmVc3d0drFAriLOU2RMwQFKljM+41lJTau47sxt6YWA==",
+          "requires": {
+            "@types/http-link-header": "^1.0.1",
+            "@types/node": "^13.1.0",
+            "canonicalize": "^1.0.1",
+            "cross-fetch": "^3.0.6",
+            "http-link-header": "^1.0.2",
+            "relative-to-absolute-iri": "^1.0.5"
+          }
+        },
+        "jsonld-streaming-parser": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.3.2.tgz",
+          "integrity": "sha512-C9hyL5LRb2K0eaS5biP+ixUtMjr3UPJn9WInNYAmjX9tL7NzeSw3lY7nW3GEnKETxF3I3btvEPR1Nm/+tHMWZQ==",
+          "requires": {
+            "@types/http-link-header": "^1.0.1",
+            "@types/rdf-js": "*",
+            "canonicalize": "^1.0.1",
+            "http-link-header": "^1.0.2",
+            "jsonld-context-parser": "^2.1.2",
+            "jsonparse": "^1.3.1",
+            "rdf-data-factory": "^1.0.4"
+          }
+        },
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-optimize-query-operation-join-bgp": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.21.1.tgz",
+      "integrity": "sha512-4P4MNxEfGZJYE4z9OXTOWWykz0w3h2dtw8p8pLDcXplRIh1U9BaS7rtYVl953PvNfLsc1DS3Kpn0MGEN3NJdGA==",
+      "requires": {
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-ask": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.21.1.tgz",
+      "integrity": "sha512-23sE2Kr+z5UHcgQ+8xGv9dJPxBnv5eavWqSkgIESWEVzBfogvJQ8mMt/2wl1+bvdip0Nme+MJ9/hUYTMqr//ew==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-bgp-empty": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.21.1.tgz",
+      "integrity": "sha512-Y1W7ViP/ZRlcOrWJk7Y2HsU2+qS+qc1A8VGfpKzhwZaIbBS6FUiQnAHkH8eDrO9RtET+zanKxu37+Jnj2n6MyQ==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-bgp-left-deep-smallest": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.21.2.tgz",
+      "integrity": "sha512-7QTQiHFbdZcTxv35SddFzorBuvoQio7KXY/z0hU/JoFr0vx5qtZQFXwrl0dt41xqnJkFGcv1s7U3Zx6Rc1uQZQ==",
+      "requires": {
+        "@comunica/context-entries": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-bgp-single": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.21.1.tgz",
+      "integrity": "sha512-a4xupJleAxeyxA+m8Ghul6AtfBRCMWv5Ftr5DCcZF2j96UCREnSnD1OuMTJfsf7hWV+H9TGJ3gtK1IinB1LxAQ==",
+      "requires": {
+        "@comunica/context-entries": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-construct": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.21.1.tgz",
+      "integrity": "sha512-b1baZhA0py1JEI9xNGtEcHt0VJOMMBkA5tC8ePabNnPXc2Bwn29grzb+PQwkf32rU6tRRgJHRua5EcIZqDRcqg==",
+      "requires": {
+        "@comunica/data-factory": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-describe-subject": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.21.1.tgz",
+      "integrity": "sha512-KGACWNnYRQVqPzaF1iyYiivFfAucnPU6yaJ0mUKoSiMXEwVCIHOZL8m29TMxHqc5AI6C/AZlvddT1MHQ+cFOXw==",
+      "requires": {
+        "@comunica/actor-query-operation-union": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "rdf-data-factory": "^1.0.3",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-distinct-hash": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.21.1.tgz",
+      "integrity": "sha512-DiIwjep3FlUyDNqyenRyN/CxGKOFxfIXDsOupYpQq0H5KSYEVyyYNJao4F+ZvdcLHoSRJkLVW+GTTb8zCbEGbg==",
+      "requires": {
+        "@comunica/actor-abstract-bindings-hash": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-extend": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.21.2.tgz",
+      "integrity": "sha512-dXL7Lrp09CZUU8T6EMXaf4eAMzcSsMpIS5XvU+LjF9u9vMjkTU2EmTpeW5l0WoWQhy9woqL0wTceckfGF3nQRQ==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5",
+        "sparqlee": "^1.6.2"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-filter-sparqlee": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.21.2.tgz",
+      "integrity": "sha512-xPqalmx2a84HzdZ87YVswJYf05Uj/AyRXmtQfHB2XNULzReNLyq56LUs22tOqWDuthzgL/0yTKtzYh8d8J4WVQ==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5",
+        "sparqlee": "^1.6.2"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-from-quad": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.21.1.tgz",
+      "integrity": "sha512-fJ2qk7jb5vouiCYI/S37O9gQg8Ol5Y5vmgzmVj//aTV7/oobI7j0V3hRyrM7pN6RhKK7g9daxoO1rqeZkUBQ7Q==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-group": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-1.21.1.tgz",
+      "integrity": "sha512-oiZEJH/z4sEtk7ImT8yyBHzlHJtvgcocQVoaGJGU+dor6i2qTTMULPdyzYnAYS8bJLczYnpnb5TDakGGn6ijQg==",
+      "requires": {
+        "@comunica/actor-abstract-bindings-hash": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5",
+        "sparqlee": "^1.6.2"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-join": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.21.1.tgz",
+      "integrity": "sha512-x3IwZ61R/nVIgG9+nCVJeaeJZfmfFuFfgdDi2wUFrAPH3C2ebJLinOOiJ/BMR9qYUjxHXm/3R2r35DZyUM03yw==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-leftjoin-left-deep": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-left-deep/-/actor-query-operation-leftjoin-left-deep-1.21.1.tgz",
+      "integrity": "sha512-qUcCPnQzwSVBVipPo0fnQeJt8EWWaBzZ8ujFE9zwlrhuTlZtS/XeoIhtKyIB3LoBx/D5gIGlREdFtz0wTFdJlQ==",
+      "requires": {
+        "@comunica/bus-rdf-join": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-leftjoin-nestedloop": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.21.2.tgz",
+      "integrity": "sha512-O82jBCmkeSy8JMaKfZOqnn3QYHfj/0Z8CRSfYsGV83xjVuXv/hg0QogKmoW9Vl0wJRoVLb/ydpmVXaBFzH3rnw==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "sparqlalgebrajs": "^2.5.5",
+        "sparqlee": "^1.6.2"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-minus": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.21.1.tgz",
+      "integrity": "sha512-3UcQMn5tiAwIRxilfJuhKRFYKYrTsGHyJF8EE4OJMhbPZIZWKlQG298H7u51AOYtTOrmIgU6Wny2U8Ju15IM+w==",
+      "requires": {
+        "@comunica/actor-abstract-bindings-hash": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-orderby-sparqlee": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.21.2.tgz",
+      "integrity": "sha512-datwGMxBhAV6jDPENGmOJGkC9qTGCaOQijWrd0AbeYlThD3GaBeGl+n86xd3sfY3AwGQrkle2DwEhjliXPmtng==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5",
+        "sparqlee": "^1.6.2"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-path-alt": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.21.1.tgz",
+      "integrity": "sha512-YqvCX7fAYGqJnSEDOzF02niFrNWSjHoXF1UOF8uT3fFa+iH9lcnVbWQUkddNieIqlwiLw/BEufnx24XQiogIQA==",
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-path-inv": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.21.1.tgz",
+      "integrity": "sha512-PZuAc50w9TOgO1kESMv+P/wLZrHZMlYJSKpTrr+RikM7pM0t3VemI01qDdL63gCY2UxGh3kTCwYkv1qOx5JZwg==",
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1"
+      }
+    },
+    "@comunica/actor-query-operation-path-link": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.21.1.tgz",
+      "integrity": "sha512-aScmnhisOVmRYUPWOjbzxMO4DHzGmqaRKvoHqVMEF9tgAX5E4nmJ1XvFBE9vzuvY1aBxPm5sHnSYlEtUeGa5Mg==",
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-path-nps": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.21.1.tgz",
+      "integrity": "sha512-HDw1AoshhNiKWeNcACmSwiSquf0PZkPjoN3cTjg/8wOQz3Yf/XEQfdCIJ9R2vMHaIArMlprq5p4MGrf23RkMcw==",
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-path-one-or-more": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.21.1.tgz",
+      "integrity": "sha512-PxOhNKSrgfF5In7DBQOcfZKZRs9o843Cn6Shs1n7Gv0Qa4kbHRFssRe2bL65WTHVNiByghOgOYfUERJfNz0IJQ==",
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-path-seq": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.21.1.tgz",
+      "integrity": "sha512-c1PRbRf18xknqeAMC96FkPzc9Tbz7zGU3FLrDI92Mu5cAcABhAwev3BM1T19UhI/cNkgGkXNa61SkWLVND3oGg==",
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-path-zero-or-more": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.21.1.tgz",
+      "integrity": "sha512-NzgKiD1w+gq/muE9Bd4tQjxfKnVwWm9LMlP8ZBSdZfMQmj4vNAHQhhVHjVPTflElwtB47UlqlRQVxWlP0O79JA==",
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-path-zero-or-one": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.21.1.tgz",
+      "integrity": "sha512-WSNAAlwYm5FBoSOrxX9rZ2VbEQi+k1od738UV4BgoK9YOKZrgDKfj0KhX4niFfnJCjQHAM3iX1GjpsmkYthlSQ==",
+      "requires": {
+        "@comunica/actor-abstract-path": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-project": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.21.1.tgz",
+      "integrity": "sha512-NTxKHCQWUxotmOnp7K4l2r1NbUQv2Ei2VOCfXd99Ix1CDrNlNt0bTDbKjDaQdwFm+wwDM2IoqmkbeLgD4KU3yA==",
+      "requires": {
+        "@comunica/data-factory": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-quadpattern": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.21.1.tgz",
+      "integrity": "sha512-5HmXPT1aU9jpdVaPXeDr7OtKsArQ9xzyZb4KjdfJJPJh5GB5eRX22rA/3xJtb3eugQohNd4miCd8FsfNKx/Lmw==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-reduced-hash": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.21.1.tgz",
+      "integrity": "sha512-MDtwwFeP0+CuloFxDtWXbdAsJyNuN+RLYPUbesBtusH9SmeUQjEVopLHpDp3QsZJB02HLeaz3pLMlVZTwxOQWQ==",
+      "requires": {
+        "@comunica/actor-abstract-bindings-hash": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^6.0.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-service": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.21.1.tgz",
+      "integrity": "sha512-ffIUCnMSTOshFVsVvI8RYTvo3l6nyTinVkl2sxo7O4Cty3jidxA4TScbWPue64sZbbuGvjPb2+2CTvHII2uZjQ==",
+      "requires": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
+        "@comunica/context-entries": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-slice": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.21.1.tgz",
+      "integrity": "sha512-tuV+ccKKSFL5xnrKVKoJohXWxYOy/T+hW+dS+EOA0cTsluYJSd3Pj3JSE7tfxCRjTn8rOtgqOve3rk8NVkRHYA==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-sparql-endpoint": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.21.2.tgz",
+      "integrity": "sha512-Zyy1SgumHMQKziQFujgckXWG46Un1clGLgNObf1tTy4Gj66kWzO8YNZ5nuXVbFY6D1DyAis4vzsZvV1ieKX7gQ==",
+      "requires": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@comunica/utils-datasource": "^1.21.1",
+        "@types/rdf-js": "*",
+        "arrayify-stream": "^1.0.0",
+        "asynciterator": "^3.1.0",
+        "fetch-sparql-endpoint": "^2.0.0",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-union": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.21.1.tgz",
+      "integrity": "sha512-KnFTTt3Eem/KP7J3jt67WryjUb3Ma67Zjs0uvSavhEZ8fDSEtMpU1eEK8WEOvrLPm2gh8u4oBNJ7A1VQbRV+Hg==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-update-add-rewrite": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-add-rewrite/-/actor-query-operation-update-add-rewrite-1.21.1.tgz",
+      "integrity": "sha512-dV0yT36fUBJnLSQuwcdGVr8qyoL0Tu5jbL4ONbhjqAxHP8e4wlqwzQRiZku5ScqgoBmuZ91oeFXnIoQ2EhjCKg==",
+      "requires": {
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-update-clear": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-1.21.1.tgz",
+      "integrity": "sha512-YDhigDrIMLYZeUIJ1uvs5F9HLWPs1+AcYuq6FHrYGhqpqqQ0PyUDsl+LcoI67VvRidLIu3/viecU6Bdvb8Gt6w==",
+      "requires": {
+        "rdf-data-factory": "^1.0.4"
+      }
+    },
+    "@comunica/actor-query-operation-update-compositeupdate": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-1.21.1.tgz",
+      "integrity": "sha512-9odx0936F9WQQZ+K7SChzwDkjyIolwOSTIg7epsp/Z+cltp0ZeLMEJvr9ZYgYf5qxZT4SHxiQ+sjfAYffVSRnQ==",
+      "requires": {
+        "@types/rdf-js": "*"
+      }
+    },
+    "@comunica/actor-query-operation-update-copy-rewrite": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-copy-rewrite/-/actor-query-operation-update-copy-rewrite-1.21.1.tgz",
+      "integrity": "sha512-Ou0oL0e7FHRfWB/3DVko/4ESoxCN9Ue6CasVxUOAN2z9FSMYPV9SF8AgZ8R6LeSwHKeIwXhv2sGg6LiJucxz2Q==",
+      "requires": {
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-update-create": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-1.21.1.tgz",
+      "integrity": "sha512-RgwdyjIOrxldqNndzrONRIjPBAXThyxxGtr8xjB7V7q9TlnLVXlAAD7PrSZcH8MLY0VoPNMOCVR0y9t4TKBt0w=="
+    },
+    "@comunica/actor-query-operation-update-deleteinsert": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-1.21.1.tgz",
+      "integrity": "sha512-BidV3Mn1w4ieQvNgVDHS9hwuyx9Wy+fB5+btuNEh9JHdpkHDZlN0vvqhpExVS1a7bx9cdQUpwouipR6THQ5veQ==",
+      "requires": {
+        "@comunica/actor-query-operation-construct": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0"
+      }
+    },
+    "@comunica/actor-query-operation-update-drop": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-1.21.1.tgz",
+      "integrity": "sha512-v//e5tqsqFsu37A+GfCHBqbOfDhI7J8uRjXPZ8VnuapMeUfLQTZSVGf2xQ+/FD/UDp3/gpERKVC7cRXPzoWEFQ==",
+      "requires": {
+        "rdf-data-factory": "^1.0.4"
+      }
+    },
+    "@comunica/actor-query-operation-update-load": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-1.21.1.tgz",
+      "integrity": "sha512-ql4eAZhwIqF5CjzCcU6vmRaxHwYJTXnLsseBmQzJrgvKNxr3ols0E6sc4tia1IIeRTmHmOz+h7AZD4uyWw+Xrg==",
+      "requires": {
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-update-move-rewrite": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-move-rewrite/-/actor-query-operation-update-move-rewrite-1.21.1.tgz",
+      "integrity": "sha512-T71U+wuWxzpYbVmJ0Sb/FFQY/Vh8nvCDgih4GOFPEI2UhZFYsQ5ilGy8a5xBPeuuuSWvYEvL/+VZPeIp8GZTjA==",
+      "requires": {
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-values": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.21.1.tgz",
+      "integrity": "sha512-BfDg+Lg4snRI4CLdopztaErd040P7y4sflriDCMHEoqVVQuha89Scddcx3ClqOtJx5mScYmjGxkt8ttQwx5MHg==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "asynciterator": "^3.1.0",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-rdf-dereference-fallback": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-fallback/-/actor-rdf-dereference-fallback-1.21.1.tgz",
+      "integrity": "sha512-iXaC7/jUWMJQKoNa9Hm4UouXTJfER/jyK7HQ0q9ddkLvXYTWwcltnnLxs+dXQRbpUZm8NvP/LPUC3H1G85Tzwg=="
+    },
     "@comunica/actor-rdf-dereference-file": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-file/-/actor-rdf-dereference-file-1.19.2.tgz",
@@ -1254,6 +3014,78 @@
       "requires": {
         "cross-fetch": "^3.0.5",
         "relative-to-absolute-iri": "^1.0.5"
+      }
+    },
+    "@comunica/actor-rdf-join-multi-smallest": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-multi-smallest/-/actor-rdf-join-multi-smallest-1.21.1.tgz",
+      "integrity": "sha512-3PmXF6QgNmhYLm0XrN3Fdyr632YwHmv/kngwLdIRZAFyGBOY41vEoyLzbSiQNBCmdT1lJ1qX4tl3yVQkskPCoQ==",
+      "requires": {
+        "@comunica/bus-query-operation": "^1.21.1",
+        "@comunica/mediatortype-iterations": "^1.21.1",
+        "@comunica/types": "^1.21.1"
+      }
+    },
+    "@comunica/actor-rdf-join-nestedloop": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.21.1.tgz",
+      "integrity": "sha512-19zZ7rgPxWgxKJcN2HeimpGj7TCx7yYLWDyhKw9KPra/7Ogc8bKhawOINCEqWdyi0nACQO9G/gXCpakjUmnd8g==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "asyncjoin": "^1.0.3"
+      }
+    },
+    "@comunica/actor-rdf-join-symmetrichash": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-symmetrichash/-/actor-rdf-join-symmetrichash-1.21.1.tgz",
+      "integrity": "sha512-st1NVQ0g/ODC+qf3z+QANNYj5Hngqlq3D+cxI5oswFeTnKVFWWB66DjzO0oiqE3YuUu0aqNoV5Jty4iTyBieig==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "asyncjoin": "^1.0.3"
+      }
+    },
+    "@comunica/actor-rdf-metadata-all": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-1.21.1.tgz",
+      "integrity": "sha512-YbDuyOrBcQ9dzW0WTJ26wr35QxddohjuZ0p7Zs1wNFr6uImkkcL9C12h9QJOA4SRa1//u9DhWxni8AMmn6w/FA==",
+      "requires": {
+        "@types/rdf-js": "*"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-hydra-controls": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.21.1.tgz",
+      "integrity": "sha512-pfZeKwKaYR73QhGHrURGE+cNB5qavKaW6F9EnjkE44maTvyflW8RWog6p8s5dD20FLCKq/OLyLpqBNQ7Z1y04Q==",
+      "requires": {
+        "@types/rdf-js": "*",
+        "@types/uritemplate": "^0.3.4",
+        "uritemplate": "0.3.4"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-hydra-count": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.21.1.tgz",
+      "integrity": "sha512-y7U/hQ/R7iKDa4Y+XBsyjaHVbpuzgq6Zs46Fm1u6nI6ln4e6Cs3sDHZgegzcZ/Orul5+vn61yb0hhO1JxJlOAg=="
+    },
+    "@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-1.21.1.tgz",
+      "integrity": "sha512-mii4UIX2xwAo2SLQsJ1UqS8rMnnREsXQfti+6hAJ81hu4I77YVnC8MJ0McripzqHLXukGPepJlYwNZpbl1KrhA=="
+    },
+    "@comunica/actor-rdf-metadata-extract-sparql-service": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.21.2.tgz",
+      "integrity": "sha512-3sO7giO4UroalkIHGU3KlFQk+OINOvUx3eCdD60nZUvxRBlfUKkSMyYmCbGEY0O9LWvVAXWclnwlKfI+C7mPdQ==",
+      "requires": {
+        "relative-to-absolute-iri": "^1.0.5"
+      }
+    },
+    "@comunica/actor-rdf-metadata-primary-topic": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.21.1.tgz",
+      "integrity": "sha512-aBinVc2+fedm0KzF6NmmDRSGaZyJhPimeTpiQh6Vrm7vPw+J5SuqfXD0AccLJKcWvGMbiRMagWP+lLTBjiMGWw==",
+      "requires": {
+        "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-rdf-parse-html": {
@@ -1328,6 +3160,178 @@
         "rdfa-streaming-parser": "^1.3.0"
       }
     },
+    "@comunica/actor-rdf-resolve-hypermedia-links-next": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-1.21.1.tgz",
+      "integrity": "sha512-x6q1vQ45egXGjX4T4RKFf6A35YNDqMdGIBdTi4LAocKqWnr1Nus2qcVP2oHKXQEDssZHYilq348J98B1Gyz1WA=="
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-1.21.1.tgz",
+      "integrity": "sha512-6h/9Dm/zBRqoLBZcZtV/x0dT3+goC9fIDJHqyzOgVg7Xf9iQsy2yEVfUNkqIWUK9Rh4dWglDfmdLihoZ7GKfMw=="
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-none": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-1.21.1.tgz",
+      "integrity": "sha512-Bm367n52hT2Tl0aGPL7Nao3Vb+SRfOQ0WVXyYRiIYgmgQ8RHuFiyDfj//o0GOmeu2dU6LxvfLK9KJdzvaBSXVw==",
+      "requires": {
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.21.1",
+        "@types/rdf-js": "*",
+        "rdf-store-stream": "^1.2.0"
+      }
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-qpf": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.21.1.tgz",
+      "integrity": "sha512-zgXqBeP8mlSIZEYLZuMVkfE88S67zmrnhtNfQ7iO8wuzgWboeeMhITMZy95/Fh9zKcIV1PSFuSH/BsDOXARHNg==",
+      "requires": {
+        "@comunica/bus-rdf-dereference": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2"
+      },
+      "dependencies": {
+        "@comunica/bus-rdf-dereference": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.21.1.tgz",
+          "integrity": "sha512-gejQdUmWCtXzlrSIVwVBuTtijLncO88hpqZjqkNo+WKTilCT9GdXSqRw137GX6ZPsBXKf/Pztupid3oUPG+2xg==",
+          "requires": {
+            "@comunica/context-entries": "^1.21.1",
+            "@types/rdf-js": "*"
+          }
+        }
+      }
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-sparql": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.21.2.tgz",
+      "integrity": "sha512-q6S9RDxzr00RViBrZ1wUHfzFjkXcHFWfRXbVI0bG2MR/oN9SVySLgSozte9KFjCWiuFc25jsntyB1dfXiH/i6Q==",
+      "requires": {
+        "@comunica/bus-query-operation": "^1.21.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "fetch-sparql-endpoint": "^2.0.0",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-rdf-resolve-quad-pattern-federated": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.21.1.tgz",
+      "integrity": "sha512-Leo6a8wIJ/zIxauRmzdz3bdKpW4tgSJb6QRle9/wP2FgNkimhh+Pt08f7ot2E/49ewgmwHyiv0ha5CQOwRxtqg==",
+      "requires": {
+        "@comunica/context-entries": "^1.21.1",
+        "@comunica/data-factory": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.21.1.tgz",
+      "integrity": "sha512-v8t+QW8mBrisLU2DErhyGo4DKrmLOKUjls2A1THYNSP8d1k1uKg3UDb9CXwezpfk+O4Q/wqtMzxOomJjxlgOaw==",
+      "requires": {
+        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.21.1",
+        "@comunica/bus-rdf-metadata": "^1.21.1",
+        "@comunica/bus-rdf-metadata-extract": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@comunica/utils-datasource": "^1.21.1",
+        "@types/lru-cache": "^5.1.0",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "lru-cache": "^6.0.0",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.21.1.tgz",
+      "integrity": "sha512-bb8v9tUlgL4MhfGhDK7wHnrayF6oogRl4aby3gcWhgrzkGwmQzdTcldtZtdaoVBH5j30WE0dH36aHPxMkRha1w==",
+      "requires": {
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0"
+      }
+    },
     "@comunica/actor-rdf-serialize-jsonld": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.19.0.tgz",
@@ -1347,6 +3351,193 @@
         "rdf-string": "^1.5.0"
       }
     },
+    "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-1.21.1.tgz",
+      "integrity": "sha512-lLYMWc6hShnOFkIfbwW14t9Z9Zqb0hZJBN5trZt/98F39N+QNS5lE0rDeRhXUtXvp2NKrVvXPn/6q67V4Zb68w==",
+      "requires": {
+        "cross-fetch": "^3.0.5"
+      }
+    },
+    "@comunica/actor-rdf-update-quads-hypermedia": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-1.21.1.tgz",
+      "integrity": "sha512-NAKEPf6Gog83/biNo5U2p1KFkb0yzodQCZaUGWGjJIkbB2EEUYJyWBUBCnW5FX70/uXcv/AhhdTA8jAGwVo+5g==",
+      "requires": {
+        "@comunica/bus-rdf-dereference": "^1.21.1",
+        "@comunica/bus-rdf-metadata": "^1.21.1",
+        "@comunica/bus-rdf-metadata-extract": "^1.21.1",
+        "@comunica/bus-rdf-update-hypermedia": "^1.21.1",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "@comunica/bus-rdf-dereference": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.21.1.tgz",
+          "integrity": "sha512-gejQdUmWCtXzlrSIVwVBuTtijLncO88hpqZjqkNo+WKTilCT9GdXSqRw137GX6ZPsBXKf/Pztupid3oUPG+2xg==",
+          "requires": {
+            "@comunica/context-entries": "^1.21.1",
+            "@types/rdf-js": "*"
+          }
+        }
+      }
+    },
+    "@comunica/actor-rdf-update-quads-rdfjs-store": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-1.21.1.tgz",
+      "integrity": "sha512-OexfNx+0eIs201/Ig56IjiN5HNsp3lX1YC7bMwDHPNFWmRhW8XrTnbHED3vPe81Qx/9FgahJHf7fRwHlgUlioQ==",
+      "requires": {
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "rdf-data-factory": "^1.0.4",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "@comunica/actor-sparql-parse-algebra": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.21.1.tgz",
+      "integrity": "sha512-sZVyIfGiMHEG3CaPFYIO9V27sjEgW0nLx95ASSexY+5qYlwEog97CJxP/gblm/fDIsNRQfQgnhQUzyAW7AuYCw==",
+      "requires": {
+        "@types/sparqljs": "^3.0.0",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5",
+        "sparqljs": "^3.4.1"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/actor-sparql-parse-graphql": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.21.1.tgz",
+      "integrity": "sha512-qC2NAjK+ff3CHqsnsiiW8LZJ9V5004wI3gRoIz0stwljGvk3i/gmxs2sWucbi/IpgqFK4eaxQcGc3XTE4E4qig==",
+      "requires": {
+        "graphql-to-sparql": "^2.2.0"
+      }
+    },
+    "@comunica/actor-sparql-serialize-json": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.21.1.tgz",
+      "integrity": "sha512-NuPJzuKVdq435Al5hLnwA3reZXyiYohbM2WTgeffyB45VFNGsx7OBKkMDlprwpbH/XD4PUdQjrwDqwBxzRCXbw==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "@comunica/actor-sparql-serialize-rdf": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.21.1.tgz",
+      "integrity": "sha512-5CIA0LGO0VtCT5DMzOIVSVS1y2D8INkSrsOzOyP1my0fBYK7s0c9O5khaZYI7sBOgjOhAeHz6yECjz7EWmdATw==",
+      "requires": {
+        "@comunica/types": "^1.21.1"
+      }
+    },
+    "@comunica/actor-sparql-serialize-simple": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.21.1.tgz",
+      "integrity": "sha512-2ud0Uc3JlUM0SgRP1BXXGYwFBAmuuJhx8UBIA1K0VmJ7oik8kYaPLROcOFbT6LiamQ6tDoGPgqnZ/08xvuuF0Q==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*"
+      }
+    },
+    "@comunica/actor-sparql-serialize-sparql-csv": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-csv/-/actor-sparql-serialize-sparql-csv-1.21.1.tgz",
+      "integrity": "sha512-Pki5Wi6DI7o6d44xW7jXyq5LfzLUDBNyObuvR8V9LuL5uAcJp2kjJyPkzuv5YNQYG+uFHQT6Xno8bXHSuD+vHA==",
+      "requires": {
+        "@comunica/bus-query-operation": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*"
+      }
+    },
+    "@comunica/actor-sparql-serialize-sparql-json": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.21.1.tgz",
+      "integrity": "sha512-vYvufYI/6j6KZB+J9LE7P7p6DtCtRAI0CBu47YJ4R9AVFvaHUY+OBuznTqEUvYLFGjsfnr/tylKrrPHvGQIPZA==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*"
+      }
+    },
+    "@comunica/actor-sparql-serialize-sparql-tsv": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-tsv/-/actor-sparql-serialize-sparql-tsv-1.21.1.tgz",
+      "integrity": "sha512-AhJH8q2lS+wdha6hRYOSYE0pk9h2tLuh4nAuqO+oOMv/eKOtEJkkKOtt+d3mez7Q1G39vm9WrqEtodPvLWsSkg==",
+      "requires": {
+        "@comunica/bus-query-operation": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "rdf-string-ttl": "^1.1.0"
+      }
+    },
+    "@comunica/actor-sparql-serialize-sparql-xml": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.21.1.tgz",
+      "integrity": "sha512-Xyqo8qF3F7SkLGHmXeHjDF5JqBB5EmpK35JkIHqmVmu2aTS+LfF8d+pMGoWQQn4FRl+IGG4O+sp9B4wXGAW6sw==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "@types/xml": "^1.0.2",
+        "xml": "^1.0.1"
+      }
+    },
+    "@comunica/actor-sparql-serialize-stats": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.21.1.tgz",
+      "integrity": "sha512-vuDzN+8ZWTcSK9fz5F4s0uSEclMTZtKzCBTwdvxDPAQ2zFkbsCPQzZ8Cmn0MxGxUk4sKR7rjY1ELUsD/ZXqprw==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*"
+      }
+    },
+    "@comunica/actor-sparql-serialize-table": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.21.1.tgz",
+      "integrity": "sha512-9iUliyqhXZct+CikD/7KSv/rujeE2odkpNMrJUflTZqtHeb0c90jWxHlgYmfV3u8lQi44F4G5tk33gX3m8O2ag==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "rdf-terms": "^1.6.2"
+      }
+    },
+    "@comunica/actor-sparql-serialize-tree": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.21.1.tgz",
+      "integrity": "sha512-628vwFD/bBcheUyrhLm8LajZV8MjfbTPvVnBuxU6iRkKDTZnqv0pDGltEjGImQuc+3E/2KLk9JuMZquDWClPgQ==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "sparqljson-to-tree": "^2.0.0"
+      }
+    },
+    "@comunica/bus-context-preprocess": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.21.1.tgz",
+      "integrity": "sha512-fJAKiNScSPB82aNjmvJPNAgBdCOJ4Y1oe26brHvyvHgcIyq00sqNxlJXa3C4W1tS/LkyT+lXfG7pheYC8cZzdg=="
+    },
     "@comunica/bus-http": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.19.2.tgz",
@@ -1356,10 +3547,85 @@
         "web-streams-node": "^0.4.0"
       }
     },
+    "@comunica/bus-http-invalidate": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-1.21.1.tgz",
+      "integrity": "sha512-+Kb18K/ukOm8zHSXkYIGXh4cmdyEYsF/aTyVRsSyB5FHijuZCQ5p4PEgYjsurWSinfC76WOtONf3qLmkDAXErg=="
+    },
     "@comunica/bus-init": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.19.2.tgz",
       "integrity": "sha512-SVIcKPSrPlHxrndsKX650ijrOPMyBdZZkDe/mLXUKNq7cSerdQZtP6w95u7/fnBwjwXOAMjPiyP3L07rD6KAcA=="
+    },
+    "@comunica/bus-optimize-query-operation": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.21.1.tgz",
+      "integrity": "sha512-LTWYILQC//EYhWfokp/BluI0ND++31kQNjWRlXrnVHsriieptMx6bEFsWU3qbc8LapLvBj9VVOGfHzXZieYghg==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/bus-query-operation": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.21.1.tgz",
+      "integrity": "sha512-sofM518TRNPZzLlL08cIoF5cGR3PFSXykgRMp4P+eCtsbrgnoSXx3sBOimO96VUV3BSZsWAJzXxAOeaRPM8XOQ==",
+      "requires": {
+        "@comunica/context-entries": "^1.21.1",
+        "@comunica/data-factory": "^1.21.1",
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "immutable": "^3.8.2",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
     },
     "@comunica/bus-rdf-dereference": {
       "version": "1.19.2",
@@ -1367,6 +3633,69 @@
       "integrity": "sha512-vK73nWJh1xF5Br1NFNX0Lx8nF6NDwKwgMzxqIxOj/gOxUJgTFOaWm7/brYc38ITSrDfYOAmlL4p2bGMNkdfm2A==",
       "requires": {
         "@types/rdf-js": "*"
+      }
+    },
+    "@comunica/bus-rdf-dereference-paged": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.21.1.tgz",
+      "integrity": "sha512-E0SQt34A9y9ffa01+NnyXNPazY3ckmr/qmKsWbfNWnVMtgVKqRb3GnydOktYL5jLvNcAaEN1w9AnRxqM6VtoFw==",
+      "requires": {
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0"
+      }
+    },
+    "@comunica/bus-rdf-join": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.21.1.tgz",
+      "integrity": "sha512-O2rBiE2TiEWO1H04b3GQcSg46zV8gpeh6+Fx8Swr+XDV5W4aMvGxl+OsblstAY0cFCb1zNBokozAh6eYTLh3Wg==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0"
+      }
+    },
+    "@comunica/bus-rdf-metadata": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.21.1.tgz",
+      "integrity": "sha512-THCujnE/utBRzc6uJAuB9TKm2PIVphgr1UyWufLrcVG6UBIFYpsff67aZF35brBE85rnpGbyHxwDGh521lg7qw==",
+      "requires": {
+        "@types/rdf-js": "*"
+      }
+    },
+    "@comunica/bus-rdf-metadata-extract": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.21.1.tgz",
+      "integrity": "sha512-Q1T54qlM3Vpev6H4Y/BuMpfz+Qi6/UcDeRo/eySovtCpJ2bWi8w/+UNdeGAZhYL9InqO9qJ2PUn+TiQ/sGIojg==",
+      "requires": {
+        "@comunica/types": "^1.21.1",
+        "@types/rdf-js": "*",
+        "graphql-ld": "^1.2.0",
+        "rdf-store-stream": "^1.2.0",
+        "sparqlalgebrajs": "^2.5.5",
+        "stream-to-string": "^1.2.0"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-parse": {
@@ -1386,6 +3715,60 @@
         "@types/rdf-js": "*"
       }
     },
+    "@comunica/bus-rdf-resolve-hypermedia": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.21.1.tgz",
+      "integrity": "sha512-eXjeGv86pw4SQAIEVtinwxCxYAwnaBaXqMxHMlplfBLcr2S2g0X5uxWbH9jQPpegvpQF8mX6y9VuslPC0ZzGMg==",
+      "requires": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0"
+      }
+    },
+    "@comunica/bus-rdf-resolve-hypermedia-links": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-1.21.1.tgz",
+      "integrity": "sha512-+g1s+Csz019Ma7YscdYwYCaVvodKggjPpI4yaM60dd/FQZIY9bMRlXr35k9b4HiIvQK4BEAUX/y9bkaSdbSJ5A=="
+    },
+    "@comunica/bus-rdf-resolve-hypermedia-links-queue": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-1.21.1.tgz",
+      "integrity": "sha512-GAn27HnCw2pQW8974jjEKlFfi6i89QAYIUqw5w3VlYc8lbyaSDO4G+7rKt1mgIA/FHtxwXNgeRWUkxEdMZd3tA=="
+    },
+    "@comunica/bus-rdf-resolve-quad-pattern": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.21.1.tgz",
+      "integrity": "sha512-3gxbhHBAC62GqVZx567+yee1Y1gpjfLQ59dHC04cRsYPRfWg+5pYAizFFlP+R1dR8StIcR89WRzZpmmZRrkVhg==",
+      "requires": {
+        "@comunica/context-entries": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
     "@comunica/bus-rdf-serialize": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.19.0.tgz",
@@ -1393,6 +3776,71 @@
       "requires": {
         "@comunica/actor-abstract-mediatyped": "^1.19.0",
         "@types/rdf-js": "*"
+      }
+    },
+    "@comunica/bus-rdf-update-hypermedia": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-1.21.1.tgz",
+      "integrity": "sha512-XnL2muy5bj3ldFa0IUjrytkFvCB6KMfuCC1QnP4ezh+atykColkIab1MbR7M2stsmeRiSMbEtSaE/RS7i5r8CQ==",
+      "requires": {
+        "@comunica/bus-rdf-update-quads": "^1.21.1"
+      }
+    },
+    "@comunica/bus-rdf-update-quads": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-1.21.1.tgz",
+      "integrity": "sha512-Ue/n+BimHe97mKPMpIDu26mD2SYse2+NvbpoqTfi7wIojcwmQwRiZoOxXupXOmIbWzmcCfNAIH2+1ZMoUCz3QQ==",
+      "requires": {
+        "@comunica/context-entries": "^1.21.1",
+        "@types/rdf-js": "*",
+        "asynciterator": "^3.1.0"
+      }
+    },
+    "@comunica/bus-sparql-parse": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.21.1.tgz",
+      "integrity": "sha512-vSY4O5CD7wxRWY78ZO+ZRSBYBOnxAcz9meqe58Y31B4jdPg7YggZLQ+095t9P4BZqRVeIrseCddDiyEpG1iJDw==",
+      "requires": {
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@comunica/bus-sparql-serialize": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.21.1.tgz",
+      "integrity": "sha512-qxKe1idPxVsfcdq8EPTDNB2P54fnXe+3vvaWeS1uG5yY1LMh39hSRGR/bz8BSsO1CZBytNvNjEaUnfFrWQcYuA==",
+      "requires": {
+        "@comunica/actor-abstract-mediatyped": "^1.21.1",
+        "@comunica/types": "^1.21.1"
+      },
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": {
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.21.1.tgz",
+          "integrity": "sha512-5LzWccqId3AfAeCPGqPkOiDATXrooXYLn58sNXDRdDUsRpL/jZ6be+7F000ZLTHnDRVCiLCXtb5P7984bBIzaA=="
+        }
       }
     },
     "@comunica/context-entries": {
@@ -1408,6 +3856,34 @@
         "immutable": "^3.8.2"
       }
     },
+    "@comunica/data-factory": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/data-factory/-/data-factory-1.21.1.tgz",
+      "integrity": "sha512-bMAyc0YvBFR7n1olpk1kDLh5SYrVNnInPq9Ceh/FJiEwlvFOJBTGB949HHIXmRWAjuUDwSSFQRX74M9kURCHzQ==",
+      "requires": {
+        "@types/rdf-js": "*"
+      }
+    },
+    "@comunica/logger-pretty": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.21.1.tgz",
+      "integrity": "sha512-69aolnWF0fGSn3D+aniLuglbTW1/ZuG9WkWEzSfdzAHrdAlj7GjN+mT50C3C16rBUGZIMLt8gl7thfqpIgN6hQ=="
+    },
+    "@comunica/logger-void": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.21.1.tgz",
+      "integrity": "sha512-uw5rc7GmMNygcV8xkQEKKpLI36AfW4WSXKUbOODHXhfmq26LpYmKmZzwYTqYoUzeokHTljD5rEOILfCBDtb+1A=="
+    },
+    "@comunica/mediator-all": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-1.21.1.tgz",
+      "integrity": "sha512-QfY4LCVeZa/UTWNRTbXi9KsK1Vru//eYcKpqYqqKOnoD1hltfFFrxHF8ekO9yB++Z487IRhk8Z8SFwU4yjYP9g=="
+    },
+    "@comunica/mediator-combine-pipeline": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.21.1.tgz",
+      "integrity": "sha512-H9b5ItQ216OO05fzwNOhueuaR5v2EeYcJCZFBwDzsqngVG2mHxclm53568ALZqGlLOTxQccCOEJEUj7Z21swtQ=="
+    },
     "@comunica/mediator-combine-union": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.19.2.tgz",
@@ -1422,6 +3898,27 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.19.2.tgz",
       "integrity": "sha512-F+PxeAWTrMEW0s48oaV5h3YrywoO3vPqCgSKyDfRx2YtjJX3SjJduGVNsKKCK4oWNG/NINOg3eUaTG8p4JMbWQ=="
+    },
+    "@comunica/mediatortype-iterations": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-iterations/-/mediatortype-iterations-1.21.1.tgz",
+      "integrity": "sha512-UmPlJS4ryt4QoYKlsYugfTsTAioWeiX3OPye3yKTjVW31V2iq9CCaWALFm2engutjf24R3lU73JRcINr9K6Q3g=="
+    },
+    "@comunica/runner": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.21.1.tgz",
+      "integrity": "sha512-yFeHvFLGHTYXlROK6xKoWLnW0Wx0jL+NRzvB3izIXc+p34bOuua8sjmGFQzW0OU7/04S0xM8BUTG2n33s26yUw==",
+      "requires": {
+        "componentsjs": "^4.0.6"
+      }
+    },
+    "@comunica/runner-cli": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.21.1.tgz",
+      "integrity": "sha512-T25yhU+2WJrP0xcYYpKiCPFSedy5Ml8/3geuPgU/FZZijma2jb9+PA1R9n9Mayr+Eqj37G6blcjgZ2cIVpo4aA==",
+      "requires": {
+        "@comunica/runner": "^1.21.1"
+      }
     },
     "@comunica/types": {
       "version": "1.21.1",
@@ -1455,6 +3952,16 @@
             "rdf-data-factory": "^1.0.4"
           }
         }
+      }
+    },
+    "@comunica/utils-datasource": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.21.1.tgz",
+      "integrity": "sha512-4xCOa0j7y972haYZWcNMfuHzOjyjOmM3dj6+wacW243P1VmsPv7xwb7sY4s+VcdmX6AcEEGM5wZ+3fm/mSgR6g==",
+      "requires": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
+        "@comunica/context-entries": "^1.21.1",
+        "asynciterator": "^3.1.0"
       }
     },
     "@dabh/diagnostics": {
@@ -2998,8 +5505,7 @@
     "@types/lru-cache": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
-      "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==",
-      "dev": true
+      "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
     },
     "@types/mime": {
       "version": "1.3.2",
@@ -3191,6 +5697,11 @@
         "@types/node": "*"
       }
     },
+    "@types/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-82E/lVRaqelV9qmRzzJ1PKTpyrpnT7mwdneKNJB9hUtypZDMggloDfFUCIqRRx3lYRxteCwXSq9c+W71Vf0QnQ=="
+    },
     "@types/sparqljs": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.0.tgz",
@@ -3232,6 +5743,11 @@
         "@types/superagent": "*"
       }
     },
+    "@types/uritemplate": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uritemplate/-/uritemplate-0.3.4.tgz",
+      "integrity": "sha512-1D8mJEeQEXynoPQKJkneIK+tXaM2Qnk6c80RBQPV/O2ToypI4mlqXy5jojnYKjTX2Q+EMNMOWt0wNdLbb2MUpA=="
+    },
     "@types/url-join": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-4.0.0.tgz",
@@ -3246,6 +5762,14 @@
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.0.tgz",
       "integrity": "sha512-Y29uQ3Uy+58bZrFLhX36hcI3Np37nqWE7ky5tjiDoy1GDZnIwVxS0CgF+s+1bXMzjKBFy+fqaRfb708iNzdinw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/xml": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/xml/-/xml-1.0.5.tgz",
+      "integrity": "sha512-h3PVM7waRi2UeoaY2BhpLGvettU/3vfCbsjXMV/9Ex5WjvIy82J8Qfp1xiPxM4kTSOLdFFpjRwQ7YY7XJeKBvg==",
       "requires": {
         "@types/node": "*"
       }
@@ -3783,6 +6307,14 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.1.0.tgz",
       "integrity": "sha512-+iDz8roOCGT+hvhhJ+GsQliEEB4Qd1QL1RIsllssZ3MkrtBGqc5Uwi3n5LcLp2f3rXRK07+qJPZQO+YvFCQzug=="
+    },
+    "asyncjoin": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/asyncjoin/-/asyncjoin-1.0.3.tgz",
+      "integrity": "sha512-wBlf3sOdmUwbFW+zq1HBeOLdQAThSaFfTcdTFZGdB6OVR5VsIKZTycIC8ykDnzJhaZH2OaP23tru1DlLJvrRjA==",
+      "requires": {
+        "asynciterator": "^3.0.0"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -5050,8 +7582,7 @@
     "decimal.js": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
-      "dev": true
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -6712,6 +9243,82 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
+    },
+    "graphql": {
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
+      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw=="
+    },
+    "graphql-ld": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-ld/-/graphql-ld-1.2.0.tgz",
+      "integrity": "sha512-CEYmJcFCW7EumwOFdTVqo5cEv53VJLll5rNWQ29YOWLM6HKLzuWB+TBf40I4Eub+xai1Q7oFD9xguhq/rg9oaw==",
+      "requires": {
+        "@types/rdf-js": "*",
+        "graphql-to-sparql": "^2.2.0",
+        "jsonld-context-parser": "^2.1.0",
+        "sparqlalgebrajs": "^2.4.0",
+        "sparqljson-to-tree": "^2.1.0"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
+    "graphql-to-sparql": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-2.2.0.tgz",
+      "integrity": "sha512-RHe8mpmYtUreOLhvjbgwJKNGwQsvDyMdHNj+x4REgX7V02QSZvbpHE2IG6c0TO1DjbLRNUK7/2pRUhfq8FDLeA==",
+      "requires": {
+        "@types/rdf-js": "*",
+        "graphql": "^15.0.0",
+        "jsonld-context-parser": "^2.0.2",
+        "minimist": "^1.2.0",
+        "rdf-data-factory": "^1.0.3",
+        "sparqlalgebrajs": "^2.4.0"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
     },
     "handlebars": {
       "version": "4.7.6",
@@ -9922,6 +12529,11 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "negotiate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/negotiate/-/negotiate-1.0.1.tgz",
+      "integrity": "sha1-NayLVnL3sF+qEL8CYTQusRIDcP0="
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -11114,6 +13726,14 @@
         "rdf-data-factory": "^1.0.0"
       }
     },
+    "rdf-string-ttl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-string-ttl/-/rdf-string-ttl-1.1.0.tgz",
+      "integrity": "sha512-c+CYNhrOhYF3sRuyBuwxSPRdyBDJOm6mX3FhIKrvPsAKmYE8uVtXuBoAiORc/UW7zYoM+CKmqtgkiFsqOz+6Jg==",
+      "requires": {
+        "rdf-data-factory": "^1.0.2"
+      }
+    },
     "rdf-terms": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.6.2.tgz",
@@ -11696,6 +14316,11 @@
         }
       }
     },
+    "spark-md5": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.1.tgz",
+      "integrity": "sha512-0tF3AGSD1ppQeuffsLDIOWlKUd3lS92tFxcsrh5Pe3ZphhnoK+oXIBTzOAThZCiuINZLvpiLH/1VS1/ANEJVig=="
+    },
     "sparqlalgebrajs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-3.0.0.tgz",
@@ -11759,6 +14384,48 @@
         }
       }
     },
+    "sparqlee": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-1.6.2.tgz",
+      "integrity": "sha512-Wvp1wYrbzxHEEb4rXw7SfxILhrl+YlDBv4mS4FJqJxFpZbblgPIKlscyif8kB4kezJXCxXExzV/ArN231jKrfg==",
+      "requires": {
+        "@types/rdf-js": "^4.0.0",
+        "@types/spark-md5": "^3.0.2",
+        "@types/uuid": "^8.0.0",
+        "decimal.js": "^10.2.0",
+        "hash.js": "^1.1.7",
+        "immutable": "^3.8.2",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "relative-to-absolute-iri": "^1.0.6",
+        "spark-md5": "^3.0.1",
+        "sparqlalgebrajs": "^2.4.0",
+        "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "sparqlalgebrajs": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.5.tgz",
+          "integrity": "sha512-sG9XI5311mS+JPDaeZUwtwYaYDRiTZDzxtHVS1GSrnfcZ2aiK1fa1PX9z16l7dtS35X3z1j1qyHEElzZO5OM3A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "minimist": "^1.2.5",
+            "rdf-data-factory": "^1.0.4",
+            "rdf-isomorphic": "^1.2.0",
+            "rdf-string": "^1.5.0",
+            "sparqljs": "^3.3.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.4.2.tgz",
+          "integrity": "sha512-MmmZ6cMuvhf4Eh2FXX21dalgADUiZ9WN8XKMedwhTFg0r7W09/o8wvoZ8C4yA6FptnjjAjm+mGnxAEpkSRY3QQ==",
+          "requires": {
+            "rdf-data-factory": "^1.0.4"
+          }
+        }
+      }
+    },
     "sparqljs": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.1.2.tgz",
@@ -11783,6 +14450,15 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.51.tgz",
           "integrity": "sha512-66/xg5I5Te4oGi5Jws11PtNmKkZbOPZWyBZZ/l5AOrWj1Dyw+6Ge/JhYTq/2/Yvdqyhrue8RL+DGI298OJ0xcg=="
         }
+      }
+    },
+    "sparqljson-to-tree": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sparqljson-to-tree/-/sparqljson-to-tree-2.1.0.tgz",
+      "integrity": "sha512-LwEMlrvjzEigatJ8iw1RKGWL9dKmATQNbTEXyadzsOQxbBhJNaGk8G9/WPCcVj2zlCPKGMysfNGb4UfvwHKeSw==",
+      "requires": {
+        "rdf-literal": "^1.2.0",
+        "sparqljson-parse": "^1.6.0"
       }
     },
     "sparqlxml-parse": {
@@ -11905,6 +14581,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/streamify-array/-/streamify-array-1.0.1.tgz",
       "integrity": "sha512-ZnswaBcC6B1bhPLSQOlC6CdaDUSzU0wr2lvvHpbHNms8V7+DLd8uEAzDAWpsjxbFkijBHhuObFO/qqu52DZUMA=="
+    },
+    "streamify-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/streamify-string/-/streamify-string-1.0.1.tgz",
+      "integrity": "sha1-niIN4z4cR13TDgIG9bGBXMbJUls="
     },
     "string-length": {
       "version": "4.0.2",
@@ -12651,6 +15332,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "uritemplate": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/uritemplate/-/uritemplate-0.3.4.tgz",
+      "integrity": "sha1-BdCoU/+8iw9Jqj1NKtd3sNHuBww="
+    },
     "url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -12980,6 +15666,11 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "templates"
   ],
   "dependencies": {
+    "@comunica/actor-init-sparql": "^1.21.3",
     "@rdfjs/data-model": "^1.2.0",
     "@rdfjs/fetch": "^2.1.0",
     "@solid/identity-token-verifier": "^0.8.0",
@@ -119,7 +120,6 @@
     "punycode": "^2.1.1",
     "rdf-parse": "^1.7.0",
     "rdf-serialize": "^1.1.0",
-    "rdf-terms": "^1.5.1",
     "redis": "^3.0.2",
     "redlock": "^4.2.0",
     "sparqlalgebrajs": "^3.0.0",


### PR DESCRIPTION
Closes #784 and closes #15 (sort of).

Depends on #781.

The checks are there to make sure we only support BGP queries, but there's not really anything stopping us from allowing everything. At that point we could even remove the algebra body parser since we now only use it for validating.