### PR TITLE
Fix idp styles for small screens

### DIFF
--- a/templates/idp/email-password-interaction/main.css
+++ b/templates/idp/email-password-interaction/main.css
@@ -2884,6 +2884,7 @@ body, html {
   background-repeat: no-repeat;
   padding-bottom: 60px;
   padding-top: 60px;
+  overflow: auto;
 }
 
 .main-content-section {


### PR DESCRIPTION
The current styles don't work properly in small screens (see the screenshots below for an example).

This could be fixed in other ways, for example moving the background to the `body` and fixing the margins in the card. But this is the quickest way I found without changing too much code. I'm also not familiar with the rest of the styles, so if there's anyone who knows more about the codebase and knows a better fix, please go ahead :).

<details>

<summary>Screenshots</summary>

Before:
![Screenshot from 2021-07-09 10-11-16](https://user-images.githubusercontent.com/1517677/125046283-28450a80-e09e-11eb-82df-8a982c0677c0.png)

After:
![Screenshot from 2021-07-09 10-11-45](https://user-images.githubusercontent.com/1517677/125046289-2aa76480-e09e-11eb-9e16-c74fefeae714.png)

</details>
