### PR TITLE
Remove generated metadata by using metadata graphs

### DIFF
--- a/src/ldp/auxiliary/LinkMetadataGenerator.ts
+++ b/src/ldp/auxiliary/LinkMetadataGenerator.ts
@@ -1,4 +1,5 @@
 import { namedNode } from '@rdfjs/data-model';
+import { SOLID_META } from '../../util/Vocabularies';
 import type { RepresentationMetadata } from '../representation/RepresentationMetadata';
 import type { AuxiliaryIdentifierStrategy } from './AuxiliaryIdentifierStrategy';
 import { MetadataGenerator } from './MetadataGenerator';
@@ -22,7 +23,9 @@ export class LinkMetadataGenerator extends MetadataGenerator {
   public async handle(metadata: RepresentationMetadata): Promise<void> {
     const identifier = { path: metadata.identifier.value };
     if (!this.identifierStrategy.isAuxiliaryIdentifier(identifier)) {
-      metadata.add(this.link, namedNode(this.identifierStrategy.getAuxiliaryIdentifier(identifier).path));
+      metadata.add(this.link,
+        namedNode(this.identifierStrategy.getAuxiliaryIdentifier(identifier).path),
+        SOLID_META.terms.ResponseMetadata);
     }
   }
 }

--- a/src/storage/accessors/FileDataAccessor.ts
+++ b/src/storage/accessors/FileDataAccessor.ts
@@ -15,7 +15,7 @@ import { joinFilePath, isContainerIdentifier } from '../../util/PathUtil';
 import { parseQuads, serializeQuads } from '../../util/QuadUtil';
 import { addResourceMetadata } from '../../util/ResourceUtil';
 import { toLiteral } from '../../util/TermUtil';
-import { CONTENT_TYPE, DC, LDP, POSIX, RDF, XSD } from '../../util/Vocabularies';
+import { CONTENT_TYPE, DC, LDP, POSIX, RDF, SOLID_META, XSD } from '../../util/Vocabularies';
 import type { FileIdentifierMapper, ResourceLink } from '../mapping/FileIdentifierMapper';
 import type { DataAccessor } from './DataAccessor';
 
@@ -319,10 +319,14 @@ export class FileDataAccessor implements DataAccessor {
    * @param stats - Stats of the file/directory corresponding to the resource.
    */
   private addPosixMetadata(metadata: RepresentationMetadata, stats: Stats): void {
-    metadata.add(DC.terms.modified, toLiteral(stats.mtime.toISOString(), XSD.terms.dateTime));
-    metadata.add(POSIX.terms.mtime, toLiteral(Math.floor(stats.mtime.getTime() / 1000), XSD.terms.integer));
+    metadata.add(DC.terms.modified,
+      toLiteral(stats.mtime.toISOString(), XSD.terms.dateTime),
+      SOLID_META.terms.ResponseMetadata);
+    metadata.add(POSIX.terms.mtime,
+      toLiteral(Math.floor(stats.mtime.getTime() / 1000), XSD.terms.integer),
+      SOLID_META.terms.ResponseMetadata);
     if (!stats.isDirectory()) {
-      metadata.add(POSIX.terms.size, toLiteral(stats.size, XSD.terms.integer));
+      metadata.add(POSIX.terms.size, toLiteral(stats.size, XSD.terms.integer), SOLID_META.terms.ResponseMetadata);
     }
   }
 

--- a/src/util/TermUtil.ts
+++ b/src/util/TermUtil.ts
@@ -38,17 +38,17 @@ export function isTerm(input?: any): input is Term {
 }
 
 /**
- * Converts a subject to a named node when needed.
+ * Converts a string to a named node when needed.
  * @param subject - Subject to potentially transform.
  */
-export function toSubjectTerm(subject: string): NamedNode;
-export function toSubjectTerm<T extends Term>(subject: T): T;
-export function toSubjectTerm<T extends Term>(subject: T | string): T | NamedNode;
-export function toSubjectTerm(subject: Term | string): Term {
+export function toNamedTerm(subject: string): NamedNode;
+export function toNamedTerm<T extends Term>(subject: T): T;
+export function toNamedTerm<T extends Term>(subject: T | string): T | NamedNode;
+export function toNamedTerm(subject: Term | string): Term {
   return typeof subject === 'string' ? namedNode(subject) : subject;
 }
 
-export const toPredicateTerm = toSubjectTerm;
+export const toPredicateTerm = toNamedTerm;
 
 /**
  * Converts an object term when needed.

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -128,6 +128,11 @@ export const SOLID_HTTP = createUriAndTermNamespace('urn:npm:solid:community-ser
   'slug',
 );
 
+export const SOLID_META = createUriAndTermNamespace('urn:npm:solid:community-server:meta:',
+  // This identifier is used as graph for all metadata that is generated on the fly and should not be stored
+  'ResponseMetadata',
+);
+
 export const VANN = createUriAndTermNamespace('http://purl.org/vocab/vann/',
   'preferredNamespacePrefix',
 );

--- a/test/unit/ldp/auxiliary/LinkMetadataGenerator.test.ts
+++ b/test/unit/ldp/auxiliary/LinkMetadataGenerator.test.ts
@@ -2,6 +2,7 @@ import type { AuxiliaryIdentifierStrategy } from '../../../../src/ldp/auxiliary/
 import { LinkMetadataGenerator } from '../../../../src/ldp/auxiliary/LinkMetadataGenerator';
 import { RepresentationMetadata } from '../../../../src/ldp/representation/RepresentationMetadata';
 import type { ResourceIdentifier } from '../../../../src/ldp/representation/ResourceIdentifier';
+import { SOLID_META } from '../../../../src/util/Vocabularies';
 
 describe('A LinkMetadataGenerator', (): void => {
   const link = 'link';
@@ -35,5 +36,6 @@ describe('A LinkMetadataGenerator', (): void => {
     await expect(generator.handle(metadata)).resolves.toBeUndefined();
     expect(metadata.quads()).toHaveLength(1);
     expect(metadata.get(link)?.value).toBe(auxiliaryId.path);
+    expect(metadata.getAll(link, SOLID_META.terms.ResponseMetadata)).toHaveLength(1);
   });
 });

--- a/test/unit/ldp/representation/RepresentationMetadata.test.ts
+++ b/test/unit/ldp/representation/RepresentationMetadata.test.ts
@@ -150,13 +150,13 @@ describe('A RepresentationMetadata', (): void => {
     it('can add a quad.', async(): Promise<void> => {
       const newQuad = quad(namedNode('random'), namedNode('new'), literal('triple'));
       metadata.addQuad('random', 'new', 'triple');
-      expect(metadata.quads()).toBeRdfIsomorphic(inputQuads.concat([ newQuad ]));
+      expect(metadata.quads()).toBeRdfIsomorphic([ ...inputQuads, newQuad ]);
     });
 
     it('can add a quad with a graph.', async(): Promise<void> => {
       const newQuad = quad(namedNode('random'), namedNode('new'), literal('triple'), namedNode('graph'));
       metadata.addQuad('random', 'new', 'triple', 'graph');
-      expect(metadata.quads()).toBeRdfIsomorphic(inputQuads.concat([ newQuad ]));
+      expect(metadata.quads()).toBeRdfIsomorphic([ ...inputQuads, newQuad ]);
     });
 
     it('can add quads.', async(): Promise<void> => {

--- a/test/unit/ldp/representation/RepresentationMetadata.test.ts
+++ b/test/unit/ldp/representation/RepresentationMetadata.test.ts
@@ -1,18 +1,35 @@
 import 'jest-rdf';
-import { literal, namedNode, quad } from '@rdfjs/data-model';
-import type { Literal, NamedNode, Quad } from 'rdf-js';
+import { defaultGraph, literal, namedNode, quad } from '@rdfjs/data-model';
+import type { NamedNode, Quad } from 'rdf-js';
 import { RepresentationMetadata } from '../../../../src/ldp/representation/RepresentationMetadata';
 import { CONTENT_TYPE } from '../../../../src/util/Vocabularies';
+
+// Helper functions to filter quads
+function getQuads(quads: Quad[], subject?: string, predicate?: string, object?: string, graph?: string): Quad[] {
+  return quads.filter((qq): boolean =>
+    (!subject || qq.subject.value === subject) &&
+    (!predicate || qq.predicate.value === predicate) &&
+    (!object || qq.object.value === object) &&
+    (!graph || qq.graph.value === graph));
+}
+
+function removeQuads(quads: Quad[], subject?: string, predicate?: string, object?: string, graph?: string): Quad[] {
+  const filtered = getQuads(quads, subject, predicate, object, graph);
+  return quads.filter((qq): boolean => !filtered.includes(qq));
+}
 
 describe('A RepresentationMetadata', (): void => {
   let metadata: RepresentationMetadata;
   const identifier = namedNode('http://example.com/id');
+  const graphNode = namedNode('http://graph');
   const inputQuads = [
     quad(identifier, namedNode('has'), literal('data')),
     quad(identifier, namedNode('has'), literal('moreData')),
     quad(identifier, namedNode('hasOne'), literal('otherData')),
+    quad(identifier, namedNode('has'), literal('data'), graphNode),
     quad(namedNode('otherNode'), namedNode('linksTo'), identifier),
     quad(namedNode('otherNode'), namedNode('has'), literal('otherData')),
+    quad(namedNode('otherNode'), namedNode('graphData'), literal('otherData'), graphNode),
   ];
 
   describe('constructor', (): void => {
@@ -87,8 +104,9 @@ describe('A RepresentationMetadata', (): void => {
     });
 
     it('can query quads.', async(): Promise<void> => {
-      expect(metadata.quads(null, namedNode('has'), null)).toHaveLength(3);
-      expect(metadata.quads(null, null, literal('otherData'))).toHaveLength(2);
+      expect(metadata.quads(null, namedNode('has'))).toHaveLength(getQuads(inputQuads, undefined, 'has').length);
+      expect(metadata.quads(null, null, literal('otherData')))
+        .toHaveLength(getQuads(inputQuads, undefined, undefined, 'otherData').length);
     });
 
     it('can change the stored identifier.', async(): Promise<void> => {
@@ -96,10 +114,10 @@ describe('A RepresentationMetadata', (): void => {
       metadata.identifier = newIdentifier;
       const newQuads = inputQuads.map((triple): Quad => {
         if (triple.subject.equals(identifier)) {
-          return quad(newIdentifier, triple.predicate, triple.object);
+          return quad(newIdentifier, triple.predicate, triple.object, triple.graph);
         }
         if (triple.object.equals(identifier)) {
-          return quad(triple.subject, triple.predicate, newIdentifier);
+          return quad(triple.subject, triple.predicate, newIdentifier, triple.graph);
         }
         return triple;
       });
@@ -129,12 +147,36 @@ describe('A RepresentationMetadata', (): void => {
       expect(metadata.quads()).toBeRdfIsomorphic(expectedMetadata.quads());
     });
 
+    it('can add a quad.', async(): Promise<void> => {
+      const newQuad = quad(namedNode('random'), namedNode('new'), literal('triple'));
+      metadata.addQuad('random', 'new', 'triple');
+      expect(metadata.quads()).toBeRdfIsomorphic(inputQuads.concat([ newQuad ]));
+    });
+
+    it('can add a quad with a graph.', async(): Promise<void> => {
+      const newQuad = quad(namedNode('random'), namedNode('new'), literal('triple'), namedNode('graph'));
+      metadata.addQuad('random', 'new', 'triple', 'graph');
+      expect(metadata.quads()).toBeRdfIsomorphic(inputQuads.concat([ newQuad ]));
+    });
+
     it('can add quads.', async(): Promise<void> => {
       const newQuads: Quad[] = [
         quad(namedNode('random'), namedNode('new'), namedNode('triple')),
       ];
       metadata.addQuads(newQuads);
       expect(metadata.quads()).toBeRdfIsomorphic([ ...newQuads, ...inputQuads ]);
+    });
+
+    it('can remove a quad.', async(): Promise<void> => {
+      const old = inputQuads[0];
+      metadata.removeQuad(old.subject as any, old.predicate as any, old.object as any, old.graph as any);
+      expect(metadata.quads()).toBeRdfIsomorphic(inputQuads.slice(1));
+    });
+
+    it('removes all matching triples if graph is undefined.', async(): Promise<void> => {
+      metadata.removeQuad(identifier, 'has', 'data');
+      expect(metadata.quads()).toHaveLength(inputQuads.length - 2);
+      expect(metadata.quads()).toBeRdfIsomorphic(removeQuads(inputQuads, identifier.value, 'has', 'data'));
     });
 
     it('can remove quads.', async(): Promise<void> => {
@@ -164,30 +206,46 @@ describe('A RepresentationMetadata', (): void => {
     });
 
     it('can remove a single value for a predicate.', async(): Promise<void> => {
-      metadata.remove(inputQuads[0].predicate as NamedNode, inputQuads[0].object as Literal);
-      expect(metadata.quads()).toBeRdfIsomorphic(inputQuads.slice(1));
+      metadata.remove(namedNode('has'), literal('data'));
+      expect(metadata.quads()).toBeRdfIsomorphic(removeQuads(inputQuads, identifier.value, 'has', 'data'));
     });
 
     it('can remove single values as string.', async(): Promise<void> => {
-      metadata.remove(inputQuads[0].predicate as NamedNode, inputQuads[0].object.value);
-      expect(metadata.quads()).toBeRdfIsomorphic(inputQuads.slice(1));
+      metadata.remove(namedNode('has'), 'data');
+      expect(metadata.quads()).toBeRdfIsomorphic(removeQuads(inputQuads, identifier.value, 'has', 'data'));
     });
 
     it('can remove multiple values for a predicate.', async(): Promise<void> => {
-      metadata.remove(namedNode('has'), [ inputQuads[0].object, inputQuads[1].object ] as NamedNode[]);
-      expect(metadata.quads()).toBeRdfIsomorphic(inputQuads.slice(2));
+      metadata.remove(namedNode('has'), [ literal('data'), 'moreData' ]);
+      let expected = removeQuads(inputQuads, identifier.value, 'has', 'data');
+      expected = removeQuads(expected, identifier.value, 'has', 'moreData');
+      expect(metadata.quads()).toBeRdfIsomorphic(expected);
     });
 
     it('can remove all values for a predicate.', async(): Promise<void> => {
       const pred = namedNode('has');
       metadata.removeAll(pred);
-      const updatedNodes = inputQuads.filter((triple): boolean =>
-        !triple.subject.equals(identifier) || !triple.predicate.equals(pred));
-      expect(metadata.quads()).toBeRdfIsomorphic(updatedNodes);
+      expect(metadata.quads()).toBeRdfIsomorphic(removeQuads(inputQuads, identifier.value, 'has'));
+    });
+
+    it('can remove all values for a predicate in a specific graph.', async(): Promise<void> => {
+      const pred = namedNode('has');
+      metadata.removeAll(pred, graphNode);
+      expect(metadata.quads()).toBeRdfIsomorphic(
+        removeQuads(inputQuads, identifier.value, 'has', undefined, graphNode.value),
+      );
     });
 
     it('can get all values for a predicate.', async(): Promise<void> => {
-      expect(metadata.getAll(namedNode('has'))).toEqualRdfTermArray([ literal('data'), literal('moreData') ]);
+      expect(metadata.getAll(namedNode('has'))).toEqualRdfTermArray(
+        [ literal('data'), literal('moreData'), literal('data') ],
+      );
+    });
+
+    it('can get all values for a predicate in a graph.', async(): Promise<void> => {
+      expect(metadata.getAll(namedNode('has'), defaultGraph())).toEqualRdfTermArray(
+        [ literal('data'), literal('moreData') ],
+      );
     });
 
     it('can get the single value for a predicate.', async(): Promise<void> => {

--- a/test/unit/util/TermUtil.test.ts
+++ b/test/unit/util/TermUtil.test.ts
@@ -2,7 +2,7 @@ import 'jest-rdf';
 import { literal, namedNode } from '@rdfjs/data-model';
 import {
   toCachedNamedNode,
-  toSubjectTerm,
+  toNamedTerm,
   toPredicateTerm,
   toObjectTerm,
   toLiteral,
@@ -45,11 +45,11 @@ describe('TermUtil', (): void => {
   describe('toSubjectTerm function', (): void => {
     it('returns the input if it was a term.', async(): Promise<void> => {
       const nn = namedNode('name');
-      expect(toSubjectTerm(nn)).toBe(nn);
+      expect(toNamedTerm(nn)).toBe(nn);
     });
 
     it('returns a named node when a string is used.', async(): Promise<void> => {
-      expect(toSubjectTerm('nn')).toEqualRdfTerm(namedNode('nn'));
+      expect(toNamedTerm('nn')).toEqualRdfTerm(namedNode('nn'));
     });
   });
 


### PR DESCRIPTION
Closes #774 .

Alternative solution to #782 .

In #782 the solution is to force all functions that generate metadata to also have a function that removes the same metadata.

The solution in this PR is to assign that metadata to a specific graph and then remove that entire graph from the metadata before storing it in the backend.

This second solution makes many things a lot easier, as it no longer requires double the work when generating metadata. The main issue with this one is that introducing graphs into the metadata might complicate certain things and make it harder to understand how to use it. I tried to keep everything working as it used to in case no graphs are mentioned. In general the idea is that it shouldn't matter in which graph the metadata is stored when requesting information. Things can go wrong now though if the same information would be stored in different graphs so that's something that needs to be remembered when writing metadata.

Opinions are welcome. Personally I prefer this one due to it requiring less work and also have more potential for extensability in the future.

Note that none of these solutions solves the issue of patching containers since there the problem is in the body itself.