### PR TITLE
feat: Move all metadata file knowledge to file mapper

### DIFF
--- a/src/pods/generate/variables/RootFilePathHandler.ts
+++ b/src/pods/generate/variables/RootFilePathHandler.ts
@@ -21,7 +21,7 @@ export class RootFilePathHandler extends VariableHandler {
 
   public async handle({ identifier, settings }: { identifier: ResourceIdentifier; settings: PodSettings }):
   Promise<void> {
-    const path = (await this.fileMapper.mapUrlToFilePath(identifier)).filePath;
+    const path = (await this.fileMapper.mapUrlToFilePath(identifier, false)).filePath;
     try {
       // Even though we check if it already exists, there is still a potential race condition
       // in between this check and the store being created.

--- a/src/storage/mapping/FileIdentifierMapper.ts
+++ b/src/storage/mapping/FileIdentifierMapper.ts
@@ -13,6 +13,10 @@ export interface ResourceLink {
    * Content-type for a document (not defined for containers).
    */
   contentType?: string;
+  /**
+   * If the resource is a metadata file.
+   */
+  isMetadata: boolean;
 }
 
 /**
@@ -33,11 +37,13 @@ export interface FileIdentifierMapper {
    * If there is no corresponding file a file path will be generated.
    * For containers the content-type input gets ignored.
    * @param identifier - The input identifier.
+   * @param isMetadata - If we are mapping the metadata of the resource instead of its data.
    * @param contentType - The (optional) content-type of the resource.
    *
    * @returns A ResourceLink with all the necessary metadata.
    */
-  mapUrlToFilePath: (identifier: ResourceIdentifier, contentType?: string) => Promise<ResourceLink>;
+  mapUrlToFilePath: (identifier: ResourceIdentifier, isMetadata: boolean, contentType?: string) =>
+  Promise<ResourceLink>;
 }
 
 /**

--- a/test/unit/pods/generate/TemplatedResourcesGenerator.test.ts
+++ b/test/unit/pods/generate/TemplatedResourcesGenerator.test.ts
@@ -18,11 +18,16 @@ class DummyFactory implements FileIdentifierMapperFactory {
     const trimRoot = trimTrailingSlashes(rootFilePath);
     return {
       async mapFilePathToUrl(filePath: string, isContainer: boolean): Promise<ResourceLink> {
-        const path = `${trimBase}${filePath.slice(trimRoot.length)}`;
+        let path = `${trimBase}${filePath.slice(trimRoot.length)}`;
+        const isMetadata = filePath.endsWith('.meta');
+        if (isMetadata) {
+          path = path.slice(0, -'.meta'.length);
+        }
         return {
           identifier: { path: isContainer ? ensureTrailingSlash(path) : path },
           filePath,
           contentType: isContainer ? undefined : 'text/turtle',
+          isMetadata,
         };
       },
     } as any;

--- a/test/unit/pods/generate/variables/RootFilePathHandler.test.ts
+++ b/test/unit/pods/generate/variables/RootFilePathHandler.test.ts
@@ -23,6 +23,7 @@ describe('A RootFilePathHandler', (): void => {
       mapUrlToFilePath: async(id): Promise<ResourceLink> => ({
         identifier: id,
         filePath: joinFilePath(rootFilePath, id.path.slice(baseUrl.length)),
+        isMetadata: false,
       }),
       mapFilePathToUrl: jest.fn(),
     });

--- a/test/unit/storage/mapping/BaseFileIdentifierMapper.test.ts
+++ b/test/unit/storage/mapping/BaseFileIdentifierMapper.test.ts
@@ -1,5 +1,6 @@
 import { BaseFileIdentifierMapper } from '../../../../src/storage/mapping/BaseFileIdentifierMapper';
 import { BadRequestHttpError } from '../../../../src/util/errors/BadRequestHttpError';
+import { ConflictHttpError } from '../../../../src/util/errors/ConflictHttpError';
 import { NotFoundHttpError } from '../../../../src/util/errors/NotFoundHttpError';
 import { trimTrailingSlashes } from '../../../../src/util/PathUtil';
 
@@ -12,51 +13,71 @@ describe('An BaseFileIdentifierMapper', (): void => {
 
   describe('mapUrlToFilePath', (): void => {
     it('throws 404 if the input path does not contain the base.', async(): Promise<void> => {
-      await expect(mapper.mapUrlToFilePath({ path: 'invalid' })).rejects.toThrow(NotFoundHttpError);
+      await expect(mapper.mapUrlToFilePath({ path: 'invalid' }, false)).rejects.toThrow(NotFoundHttpError);
     });
 
     it('throws 404 if the relative path does not start with a slash.', async(): Promise<void> => {
-      const result = mapper.mapUrlToFilePath({ path: `${trimTrailingSlashes(base)}test` });
+      const result = mapper.mapUrlToFilePath({ path: `${trimTrailingSlashes(base)}test` }, false);
       await expect(result).rejects.toThrow(BadRequestHttpError);
       await expect(result).rejects.toThrow('URL needs a / after the base');
     });
 
     it('throws 400 if the input path contains relative parts.', async(): Promise<void> => {
-      const result = mapper.mapUrlToFilePath({ path: `${base}test/../test2` });
+      const result = mapper.mapUrlToFilePath({ path: `${base}test/../test2` }, false);
       await expect(result).rejects.toThrow(BadRequestHttpError);
       await expect(result).rejects.toThrow('Disallowed /.. segment in URL');
     });
 
     it('returns the corresponding file path for container identifiers.', async(): Promise<void> => {
-      await expect(mapper.mapUrlToFilePath({ path: `${base}container/` })).resolves.toEqual({
+      await expect(mapper.mapUrlToFilePath({ path: `${base}container/` }, false)).resolves.toEqual({
         identifier: { path: `${base}container/` },
         filePath: `${rootFilepath}container/`,
+        isMetadata: false,
       });
     });
 
     it('returns the default content-type.', async(): Promise<void> => {
-      await expect(mapper.mapUrlToFilePath({ path: `${base}test` })).resolves.toEqual({
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test` }, false)).resolves.toEqual({
         identifier: { path: `${base}test` },
         filePath: `${rootFilepath}test`,
         contentType: 'application/octet-stream',
+        isMetadata: false,
       });
-      await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` })).resolves.toEqual({
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, false)).resolves.toEqual({
         identifier: { path: `${base}test.ttl` },
         filePath: `${rootFilepath}test.ttl`,
         contentType: 'application/octet-stream',
+        isMetadata: false,
       });
-      await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` })).resolves.toEqual({
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` }, false)).resolves.toEqual({
         identifier: { path: `${base}test.txt` },
         filePath: `${rootFilepath}test.txt`,
         contentType: 'application/octet-stream',
+        isMetadata: false,
       });
     });
 
     it('generates a file path if supported content-type was provided.', async(): Promise<void> => {
-      await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, 'text/turtle')).resolves.toEqual({
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, false, 'text/turtle')).resolves.toEqual({
         identifier: { path: `${base}test.ttl` },
         filePath: `${rootFilepath}test.ttl`,
         contentType: 'text/turtle',
+        isMetadata: false,
+      });
+    });
+
+    it('errors on metadata identifiers.', async(): Promise<void> => {
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.meta` }, true)).rejects.toThrow(ConflictHttpError);
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.meta` }, true))
+        .rejects.toThrow('Not allowed to create files with the metadata extension.');
+    });
+
+    it('generates correct metadata file paths.', async(): Promise<void> => {
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` }, true)).resolves.toEqual({
+        identifier: { path: `${base}test.txt` },
+        filePath: `${rootFilepath}test.txt.meta`,
+        contentType: 'application/octet-stream',
+        isMetadata: true,
       });
     });
   });
@@ -70,6 +91,7 @@ describe('An BaseFileIdentifierMapper', (): void => {
       await expect(mapper.mapFilePathToUrl(`${rootFilepath}container/`, true)).resolves.toEqual({
         identifier: { path: `${base}container/` },
         filePath: `${rootFilepath}container/`,
+        isMetadata: false,
       });
     });
 
@@ -78,16 +100,28 @@ describe('An BaseFileIdentifierMapper', (): void => {
         identifier: { path: `${base}test` },
         filePath: `${rootFilepath}test`,
         contentType: 'application/octet-stream',
+        isMetadata: false,
       });
       await expect(mapper.mapFilePathToUrl(`${rootFilepath}test.ttl`, false)).resolves.toEqual({
         identifier: { path: `${base}test.ttl` },
         filePath: `${rootFilepath}test.ttl`,
         contentType: 'application/octet-stream',
+        isMetadata: false,
       });
       await expect(mapper.mapFilePathToUrl(`${rootFilepath}test.txt`, false)).resolves.toEqual({
         identifier: { path: `${base}test.txt` },
         filePath: `${rootFilepath}test.txt`,
         contentType: 'application/octet-stream',
+        isMetadata: false,
+      });
+    });
+
+    it('identifies metadata files.', async(): Promise<void> => {
+      await expect(mapper.mapFilePathToUrl(`${rootFilepath}test.meta`, false)).resolves.toEqual({
+        identifier: { path: `${base}test` },
+        filePath: `${rootFilepath}test.meta`,
+        contentType: 'application/octet-stream',
+        isMetadata: true,
       });
     });
   });

--- a/test/unit/storage/mapping/FixedContentTypeMapper.test.ts
+++ b/test/unit/storage/mapping/FixedContentTypeMapper.test.ts
@@ -13,56 +13,61 @@ describe('An FixedContentTypeMapper', (): void => {
 
     describe('mapUrlToFilePath', (): void => {
       it('throws 404 if the input path does not contain the base.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: 'invalid' })).rejects.toThrow(NotFoundHttpError);
+        await expect(mapper.mapUrlToFilePath({ path: 'invalid' }, false)).rejects.toThrow(NotFoundHttpError);
       });
 
       it('throws 404 if the relative path does not start with a slash.', async(): Promise<void> => {
-        const result = mapper.mapUrlToFilePath({ path: `${trimTrailingSlashes(base)}test` });
+        const result = mapper.mapUrlToFilePath({ path: `${trimTrailingSlashes(base)}test` }, false);
         await expect(result).rejects.toThrow(BadRequestHttpError);
         await expect(result).rejects.toThrow('URL needs a / after the base');
       });
 
       it('throws 400 if the input path contains relative parts.', async(): Promise<void> => {
-        const result = mapper.mapUrlToFilePath({ path: `${base}test/../test2` });
+        const result = mapper.mapUrlToFilePath({ path: `${base}test/../test2` }, false);
         await expect(result).rejects.toThrow(BadRequestHttpError);
         await expect(result).rejects.toThrow('Disallowed /.. segment in URL');
       });
 
       it('returns the corresponding file path for container identifiers.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}container/` })).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}container/` }, false)).resolves.toEqual({
           identifier: { path: `${base}container/` },
           filePath: `${rootFilepath}container/`,
+          isMetadata: false,
         });
       });
 
       it('always returns the configured content-type.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test` })).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test` }, false)).resolves.toEqual({
           identifier: { path: `${base}test` },
           filePath: `${rootFilepath}test`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` })).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, false)).resolves.toEqual({
           identifier: { path: `${base}test.ttl` },
           filePath: `${rootFilepath}test.ttl`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` })).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` }, false)).resolves.toEqual({
           identifier: { path: `${base}test.txt` },
           filePath: `${rootFilepath}test.txt`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
       });
 
       it('generates a file path if supported content-type was provided.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, 'text/turtle')).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, false, 'text/turtle')).resolves.toEqual({
           identifier: { path: `${base}test.ttl` },
           filePath: `${rootFilepath}test.ttl`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
       });
 
       it('throws 400 if the given content-type is not supported.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, 'application/n-quads')).rejects
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, false, 'application/n-quads')).rejects
           .toThrow(
             new BadRequestHttpError(`Unsupported content type application/n-quads, only text/turtle is allowed`),
           );
@@ -78,6 +83,7 @@ describe('An FixedContentTypeMapper', (): void => {
         await expect(mapper.mapFilePathToUrl(`${rootFilepath}container/`, true)).resolves.toEqual({
           identifier: { path: `${base}container/` },
           filePath: `${rootFilepath}container/`,
+          isMetadata: false,
         });
       });
 
@@ -86,16 +92,19 @@ describe('An FixedContentTypeMapper', (): void => {
           identifier: { path: `${base}test` },
           filePath: `${rootFilepath}test`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
         await expect(mapper.mapFilePathToUrl(`${rootFilepath}test.ttl`, false)).resolves.toEqual({
           identifier: { path: `${base}test.ttl` },
           filePath: `${rootFilepath}test.ttl`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
         await expect(mapper.mapFilePathToUrl(`${rootFilepath}test.txt`, false)).resolves.toEqual({
           identifier: { path: `${base}test.txt` },
           filePath: `${rootFilepath}test.txt`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
       });
     });
@@ -107,40 +116,45 @@ describe('An FixedContentTypeMapper', (): void => {
 
     describe('mapUrlToFilePath', (): void => {
       it('returns the corresponding file path for container identifiers.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}container/` })).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}container/` }, false)).resolves.toEqual({
           identifier: { path: `${base}container/` },
           filePath: `${rootFilepath}container/`,
+          isMetadata: false,
         });
       });
 
       it('always returns the configured content-type.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test` })).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test` }, false)).resolves.toEqual({
           identifier: { path: `${base}test` },
           filePath: `${rootFilepath}test.ttl`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` })).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, false)).resolves.toEqual({
           identifier: { path: `${base}test.ttl` },
           filePath: `${rootFilepath}test.ttl.ttl`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` })).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` }, false)).resolves.toEqual({
           identifier: { path: `${base}test.txt` },
           filePath: `${rootFilepath}test.txt.ttl`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
       });
 
       it('generates a file path if supported content-type was provided.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, 'text/turtle')).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, false, 'text/turtle')).resolves.toEqual({
           identifier: { path: `${base}test.ttl` },
           filePath: `${rootFilepath}test.ttl.ttl`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
       });
 
       it('throws 400 if the given content-type is not supported.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, 'application/n-quads')).rejects
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, false, 'application/n-quads')).rejects
           .toThrow(
             new BadRequestHttpError(`Unsupported content type application/n-quads, only text/turtle is allowed`),
           );
@@ -152,6 +166,7 @@ describe('An FixedContentTypeMapper', (): void => {
         await expect(mapper.mapFilePathToUrl(`${rootFilepath}container/`, true)).resolves.toEqual({
           identifier: { path: `${base}container/` },
           filePath: `${rootFilepath}container/`,
+          isMetadata: false,
         });
       });
 
@@ -160,6 +175,7 @@ describe('An FixedContentTypeMapper', (): void => {
           identifier: { path: `${base}test` },
           filePath: `${rootFilepath}test.ttl`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
       });
 
@@ -176,42 +192,46 @@ describe('An FixedContentTypeMapper', (): void => {
 
     describe('mapUrlToFilePath', (): void => {
       it('returns the corresponding file path for container identifiers.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}container/` })).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}container/` }, false)).resolves.toEqual({
           identifier: { path: `${base}container/` },
           filePath: `${rootFilepath}container/`,
+          isMetadata: false,
         });
       });
 
       it('always returns the configured content-type.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` })).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, false)).resolves.toEqual({
           identifier: { path: `${base}test.ttl` },
           filePath: `${rootFilepath}test`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt.ttl` })).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt.ttl` }, false)).resolves.toEqual({
           identifier: { path: `${base}test.txt.ttl` },
           filePath: `${rootFilepath}test.txt`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
       });
 
       it('generates a file path if supported content-type was provided.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, 'text/turtle')).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, false, 'text/turtle')).resolves.toEqual({
           identifier: { path: `${base}test.ttl` },
           filePath: `${rootFilepath}test`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
       });
 
       it('throws 404 if the url does not end with the suffix.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.nq` }, 'text/turtle')).rejects
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.nq` }, false, 'text/turtle')).rejects
           .toThrow(NotFoundHttpError);
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test` }, 'text/turtle')).rejects
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test` }, false, 'text/turtle')).rejects
           .toThrow(NotFoundHttpError);
       });
 
       it('throws 400 if the given content-type is not supported.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, 'application/n-quads')).rejects
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, false, 'application/n-quads')).rejects
           .toThrow(
             new BadRequestHttpError(`Unsupported content type application/n-quads, only text/turtle is allowed`),
           );
@@ -223,6 +243,7 @@ describe('An FixedContentTypeMapper', (): void => {
         await expect(mapper.mapFilePathToUrl(`${rootFilepath}container/`, true)).resolves.toEqual({
           identifier: { path: `${base}container/` },
           filePath: `${rootFilepath}container/`,
+          isMetadata: false,
         });
       });
 
@@ -231,16 +252,19 @@ describe('An FixedContentTypeMapper', (): void => {
           identifier: { path: `${base}test.ttl` },
           filePath: `${rootFilepath}test`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
         await expect(mapper.mapFilePathToUrl(`${rootFilepath}test.ttl`, false)).resolves.toEqual({
           identifier: { path: `${base}test.ttl.ttl` },
           filePath: `${rootFilepath}test.ttl`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
         await expect(mapper.mapFilePathToUrl(`${rootFilepath}test.txt`, false)).resolves.toEqual({
           identifier: { path: `${base}test.txt.ttl` },
           filePath: `${rootFilepath}test.txt`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
       });
     });
@@ -252,24 +276,26 @@ describe('An FixedContentTypeMapper', (): void => {
 
     describe('mapUrlToFilePath', (): void => {
       it('returns the corresponding file path for container identifiers.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}container/` })).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}container/` }, false)).resolves.toEqual({
           identifier: { path: `${base}container/` },
           filePath: `${rootFilepath}container/`,
+          isMetadata: false,
         });
       });
 
       it('always returns the configured content-type.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` })).resolves.toEqual({
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.ttl` }, false)).resolves.toEqual({
           identifier: { path: `${base}test.ttl` },
           filePath: `${rootFilepath}test.nq`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
       });
 
       it('throws 404 if the url does not end with the suffix.', async(): Promise<void> => {
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test.nq` }, 'text/turtle')).rejects
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test.nq` }, false, 'text/turtle')).rejects
           .toThrow(NotFoundHttpError);
-        await expect(mapper.mapUrlToFilePath({ path: `${base}test` }, 'text/turtle')).rejects
+        await expect(mapper.mapUrlToFilePath({ path: `${base}test` }, false, 'text/turtle')).rejects
           .toThrow(NotFoundHttpError);
       });
     });
@@ -279,6 +305,7 @@ describe('An FixedContentTypeMapper', (): void => {
         await expect(mapper.mapFilePathToUrl(`${rootFilepath}container/`, true)).resolves.toEqual({
           identifier: { path: `${base}container/` },
           filePath: `${rootFilepath}container/`,
+          isMetadata: false,
         });
       });
 
@@ -287,6 +314,7 @@ describe('An FixedContentTypeMapper', (): void => {
           identifier: { path: `${base}test.ttl` },
           filePath: `${rootFilepath}test.nq`,
           contentType: 'text/turtle',
+          isMetadata: false,
         });
       });
 

--- a/test/unit/storage/mapping/SubdomainExtensionBasedMapper.test.ts
+++ b/test/unit/storage/mapping/SubdomainExtensionBasedMapper.test.ts
@@ -15,39 +15,42 @@ describe('A SubdomainExtensionBasedMapper', (): void => {
   describe('mapUrlToFilePath', (): void => {
     it('converts file paths to identifiers with a subdomain.', async(): Promise<void> => {
       const identifier = { path: `${getSubdomain('alice')}test.txt` };
-      await expect(mapper.mapUrlToFilePath(identifier, 'text/plain')).resolves.toEqual({
+      await expect(mapper.mapUrlToFilePath(identifier, false, 'text/plain')).resolves.toEqual({
         identifier,
         filePath: `${rootFilepath}alice/test.txt`,
         contentType: 'text/plain',
+        isMetadata: false,
       });
     });
 
     it('adds the default subdomain to the file path for root identifiers.', async(): Promise<void> => {
       const identifier = { path: `${base}test.txt` };
-      await expect(mapper.mapUrlToFilePath(identifier, 'text/plain')).resolves.toEqual({
+      await expect(mapper.mapUrlToFilePath(identifier, false, 'text/plain')).resolves.toEqual({
         identifier,
         filePath: `${rootFilepath}www/test.txt`,
         contentType: 'text/plain',
+        isMetadata: false,
       });
     });
 
     it('decodes punycode when generating a file path.', async(): Promise<void> => {
       const identifier = { path: `${getSubdomain('xn--c1yn36f')}t%20est.txt` };
-      await expect(mapper.mapUrlToFilePath(identifier, 'text/plain')).resolves.toEqual({
+      await expect(mapper.mapUrlToFilePath(identifier, false, 'text/plain')).resolves.toEqual({
         identifier,
         filePath: `${rootFilepath}點看/t est.txt`,
         contentType: 'text/plain',
+        isMetadata: false,
       });
     });
 
     it('errors if the path is invalid.', async(): Promise<void> => {
       const identifier = { path: `veryinvalidpath` };
-      await expect(mapper.mapUrlToFilePath(identifier, 'text/plain')).rejects.toThrow(NotFoundHttpError);
+      await expect(mapper.mapUrlToFilePath(identifier, false, 'text/plain')).rejects.toThrow(NotFoundHttpError);
     });
 
     it('errors if the subdomain matches the default one.', async(): Promise<void> => {
       const identifier = { path: `${getSubdomain('www')}test.txt` };
-      await expect(mapper.mapUrlToFilePath(identifier, 'text/plain')).rejects.toThrow(ForbiddenHttpError);
+      await expect(mapper.mapUrlToFilePath(identifier, false, 'text/plain')).rejects.toThrow(ForbiddenHttpError);
     });
   });
 
@@ -57,6 +60,7 @@ describe('A SubdomainExtensionBasedMapper', (): void => {
         identifier: { path: `${getSubdomain('alice')}test.txt` },
         filePath: `${rootFilepath}alice/test.txt`,
         contentType: 'text/plain',
+        isMetadata: false,
       });
     });
 
@@ -64,6 +68,7 @@ describe('A SubdomainExtensionBasedMapper', (): void => {
       await expect(mapper.mapFilePathToUrl(`${rootFilepath}alice/test.txt`, true)).resolves.toEqual({
         identifier: { path: `${getSubdomain('alice')}test.txt/` },
         filePath: `${rootFilepath}alice/test.txt`,
+        isMetadata: false,
       });
     });
 
@@ -72,6 +77,7 @@ describe('A SubdomainExtensionBasedMapper', (): void => {
         identifier: { path: `${base}test.txt` },
         filePath: `${rootFilepath}www/test.txt`,
         contentType: 'text/plain',
+        isMetadata: false,
       });
     });
 
@@ -80,6 +86,7 @@ describe('A SubdomainExtensionBasedMapper', (): void => {
         identifier: { path: `${getSubdomain('xn--c1yn36f')}t%20est.txt` },
         filePath: `${rootFilepath}點看/t est.txt`,
         contentType: 'text/plain',
+        isMetadata: false,
       });
     });
 


### PR DESCRIPTION
Based on the comment in https://github.com/solid/community-server/pull/825#discussion_r672563981

This turned out bigger than expected so having a separate PR for this.

This completely moves all knowledge of how metadata files are stored to the file mapper, making this the only place the '.meta' is found.