### PR TITLE
fix: Prevent cyclical dependency with locker and storage

### DIFF
--- a/config/identity/handler/default.json
+++ b/config/identity/handler/default.json
@@ -3,7 +3,7 @@
   "import": [
     "files-scs:config/identity/handler/adapter-factory/webid.json",
     "files-scs:config/identity/handler/interaction/handler.json",
-    "files-scs:config/identity/handler/key-value/resource-store.json",
+    "files-scs:config/identity/handler/key-value/storage.json",
     "files-scs:config/identity/handler/provider-factory/identity.json"
   ],
   "@graph": [

--- a/config/identity/handler/key-value/storage.json
+++ b/config/identity/handler/key-value/storage.json
@@ -2,14 +2,6 @@
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
   "@graph": [
     {
-      "comment": "This storage specifically uses the same path as the IDP routing, thereby guaranteeing outside access is impossible.",
-      "@id": "urn:solid-server:default:IdpStorage",
-      "@type": "JsonResourceStorage",
-      "source": { "@id": "urn:solid-server:default:ResourceStore" },
-      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
-      "container": "/idp/data/"
-    },
-    {
       "comment": "Stores expiring data. This class has a `finalize` function that needs to be called after stopping the server.",
       "@id": "urn:solid-server:default:ExpiringIdpStorage",
       "@type": "WrappedExpiringStorage",

--- a/config/storage/key-value/memory.json
+++ b/config/storage/key-value/memory.json
@@ -2,8 +2,16 @@
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
   "@graph": [
     {
-      "comment": "Used for internal storage by some classes. This uses a memory based solution.",
-      "@id": "urn:solid-server:default:Storage",
+      "comment": "These storage solutions store their data in memory."
+    },
+    {
+      "comment": "Used for internal storage by the locker.",
+      "@id": "urn:solid-server:default:LockStorage",
+      "@type": "MemoryMapStorage"
+    },
+    {
+      "comment": "Storage used by the IDP component.",
+      "@id": "urn:solid-server:default:IdpStorage",
       "@type": "MemoryMapStorage"
     }
   ]

--- a/config/storage/key-value/resource-store.json
+++ b/config/storage/key-value/resource-store.json
@@ -2,12 +2,26 @@
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
   "@graph": [
     {
-      "comment": "Used for internal storage by some classes. The specified container in the resource store will store internal data.",
-      "@id": "urn:solid-server:default:Storage",
+      "comment": "These storage solutions use the specified container in the ResourceStore to store their data."
+    },
+    {
+      "comment": [
+        "This is the internal storage for the locker, which maintains what resources are in use.",
+        "It writes directly to a low-level store, because higher-level storage typically already uses the locker and would thus cause a loop."
+      ],
+      "@id": "urn:solid-server:default:LockStorage",
+      "@type": "JsonResourceStorage",
+      "source": { "@id": "urn:solid-server:default:ResourceStore_Backend" },
+      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
+      "container": "/locks/"
+    },
+    {
+      "comment": "Storage used by the IDP component.",
+      "@id": "urn:solid-server:default:IdpStorage",
       "@type": "JsonResourceStorage",
       "source": { "@id": "urn:solid-server:default:ResourceStore" },
       "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
-      "container": "/storage/"
+      "container": "/idp/data/"
     }
   ]
 }

--- a/config/util/resource-locker/memory.json
+++ b/config/util/resource-locker/memory.json
@@ -10,7 +10,7 @@
         "locker": {
           "@type": "SingleThreadedResourceLocker"
         },
-        "storage": { "@id": "urn:solid-server:default:Storage" },
+        "storage": { "@id": "urn:solid-server:default:LockStorage" },
         "suffixes_count": "count",
         "suffixes_read": "read",
         "suffixes_write": "write"

--- a/config/util/resource-locker/redis.json
+++ b/config/util/resource-locker/redis.json
@@ -12,7 +12,7 @@
           "@type": "RedisResourceLocker",
           "redisClients": [ "6379" ]
         },
-        "storage": { "@id": "urn:solid-server:default:Storage" },
+        "storage": { "@id": "urn:solid-server:default:LockStorage" },
         "suffixes_count": "count",
         "suffixes_read": "read",
         "suffixes_write": "write"

--- a/test/integration/config/server-memory.json
+++ b/test/integration/config/server-memory.json
@@ -18,7 +18,7 @@
     "files-scs:config/ldp/metadata-writer/default.json",
     "files-scs:config/ldp/permissions/acl.json",
     "files-scs:config/storage/backend/memory.json",
-    "files-scs:config/storage/key-value/memory.json",
+    "files-scs:config/storage/key-value/resource-store.json",
     "files-scs:config/storage/middleware/default.json",
     "files-scs:config/util/auxiliary/acl.json",
     "files-scs:config/util/identifiers/suffix.json",


### PR DESCRIPTION
Closes #862 

My proposal for a solution (includes some cleanup for the storage configs).

I would use a specific storage for the lockers that only uses the backend. The expectation is then that the lockers handle the locking themselves (which they currently do).

All other classes can then use a storage that still references the full store stack. The only one we currently have is the IDP one.

I also updated one integration config to use the resource store storage so this would be caught by tests using this config.

After #757 (which is how I discovered this) the plan is to update all the default configs we have to use this kind of storage instead of the memory one which is now the default.