### PR TITLE
fix: Use memory key/value storage for sparql backends

### DIFF
--- a/config/path-routing.json
+++ b/config/path-routing.json
@@ -19,7 +19,7 @@
     "files-scs:config/ldp/metadata-writer/default.json",
     "files-scs:config/ldp/permissions/acl.json",
     "files-scs:config/storage/backend/regex.json",
-    "files-scs:config/storage/key-value/resource-store.json",
+    "files-scs:config/storage/key-value/memory.json",
     "files-scs:config/storage/middleware/default.json",
     "files-scs:config/util/auxiliary/acl.json",
     "files-scs:config/util/identifiers/suffix.json",

--- a/config/sparql-endpoint.json
+++ b/config/sparql-endpoint.json
@@ -19,7 +19,7 @@
     "files-scs:config/ldp/metadata-writer/default.json",
     "files-scs:config/ldp/permissions/acl.json",
     "files-scs:config/storage/backend/sparql.json",
-    "files-scs:config/storage/key-value/resource-store.json",
+    "files-scs:config/storage/key-value/memory.json",
     "files-scs:config/storage/middleware/default.json",
     "files-scs:config/util/auxiliary/acl.json",
     "files-scs:config/util/identifiers/suffix.json",
@@ -31,7 +31,10 @@
   ],
   "@graph": [
     {
-      "comment": "A single-pod server that stores its resources in a SPARQL endpoint."
+      "comment": [
+        "A single-pod server that stores its resources in a SPARQL endpoint.",
+        "This server only supports RDF data. For this reason it can not use its resource store for internal key/value storage."
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes #840 .

Due to all the work on storage I realized what the problem was and how to easily fix it.

The problem is that the sparql store was using the ResourceStore for the internal storage. But in that case the store only accepts RDF while the internal storage uses JSON. This explains the error message in the issue above since the converter tried to conver the JSON to JSON-LD and was missing the context. This also means #864 completely broke the sparql config since there we made it so the locker also used the ResourceStore for internal storage.

The solution is to just use the memory storage instead since that one does accept everything. It is partially a band-aid solution though since this means all IDP data (e.g. registrations) will be lost on server restart.

A more comprehensive solution would be to either set up a new file store specifically for the internal storage, or store the JSON documents in the sparql store as strings.