### PR TITLE
test: Add github actions for conformance test harness

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,39 @@
+name: Conformance test harness
+
+on:
+  schedule:
+    - cron: '23 5 * * *'
+  push:
+    branches:
+     - test/conformance
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+      - name: Check out the project
+        uses: actions/checkout@v2
+      - name: Install dependencies and run build scripts
+        run: npm ci
+      - name: Start the server in the background
+        run: npm start &
+      - name: Create the necessary folders
+        run: mkdir -p reports/css
+      - name: Pull the conformance harness docker
+        run: docker pull solidconformancetestbeta/conformance-test-harness
+      - name: Wait until the server has started
+        run: |
+          until $(curl --output /dev/null --silent --head --fail -k http://localhost:3000/); do
+            sleep 1
+          done
+      - name: Run the test harness
+        run: >
+          docker run -i --rm
+          -v "$(pwd)"/reports/css:/reports
+          --env-file=./test/deploy/conformance.env
+          --network="host" solidconformancetestbeta/conformance-test-harness
+          --output=/reports --target=css

--- a/test/deploy/conformance.env
+++ b/test/deploy/conformance.env
@@ -1,0 +1,11 @@
+SOLID_IDENTITY_PROVIDER=http://localhost:3000/idp
+USER_REGISTRATION_ENDPOINT=http://localhost:3000/idp/register
+USERS_ALICE_WEBID=http://localhost:3000/alice/profile/card#me
+USERS_ALICE_USERNAME=alice@alice.mail
+USERS_ALICE_PASSWORD=pass1234
+USERS_BOB_WEBID=http://localhost:3000/bob/profile/card#me
+USERS_BOB_USERNAME=bob@bob.mail
+USERS_BOB_PASSWORD=pass1234
+RESOURCE_SERVER_ROOT=http://localhost:3000
+TEST_CONTAINER=/alice/
+quarkus.log.category."ResultLogger".level=INFO


### PR DESCRIPTION
Closes #789 .

I initially based this on the script at https://github.com/solid/conformance-test-harness/blob/main/scripts/css.sh which uses a docker container, but since the action is already contained anyway the script now just installs locally. This saves us a few steps and doesn't require the https setup. I still have the version that uses docker should that be preferred.

Example output at https://github.com/solid/community-server/runs/3068099528 . The relevant step is "Run the test harness". The logger is configured to also output JSON at the end should we want to parse these results. Currently nothing is done with these results yet though.