### PR TITLE
Do not serve index on */*

### DIFF
--- a/src/storage/IndexRepresentationStore.ts
+++ b/src/storage/IndexRepresentationStore.ts
@@ -65,12 +65,18 @@ export class IndexRepresentationStore extends PassthroughStore {
   }
 
   /**
-   * Makes sure the stored media range matches the highest weight preference.
+   * Makes sure the stored media range explicitly matches the highest weight preference.
    */
   private matchesPreferences(preferences: RepresentationPreferences): boolean {
-    const cleaned = cleanPreferences(preferences.type);
-    const max = Math.max(...Object.values(cleaned));
-    return Object.entries(cleaned).some(([ range, weight ]): boolean =>
-      matchesMediaType(range, this.mediaRange) && weight === max);
+    // Always match */*
+    if (this.mediaRange === '*/*') {
+      return true;
+    }
+
+    // Otherwise, determine if an explicit match has the highest weight
+    const types = cleanPreferences(preferences.type);
+    const max = Math.max(...Object.values(types));
+    return Object.entries(types).some(([ range, weight ]): boolean =>
+      range !== '*/*' && (max - weight) < 0.01 && matchesMediaType(range, this.mediaRange));
   }
 }

--- a/test/util/FetchUtil.ts
+++ b/test/util/FetchUtil.ts
@@ -9,9 +9,11 @@ import { LDP } from '../../src/util/Vocabularies';
 /**
  * This is specifically for GET requests which are expected to succeed.
  */
-export async function getResource(url: string, expected?: { contentType?: string }): Promise<Response> {
+export async function getResource(url: string,
+  options?: { accept?: string },
+  expected?: { contentType?: string }): Promise<Response> {
   const isContainer = isContainerPath(url);
-  const response = await fetch(url);
+  const response = await fetch(url, { headers: options });
   expect(response.status).toBe(200);
   expect(response.headers.get('link')).toContain(`<${LDP.Resource}>; rel="type"`);
   expect(response.headers.get('link')).toContain(`<${url}.acl>; rel="acl"`);


### PR DESCRIPTION
Closes https://github.com/solid/community-server/issues/844

@joachimvh Advice on how to fix the integration test?
I could add content type to `getResource`, or just settle for Turtle. But I like the integration tests for HTML.