### PR TITLE
Further config simplification

### DIFF
--- a/config/storage/middleware/default.json
+++ b/config/storage/middleware/default.json
@@ -13,7 +13,9 @@
       "MonitoringStore:_source": { "@id": "urn:solid-server:default:ResourceStore_Index" }
     },
     {
+      "comment": "When a container with an index.html document is accessed, serve that HTML document instead of the container.",
       "@id": "urn:solid-server:default:ResourceStore_Index",
+      "@type": "IndexRepresentationStore",
       "IndexRepresentationStore:_source": { "@id": "urn:solid-server:default:ResourceStore_Locking" }
     },
     {

--- a/config/util/index/default.json
+++ b/config/util/index/default.json
@@ -2,11 +2,6 @@
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
   "@graph": [
     {
-      "comment": "When a container with an index.html document is accessed, serve that HTML document instead of the container.",
-      "@id": "urn:solid-server:default:ResourceStore_Index",
-      "@type": "IndexRepresentationStore"
-    },
-    {
       "comment": "This value can be used to set a custom handler for index files. See the example file.",
       "@id": "urn:solid-server:default:DefaultUiConverter",
       "@type": "UnsupportedAsyncHandler"

--- a/config/util/index/example.json
+++ b/config/util/index/example.json
@@ -2,11 +2,6 @@
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
   "@graph": [
     {
-      "comment": "This an example on how to disable the routing to index.html when accessing a container.",
-      "@id": "urn:solid-server:default:ResourceStore_Index",
-      "@type": "PassthroughStore"
-    },
-    {
       "comment": [
         "This converter replaces every browser request for text/html with the Databrowser UI (which then in turn loads a Turtle or other representation of the same resource).",
         "This is useful when you want to serve a UI for every file from the pod."

--- a/config/util/representation-conversion/converters/errors.json
+++ b/config/util/representation-conversion/converters/errors.json
@@ -9,19 +9,13 @@
   "@graph": [
     {
       "@id": "urn:solid-server:default:ErrorToQuadConverter",
-      "@type": "ErrorToQuadConverter",
+      "@type": "ErrorToQuadConverter"
     },
     {
       "comment": "Converts an error into a Markdown description of its details.",
       "@id": "urn:solid-server:default:ErrorToTemplateConverter",
       "@type": "ErrorToTemplateConverter",
-      "templateEngine": {
-        "@type": "HandlebarsTemplateEngine",
-        "template": "$PACKAGE_ROOT/templates/error/main.md.hbs"
-      },
-      "templatePath": "$PACKAGE_ROOT/templates/error/descriptions/",
-      "extension": ".md.hbs",
-      "contentType": "text/markdown"
+      "templateEngine": { "@type": "HandlebarsTemplateEngine" }
     }
   ]
 }


### PR DESCRIPTION
For `IndexRepresentationStore` I have simply removed the option to disable it. Due to our store stack architecture and the fact that with Components.js you need the classname for parameters there is not really an easy way to replace it with a passthrough store. One other option would be to have an alternative `config/resource-store/middleware` feature that has the stack without the index store. If required I'll add that instead. Note that you can actually disable the index store by setting its `mediaRange` to a useless range.

The second commit is my suggestion on how to handle the templates in the `ErrorToTemplateConverter`. The idea is to set default templates in the class which can then be overwritten if needed. This does roll back a part of the `TemplateEngine` changes since this requires the template to be stored in the converter, but I really like this solution because it makes it very easy to set your own templates without us having to add new config features. Instead of the 40 lines of [boilerplate](https://github.com/solid/community-server-recipes/blob/0062443b2c76f629a636542608e5f72600c80b28/mashlib/config-mashlib.json#L72-L112) you would only need to add the following to your config instead:
```json
{
  "@id": "urn:solid-server:default:ErrorToTemplateConverter",
  "ErrorToTemplateConverter:_templateOptions_mainTemplate": "./node_modules/mashlib/dist/databrowser.html",
  "ErrorToTemplateConverter:_templateOptions_codeTemplatePath": "./node_modules/mashlib/dist/",
  "ErrorToTemplateConverter:_templateOptions_extension": ".html",
  "ErrorToTemplateConverter:_templateOptions_contentType": "text/html"
}
```
I would actually suggest adding similar behaviour to all classes we have that depend on a template and where we think a user might want to update them. This way we have our default templates but still make it easy for a user to set their own. Otherwise we would have to introduce a new import for every class we have that takes a path as input (also an option of course should that be preferred).

The one disadvantage is that due to https://github.com/LinkedSoftwareDependencies/Components.js/issues/20 the code doesn't look as clean as I would want it to, but that is only minor.