### PR TITLE
feat: Rewrite TokenOwnershipValidator behaviour to remove @rdfjs/fetch dependency

### DIFF
--- a/config/identity/ownership/token.json
+++ b/config/identity/ownership/token.json
@@ -5,6 +5,7 @@
       "comment": "Determines WebID ownership by requesting a specific value to be added to the WebID document",
       "@id": "urn:solid-server:auth:password:OwnershipValidator",
       "@type": "TokenOwnershipValidator",
+      "converter": { "@id": "urn:solid-server:default:RepresentationConverter" },
       "storage": { "@id": "urn:solid-server:default:ExpiringIdpStorage" }
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@comunica/actor-init-sparql": "^1.21.3",
         "@rdfjs/data-model": "^1.2.0",
-        "@rdfjs/fetch": "^2.1.0",
         "@solid/access-token-verifier": "^0.10.0",
         "@types/arrayify-stream": "^1.0.0",
         "@types/async-lock": "^1.1.2",
@@ -27,8 +26,6 @@
         "@types/pump": "^1.1.1",
         "@types/punycode": "^2.1.0",
         "@types/rdf-js": "^4.0.2",
-        "@types/rdfjs__fetch": "^2.0.3",
-        "@types/rdfjs__fetch-lite": "^2.0.3",
         "@types/redis": "^2.8.30",
         "@types/redlock": "^4.0.1",
         "@types/sparqljs": "^3.1.2",
@@ -4733,140 +4730,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@rdfjs/dataset": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.0.1.tgz",
-      "integrity": "sha512-k/c6g4K881QX7LE3eskg6t1j31zDe+CKwTEiKkSCFk6M25gUJ/BReT/FrLdKmPjhXp+YOgHj97AtEphzTeKVeA==",
-      "dependencies": {
-        "@rdfjs/data-model": "^1.1.1"
-      },
-      "bin": {
-        "rdfjs-dataset-test": "bin/test.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@rdfjs/fetch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/fetch/-/fetch-2.1.0.tgz",
-      "integrity": "sha512-1bhXqGfbQQKHrmuZOmUUQmCpDNQC25fksYoGXUvlQ80kWuk8r/PdcdUmzApCp7HSyHFUjmgH89Pkym/9WXyDkQ==",
-      "dependencies": {
-        "@rdfjs/dataset": "^1.0.1",
-        "@rdfjs/fetch-lite": "^2.1.0",
-        "@rdfjs/formats-common": "^2.0.1"
-      }
-    },
-    "node_modules/@rdfjs/fetch-lite": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-2.1.0.tgz",
-      "integrity": "sha512-7P2+QBjSJ/oeN2CRySIrG0IHat7UDqf7KfpZ9IP/MhWN3AneTpuURlOVAKcP/tedsSdlf2ihnzO38C6uAd7ppQ==",
-      "dependencies": {
-        "isstream": "^0.1.2",
-        "nodeify-fetch": "^2.2.1",
-        "readable-stream": "^3.3.0"
-      }
-    },
-    "node_modules/@rdfjs/formats-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/formats-common/-/formats-common-2.1.0.tgz",
-      "integrity": "sha512-DVsQsMwSf+bNelIocDe35Wq/POkC+puXYd0BRwP76A3tzYKjIHwBHQFfq7wXMUaBe3jQq80x4DaFpxPaI7sPKA==",
-      "dependencies": {
-        "@rdfjs/parser-jsonld": "^1.1.1",
-        "@rdfjs/parser-n3": "^1.1.2",
-        "@rdfjs/serializer-jsonld": "^1.2.0",
-        "@rdfjs/serializer-ntriples": "^1.0.1",
-        "@rdfjs/sink-map": "^1.0.0",
-        "rdfxml-streaming-parser": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@rdfjs/parser-jsonld": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/parser-jsonld/-/parser-jsonld-1.2.1.tgz",
-      "integrity": "sha512-m8WQBacXaU2qPgf+rPEqit4EiEjBxpohvDEG4aF7YvFAT6uEto3lHu7ilKcMKpLfMKmbXp4v6KzJXm9yvockNw==",
-      "dependencies": {
-        "@rdfjs/data-model": "^1.0.1",
-        "@rdfjs/sink": "^1.0.2",
-        "concat-stream": "^2.0.0",
-        "jsonld": "^1.8.1",
-        "readable-stream": "^3.6.0"
-      }
-    },
-    "node_modules/@rdfjs/parser-jsonld/node_modules/concat-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-      "engines": [
-        "node >= 6.0"
-      ],
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/@rdfjs/parser-n3": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rdfjs/parser-n3/-/parser-n3-1.1.4.tgz",
-      "integrity": "sha512-PUKSNlfD2Zq3GcQZuOF2ndfrLbc+N96FUe2gNIzARlR2er0BcOHBHEFUJvVGg1Xmsg3hVKwfg0nwn1JZ7qKKMw==",
-      "dependencies": {
-        "@rdfjs/data-model": "^1.0.1",
-        "@rdfjs/sink": "^1.0.2",
-        "n3": "^1.3.5",
-        "readable-stream": "^3.6.0",
-        "readable-to-readable": "^0.1.0"
-      }
-    },
-    "node_modules/@rdfjs/serializer-jsonld": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/serializer-jsonld/-/serializer-jsonld-1.2.2.tgz",
-      "integrity": "sha512-BXcmi2qZlpkrJcVms9g1JSFWXeiOhgJyFsEa6UuN0CPst6WRNY5z6djp0o6rfDgfmgb5FrXFwBgAIDunI5VZoQ==",
-      "dependencies": {
-        "@rdfjs/sink": "^1.0.2",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@rdfjs/serializer-ntriples": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rdfjs/serializer-ntriples/-/serializer-ntriples-1.0.3.tgz",
-      "integrity": "sha512-XXFgzNJyYrix0YgysqYowKw40hCJ+zeVqA/CGgO3y5XyKY+NL/VJJELMn7cTwjJteiLVCgRNAvaUVn4CjJ2PCg==",
-      "dependencies": {
-        "@rdfjs/sink": "^1.0.3",
-        "@rdfjs/to-ntriples": "^1.0.2",
-        "readable-to-readable": "^0.1.0"
-      }
-    },
-    "node_modules/@rdfjs/sink": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-1.0.3.tgz",
-      "integrity": "sha512-2KfYa8mAnptRNeogxhQqkWNXqfYVWO04jQThtXKepySrIwYmz83+WlevQtA4VDLFe+kFd2TwgL29ekPe5XVUfA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@rdfjs/sink-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/sink-map/-/sink-map-1.0.1.tgz",
-      "integrity": "sha512-PRp5TjULHe2oRcupR80SClZ/l50wnSuX2Pl+TlkcRazt1w7AT86kLmQYFbDfjqGM7uDwSyD6evLJxXBDf5UuvQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@rdfjs/to-ntriples": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-1.0.2.tgz",
-      "integrity": "sha512-ngw5XAaGHjgGiwWWBPGlfdCclHftonmbje5lMys4G2j4NvfExraPIuRZgjSnd5lg4dnulRVUll8tRbgKO+7EDA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@rdfjs/types": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.0.1.tgz",
@@ -5363,41 +5226,6 @@
         "rdf-js": "*"
       }
     },
-    "node_modules/@types/rdfjs__fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__fetch/-/rdfjs__fetch-2.0.3.tgz",
-      "integrity": "sha512-QP0C7+yQ2Y4Y0tvWCW8J20OwWnbZy1e7XkPA5QzjzvnV5Nx9p0FTUkhZWSbp2ta/Ao8+CB3I2V/xk++cQrO3+A==",
-      "dependencies": {
-        "@types/rdfjs__fetch-lite": "*",
-        "rdf-js": "^4.0.2"
-      }
-    },
-    "node_modules/@types/rdfjs__fetch-lite": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__fetch-lite/-/rdfjs__fetch-lite-2.0.3.tgz",
-      "integrity": "sha512-D/TlU8wePsvUCchKTtsVUlH7U+hnkcOQyfBmakEFMx1Zw3BjIwhcLxrswXKfsmXAHK26q2a0lxb+ynHRaW15bw==",
-      "dependencies": {
-        "@types/rdfjs__formats-common": "*",
-        "rdf-js": "^4.0.2"
-      }
-    },
-    "node_modules/@types/rdfjs__formats-common": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__formats-common/-/rdfjs__formats-common-2.0.2.tgz",
-      "integrity": "sha512-2h3Db8iaOZjJIc26R8fz0LzdX3arGwQf2MzsRd6slW0Lq3B01LIN3eMS/EcCftf+yYAB+qdpOxGkwKI4e3C0Bg==",
-      "dependencies": {
-        "@types/rdfjs__sink-map": "*",
-        "rdf-js": "^4.0.2"
-      }
-    },
-    "node_modules/@types/rdfjs__sink-map": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__sink-map/-/rdfjs__sink-map-1.0.2.tgz",
-      "integrity": "sha512-J1V0NYG+ImYS7Pc2fLBop5WOLkSOrLw5+A2QeFT2fmOn1gbB++9ct9b8Muod3KD4zRswGShF0Aq8ZyT2ut/HyQ==",
-      "dependencies": {
-        "rdf-js": "^4.0.2"
-      }
-    },
     "node_modules/@types/redis": {
       "version": "2.8.30",
       "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.30.tgz",
@@ -5783,6 +5611,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6081,22 +5910,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -6132,20 +5945,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "27.0.6",
@@ -6282,14 +6083,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -6419,7 +6212,8 @@
     "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "node_modules/builtin-modules": {
       "version": "3.2.0",
@@ -6563,11 +6357,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.3.tgz",
       "integrity": "sha512-QWAGweNicWIXzcl7skvUZQ/ArdecS8fOeudnjIU0LYqSdTOSBSap+0VPMas4u11cW3a9sN5AN/aJHQUGfdWLCw=="
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "node_modules/chalk": {
       "version": "4.1.1",
@@ -6901,6 +6690,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -6984,47 +6774,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "engines": [
-        "node >= 0.8"
-      ],
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/concat-stream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/concat-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/concat-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/configstore": {
       "version": "5.0.1",
@@ -7291,17 +7040,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -7440,6 +7178,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7611,15 +7350,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -8964,19 +8694,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "engines": [
-        "node >=0.6.0"
-      ]
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9001,7 +8718,8 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -9155,27 +8873,6 @@
       ],
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/formidable": {
@@ -9385,14 +9082,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
       }
     },
     "node_modules/git-raw-commits": {
@@ -9891,27 +9580,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -10158,20 +9826,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/http2-wrapper": {
@@ -10764,7 +10418,8 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "node_modules/is-yarn-global": {
       "version": "0.3.0",
@@ -10782,11 +10437,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -12635,11 +12285,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
     "node_modules/jsdom": {
       "version": "16.6.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
@@ -12755,26 +12400,17 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "node_modules/json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "node_modules/json5": {
       "version": "2.2.0",
@@ -12810,21 +12446,6 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/jsonld": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.8.1.tgz",
-      "integrity": "sha512-f0rusl5v8aPKS3jApT5fhYsdTC/JpyK1PoJ+ZtYYtZXoyb1J0Z///mJqLwrfL/g4NueFSqPymDYIi1CcSk7b8Q==",
-      "dependencies": {
-        "canonicalize": "^1.0.1",
-        "rdf-canonize": "^1.0.2",
-        "request": "^2.88.0",
-        "semver": "^5.6.0",
-        "xmldom": "0.1.19"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/jsonld-context-parser": {
@@ -12871,14 +12492,6 @@
         "jsonld-context-parser": "^2.0.0"
       }
     },
-    "node_modules/jsonld/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -12900,20 +12513,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -13649,14 +13248,6 @@
         "node": "4.x || >=6.0.0"
       }
     },
-    "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -13697,17 +13288,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
       "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
       "dev": true
-    },
-    "node_modules/nodeify-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/nodeify-fetch/-/nodeify-fetch-2.2.1.tgz",
-      "integrity": "sha512-NAvl/0QTipKEgf9Jo179TXJ02hQ3bM0BMcn6S5aBeL51MUX46GuQW430tHWERoMpC7YLk1oBXToMyX9yDxowqQ==",
-      "dependencies": {
-        "concat-stream": "^1.6.0",
-        "cross-fetch": "^3.0.4",
-        "readable-error": "^1.0.0",
-        "readable-stream": "^3.5.0"
-      }
     },
     "node_modules/nodemailer": {
       "version": "6.6.2",
@@ -13892,14 +13472,6 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
-    },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -14549,11 +14121,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "node_modules/picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -14847,7 +14414,8 @@
     "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -14882,14 +14450,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/queue-microtask": {
@@ -14991,26 +14551,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rdf-canonize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.2.0.tgz",
-      "integrity": "sha512-MQdcRDz4+82nUrEb3hNQangBDpmep15uMmnWclGi/1KS0bNVc8oHpoNI0PFLHZsvwgwRzH31bO1JAScqUAstvw==",
-      "dependencies": {
-        "node-forge": "^0.10.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/rdf-canonize/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/rdf-data-factory": {
@@ -15487,41 +15027,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/readable-error": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/readable-error/-/readable-error-1.0.0.tgz",
-      "integrity": "sha512-CLnInu5bUphmFiZ3pD/BC6+Cg4/BzK6ZMvWfd0b2QMzYo159Z/f/nVFQ9L5IeMrqUxy0EFsp3XJ+BRfLfY13IQ==",
-      "dependencies": {
-        "readable-stream": "^2.3.3"
-      }
-    },
-    "node_modules/readable-error/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-error/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/readable-error/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -15539,14 +15044,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz",
       "integrity": "sha1-i3YU+qFGXr+g2pucpjA/onBzt88="
-    },
-    "node_modules/readable-to-readable": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/readable-to-readable/-/readable-to-readable-0.1.3.tgz",
-      "integrity": "sha512-G+0kz01xJM/uTuItKcqC73cifW8S6CZ7tp77NLN87lE5mrSU+GC8geoSAlfmp0NocmXckQ7W8s8ns73HYsIA3w==",
-      "dependencies": {
-        "readable-stream": "^3.6.0"
-      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -15691,46 +15188,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.6.tgz",
       "integrity": "sha512-Xw5/Zx6iWSCMJUXwXVOjySjH8Xli4hVFL9QQFvkl1qEmFBG94J+QUI9emnoctOCD3285f1jNV+QWV9eDYwIdfQ=="
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -16306,30 +15763,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "node_modules/sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -16838,18 +16271,6 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tr46": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
@@ -16962,22 +16383,6 @@
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -17019,11 +16424,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -17238,6 +16638,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
       "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -17330,19 +16731,6 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/vscode-textmate": {
@@ -17688,15 +17076,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "node_modules/xmldom": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
-      "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw=",
-      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
-      "engines": {
-        "node": ">=0.1"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -21471,118 +20850,6 @@
         "@types/rdf-js": "*"
       }
     },
-    "@rdfjs/dataset": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.0.1.tgz",
-      "integrity": "sha512-k/c6g4K881QX7LE3eskg6t1j31zDe+CKwTEiKkSCFk6M25gUJ/BReT/FrLdKmPjhXp+YOgHj97AtEphzTeKVeA==",
-      "requires": {
-        "@rdfjs/data-model": "^1.1.1"
-      }
-    },
-    "@rdfjs/fetch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/fetch/-/fetch-2.1.0.tgz",
-      "integrity": "sha512-1bhXqGfbQQKHrmuZOmUUQmCpDNQC25fksYoGXUvlQ80kWuk8r/PdcdUmzApCp7HSyHFUjmgH89Pkym/9WXyDkQ==",
-      "requires": {
-        "@rdfjs/dataset": "^1.0.1",
-        "@rdfjs/fetch-lite": "^2.1.0",
-        "@rdfjs/formats-common": "^2.0.1"
-      }
-    },
-    "@rdfjs/fetch-lite": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-2.1.0.tgz",
-      "integrity": "sha512-7P2+QBjSJ/oeN2CRySIrG0IHat7UDqf7KfpZ9IP/MhWN3AneTpuURlOVAKcP/tedsSdlf2ihnzO38C6uAd7ppQ==",
-      "requires": {
-        "isstream": "^0.1.2",
-        "nodeify-fetch": "^2.2.1",
-        "readable-stream": "^3.3.0"
-      }
-    },
-    "@rdfjs/formats-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/formats-common/-/formats-common-2.1.0.tgz",
-      "integrity": "sha512-DVsQsMwSf+bNelIocDe35Wq/POkC+puXYd0BRwP76A3tzYKjIHwBHQFfq7wXMUaBe3jQq80x4DaFpxPaI7sPKA==",
-      "requires": {
-        "@rdfjs/parser-jsonld": "^1.1.1",
-        "@rdfjs/parser-n3": "^1.1.2",
-        "@rdfjs/serializer-jsonld": "^1.2.0",
-        "@rdfjs/serializer-ntriples": "^1.0.1",
-        "@rdfjs/sink-map": "^1.0.0",
-        "rdfxml-streaming-parser": "^1.2.0"
-      }
-    },
-    "@rdfjs/parser-jsonld": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/parser-jsonld/-/parser-jsonld-1.2.1.tgz",
-      "integrity": "sha512-m8WQBacXaU2qPgf+rPEqit4EiEjBxpohvDEG4aF7YvFAT6uEto3lHu7ilKcMKpLfMKmbXp4v6KzJXm9yvockNw==",
-      "requires": {
-        "@rdfjs/data-model": "^1.0.1",
-        "@rdfjs/sink": "^1.0.2",
-        "concat-stream": "^2.0.0",
-        "jsonld": "^1.8.1",
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.0.2",
-            "typedarray": "^0.0.6"
-          }
-        }
-      }
-    },
-    "@rdfjs/parser-n3": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rdfjs/parser-n3/-/parser-n3-1.1.4.tgz",
-      "integrity": "sha512-PUKSNlfD2Zq3GcQZuOF2ndfrLbc+N96FUe2gNIzARlR2er0BcOHBHEFUJvVGg1Xmsg3hVKwfg0nwn1JZ7qKKMw==",
-      "requires": {
-        "@rdfjs/data-model": "^1.0.1",
-        "@rdfjs/sink": "^1.0.2",
-        "n3": "^1.3.5",
-        "readable-stream": "^3.6.0",
-        "readable-to-readable": "^0.1.0"
-      }
-    },
-    "@rdfjs/serializer-jsonld": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/serializer-jsonld/-/serializer-jsonld-1.2.2.tgz",
-      "integrity": "sha512-BXcmi2qZlpkrJcVms9g1JSFWXeiOhgJyFsEa6UuN0CPst6WRNY5z6djp0o6rfDgfmgb5FrXFwBgAIDunI5VZoQ==",
-      "requires": {
-        "@rdfjs/sink": "^1.0.2",
-        "readable-stream": "^3.6.0"
-      }
-    },
-    "@rdfjs/serializer-ntriples": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rdfjs/serializer-ntriples/-/serializer-ntriples-1.0.3.tgz",
-      "integrity": "sha512-XXFgzNJyYrix0YgysqYowKw40hCJ+zeVqA/CGgO3y5XyKY+NL/VJJELMn7cTwjJteiLVCgRNAvaUVn4CjJ2PCg==",
-      "requires": {
-        "@rdfjs/sink": "^1.0.3",
-        "@rdfjs/to-ntriples": "^1.0.2",
-        "readable-to-readable": "^0.1.0"
-      }
-    },
-    "@rdfjs/sink": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-1.0.3.tgz",
-      "integrity": "sha512-2KfYa8mAnptRNeogxhQqkWNXqfYVWO04jQThtXKepySrIwYmz83+WlevQtA4VDLFe+kFd2TwgL29ekPe5XVUfA=="
-    },
-    "@rdfjs/sink-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/sink-map/-/sink-map-1.0.1.tgz",
-      "integrity": "sha512-PRp5TjULHe2oRcupR80SClZ/l50wnSuX2Pl+TlkcRazt1w7AT86kLmQYFbDfjqGM7uDwSyD6evLJxXBDf5UuvQ=="
-    },
-    "@rdfjs/to-ntriples": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-1.0.2.tgz",
-      "integrity": "sha512-ngw5XAaGHjgGiwWWBPGlfdCclHftonmbje5lMys4G2j4NvfExraPIuRZgjSnd5lg4dnulRVUll8tRbgKO+7EDA=="
-    },
     "@rdfjs/types": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.0.1.tgz",
@@ -22069,41 +21336,6 @@
         "rdf-js": "*"
       }
     },
-    "@types/rdfjs__fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__fetch/-/rdfjs__fetch-2.0.3.tgz",
-      "integrity": "sha512-QP0C7+yQ2Y4Y0tvWCW8J20OwWnbZy1e7XkPA5QzjzvnV5Nx9p0FTUkhZWSbp2ta/Ao8+CB3I2V/xk++cQrO3+A==",
-      "requires": {
-        "@types/rdfjs__fetch-lite": "*",
-        "rdf-js": "^4.0.2"
-      }
-    },
-    "@types/rdfjs__fetch-lite": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__fetch-lite/-/rdfjs__fetch-lite-2.0.3.tgz",
-      "integrity": "sha512-D/TlU8wePsvUCchKTtsVUlH7U+hnkcOQyfBmakEFMx1Zw3BjIwhcLxrswXKfsmXAHK26q2a0lxb+ynHRaW15bw==",
-      "requires": {
-        "@types/rdfjs__formats-common": "*",
-        "rdf-js": "^4.0.2"
-      }
-    },
-    "@types/rdfjs__formats-common": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__formats-common/-/rdfjs__formats-common-2.0.2.tgz",
-      "integrity": "sha512-2h3Db8iaOZjJIc26R8fz0LzdX3arGwQf2MzsRd6slW0Lq3B01LIN3eMS/EcCftf+yYAB+qdpOxGkwKI4e3C0Bg==",
-      "requires": {
-        "@types/rdfjs__sink-map": "*",
-        "rdf-js": "^4.0.2"
-      }
-    },
-    "@types/rdfjs__sink-map": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__sink-map/-/rdfjs__sink-map-1.0.2.tgz",
-      "integrity": "sha512-J1V0NYG+ImYS7Pc2fLBop5WOLkSOrLw5+A2QeFT2fmOn1gbB++9ct9b8Muod3KD4zRswGShF0Aq8ZyT2ut/HyQ==",
-      "requires": {
-        "rdf-js": "^4.0.2"
-      }
-    },
     "@types/redis": {
       "version": "2.8.30",
       "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.30.tgz",
@@ -22395,6 +21627,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -22628,19 +21861,6 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -22673,17 +21893,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "babel-jest": {
       "version": "27.0.6",
@@ -22796,14 +22007,6 @@
         "node-addon-api": "^3.1.0"
       }
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -22907,7 +22110,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "3.2.0",
@@ -23007,11 +22211,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.3.tgz",
       "integrity": "sha512-QWAGweNicWIXzcl7skvUZQ/ArdecS8fOeudnjIU0LYqSdTOSBSap+0VPMas4u11cW3a9sN5AN/aJHQUGfdWLCw=="
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "4.1.1",
@@ -23272,6 +22471,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -23342,46 +22542,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
     },
     "configstore": {
       "version": "5.0.1",
@@ -23598,14 +22758,6 @@
       "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
       "dev": true
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -23715,7 +22867,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -23835,15 +22988,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -24824,16 +23968,6 @@
         }
       }
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -24855,7 +23989,8 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -24980,21 +24115,6 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
       "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
     },
     "formidable": {
       "version": "1.2.2",
@@ -25152,14 +24272,6 @@
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "requires": {
         "pump": "^3.0.0"
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
       }
     },
     "git-raw-commits": {
@@ -25539,20 +24651,6 @@
         }
       }
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      }
-    },
     "hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -25742,16 +24840,6 @@
         "@tootallnate/once": "1",
         "agent-base": "6",
         "debug": "4"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
       }
     },
     "http2-wrapper": {
@@ -26152,7 +25240,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-yarn-global": {
       "version": "0.3.0",
@@ -26170,11 +25259,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -27720,11 +26804,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
     "jsdom": {
       "version": "16.6.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
@@ -27813,26 +26892,17 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.2.0",
@@ -27858,25 +26928,6 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
           "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
-        }
-      }
-    },
-    "jsonld": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.8.1.tgz",
-      "integrity": "sha512-f0rusl5v8aPKS3jApT5fhYsdTC/JpyK1PoJ+ZtYYtZXoyb1J0Z///mJqLwrfL/g4NueFSqPymDYIi1CcSk7b8Q==",
-      "requires": {
-        "canonicalize": "^1.0.1",
-        "rdf-canonize": "^1.0.2",
-        "request": "^2.88.0",
-        "semver": "^5.6.0",
-        "xmldom": "0.1.19"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -27935,17 +26986,6 @@
       "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
-      }
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
       }
     },
     "jsx-ast-utils": {
@@ -28539,11 +27579,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
-    "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -28578,17 +27613,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
       "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
       "dev": true
-    },
-    "nodeify-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/nodeify-fetch/-/nodeify-fetch-2.2.1.tgz",
-      "integrity": "sha512-NAvl/0QTipKEgf9Jo179TXJ02hQ3bM0BMcn6S5aBeL51MUX46GuQW430tHWERoMpC7YLk1oBXToMyX9yDxowqQ==",
-      "requires": {
-        "concat-stream": "^1.6.0",
-        "cross-fetch": "^3.0.4",
-        "readable-error": "^1.0.0",
-        "readable-stream": "^3.5.0"
-      }
     },
     "nodemailer": {
       "version": "6.6.2",
@@ -28730,11 +27754,6 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
-    },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -29209,11 +28228,6 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -29441,7 +28455,8 @@
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
     },
     "pstree.remy": {
       "version": "1.1.8",
@@ -29471,11 +28486,6 @@
       "requires": {
         "escape-goat": "^2.0.0"
       }
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "queue-microtask": {
       "version": "1.2.2",
@@ -29547,22 +28557,6 @@
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
-        }
-      }
-    },
-    "rdf-canonize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.2.0.tgz",
-      "integrity": "sha512-MQdcRDz4+82nUrEb3hNQangBDpmep15uMmnWclGi/1KS0bNVc8oHpoNI0PFLHZsvwgwRzH31bO1JAScqUAstvw==",
-      "requires": {
-        "node-forge": "^0.10.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -29971,43 +28965,6 @@
         "type-fest": "^0.8.1"
       }
     },
-    "readable-error": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/readable-error/-/readable-error-1.0.0.tgz",
-      "integrity": "sha512-CLnInu5bUphmFiZ3pD/BC6+Cg4/BzK6ZMvWfd0b2QMzYo159Z/f/nVFQ9L5IeMrqUxy0EFsp3XJ+BRfLfY13IQ==",
-      "requires": {
-        "readable-stream": "^2.3.3"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -30022,14 +28979,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz",
       "integrity": "sha1-i3YU+qFGXr+g2pucpjA/onBzt88="
-    },
-    "readable-to-readable": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/readable-to-readable/-/readable-to-readable-0.1.3.tgz",
-      "integrity": "sha512-G+0kz01xJM/uTuItKcqC73cifW8S6CZ7tp77NLN87lE5mrSU+GC8geoSAlfmp0NocmXckQ7W8s8ns73HYsIA3w==",
-      "requires": {
-        "readable-stream": "^3.6.0"
-      }
     },
     "readdirp": {
       "version": "3.6.0",
@@ -30131,40 +29080,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.6.tgz",
       "integrity": "sha512-Xw5/Zx6iWSCMJUXwXVOjySjH8Xli4hVFL9QQFvkl1qEmFBG94J+QUI9emnoctOCD3285f1jNV+QWV9eDYwIdfQ=="
-    },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
-      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -30639,22 +29554,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -31059,15 +29958,6 @@
         "nopt": "~1.0.10"
       }
     },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
     "tr46": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
@@ -31154,19 +30044,6 @@
         "tslib": "^1.8.1"
       }
     },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -31196,11 +30073,6 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -31366,6 +30238,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
       "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -31443,16 +30316,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     },
     "vscode-textmate": {
       "version": "5.2.0",
@@ -31735,11 +30598,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "xmldom": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
-      "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
   "dependencies": {
     "@comunica/actor-init-sparql": "^1.21.3",
     "@rdfjs/data-model": "^1.2.0",
-    "@rdfjs/fetch": "^2.1.0",
     "@solid/access-token-verifier": "^0.10.0",
     "@types/arrayify-stream": "^1.0.0",
     "@types/async-lock": "^1.1.2",
@@ -93,8 +92,6 @@
     "@types/pump": "^1.1.1",
     "@types/punycode": "^2.1.0",
     "@types/rdf-js": "^4.0.2",
-    "@types/rdfjs__fetch": "^2.0.3",
-    "@types/rdfjs__fetch-lite": "^2.0.3",
     "@types/redis": "^2.8.30",
     "@types/redlock": "^4.0.1",
     "@types/sparqljs": "^3.1.2",

--- a/src/util/FetchUtil.ts
+++ b/src/util/FetchUtil.ts
@@ -1,29 +1,54 @@
-import fetch from '@rdfjs/fetch';
-import type { DatasetResponse } from '@rdfjs/fetch-lite';
-import type { Dataset } from 'rdf-js';
+import type { Response } from 'cross-fetch';
+import { fetch } from 'cross-fetch';
+import { BasicRepresentation } from '../ldp/representation/BasicRepresentation';
+import type { Representation } from '../ldp/representation/Representation';
 import { getLoggerFor } from '../logging/LogUtil';
-import { createErrorMessage } from './errors/ErrorUtil';
+import type { RepresentationConverter } from '../storage/conversion/RepresentationConverter';
+import { INTERNAL_QUADS } from './ContentTypes';
+import { BadRequestHttpError } from './errors/BadRequestHttpError';
 
 const logger = getLoggerFor('FetchUtil');
 
 /**
  * Fetches an RDF dataset from the given URL.
+ * Input can also be a Response if the request was already made.
+ * In case the given Response object was already parsed its body can be passed along as a string.
+ *
+ * The converter will be used to convert the response body to RDF.
+ *
+ * Response will be a Representation with content-type internal/quads.
  */
-export async function fetchDataset(url: string): Promise<Dataset> {
-  let rawResponse: DatasetResponse<Dataset>;
-  try {
-    rawResponse = (await fetch(url)) as DatasetResponse<Dataset>;
-  } catch (err: unknown) {
-    logger.error(`Cannot fetch ${url}: ${createErrorMessage(err)}`);
-    throw new Error(`Cannot fetch ${url}`);
+export async function fetchDataset(url: string, converter: RepresentationConverter): Promise<Representation>;
+export async function fetchDataset(response: Response, converter: RepresentationConverter, body?: string):
+Promise<Representation>;
+export async function fetchDataset(input: string | Response, converter: RepresentationConverter, body?: string):
+Promise<Representation> {
+  let response: Response;
+  if (typeof input === 'string') {
+    response = await fetch(input);
+  } else {
+    response = input;
   }
-  let dataset: Dataset;
-  try {
-    dataset = await rawResponse.dataset();
-  } catch (err: unknown) {
-    logger.error(`Could not parse RDF in ${url}: ${createErrorMessage(err)}`);
-    // Keeping the error message the same to prevent leaking possible information about intranet
-    throw new Error(`Cannot fetch ${url}`);
+  if (!body) {
+    body = await response.text();
   }
-  return dataset;
+
+  // Keeping the error message the same everywhere to prevent leaking possible information about intranet.
+  const error = new BadRequestHttpError(`Unable to access data at ${response.url}`);
+
+  if (response.status !== 200) {
+    logger.warn(`Cannot fetch ${response.url}: ${body}`);
+    throw error;
+  }
+
+  const contentType = response.headers.get('content-type');
+  if (!contentType) {
+    logger.warn(`Missing content-type header from ${response.url}`);
+    throw error;
+  }
+
+  // Try to convert to quads
+  const representation = new BasicRepresentation(body, contentType);
+  const preferences = { type: { [INTERNAL_QUADS]: 1 }};
+  return converter.handleSafe({ representation, identifier: { path: response.url }, preferences });
 }

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -100,6 +100,10 @@ export const MA = createUriAndTermNamespace('http://www.w3.org/ns/ma-ont#',
   'format',
 );
 
+export const OIDC = createUriAndTermNamespace('http://www.w3.org/ns/solid/oidc#',
+  'redirect_uris',
+);
+
 export const PIM = createUriAndTermNamespace('http://www.w3.org/ns/pim/space#',
   'Storage',
 );

--- a/test/unit/identity/ownership/TokenOwnershipValidator.test.ts
+++ b/test/unit/identity/ownership/TokenOwnershipValidator.test.ts
@@ -1,15 +1,14 @@
-import fetch from '@rdfjs/fetch';
-import type { DatasetResponse } from '@rdfjs/fetch-lite';
+import { fetch } from 'cross-fetch';
 import { DataFactory } from 'n3';
 import type { Quad } from 'n3';
-import type { DatasetCore } from 'rdf-js';
 import { v4 } from 'uuid';
 import { TokenOwnershipValidator } from '../../../../src/identity/ownership/TokenOwnershipValidator';
+import { RdfToQuadConverter } from '../../../../src/storage/conversion/RdfToQuadConverter';
 import type { ExpiringStorage } from '../../../../src/storage/keyvalue/ExpiringStorage';
 import { SOLID } from '../../../../src/util/Vocabularies';
 const { literal, namedNode, quad } = DataFactory;
 
-jest.mock('@rdfjs/fetch');
+jest.mock('cross-fetch');
 jest.mock('uuid');
 
 function quadToString(qq: Quad): string {
@@ -24,26 +23,25 @@ describe('A TokenOwnershipValidator', (): void => {
   const fetchMock: jest.Mock = fetch as any;
   const webId = 'http://alice.test.com/#me';
   const token = 'randomlyGeneratedToken';
-  let rawResponse: DatasetResponse<DatasetCore>;
-  let dataset: DatasetCore;
-  let triples: Quad[];
   const tokenTriple = quad(namedNode(webId), SOLID.terms.oidcIssuerRegistrationToken, literal(token));
+  const tokenString = `${quadToString(tokenTriple)} .`;
+  const converter = new RdfToQuadConverter();
   let storage: ExpiringStorage<string, string>;
   let validator: TokenOwnershipValidator;
+
+  function mockFetch(body: string): void {
+    fetchMock.mockImplementation((url: string): any => ({
+      text: (): any => body,
+      url,
+      status: 200,
+      headers: { get: (): any => 'text/turtle' },
+    }));
+  }
 
   beforeEach(async(): Promise<void> => {
     const now = Date.now();
     jest.spyOn(Date, 'now').mockReturnValue(now);
     (v4 as jest.Mock).mockReturnValue(token);
-    triples = [];
-
-    dataset = {
-      has: (qq: Quad): boolean => triples.some((triple): boolean => triple.equals(qq)),
-    } as any;
-
-    rawResponse = {
-      dataset: async(): Promise<DatasetCore> => dataset,
-    } as any;
 
     const map = new Map<string, any>();
     storage = {
@@ -52,40 +50,41 @@ describe('A TokenOwnershipValidator', (): void => {
       delete: jest.fn().mockImplementation((key: string): any => map.delete(key)),
     } as any;
 
-    fetchMock.mockReturnValue(rawResponse);
+    mockFetch('');
 
-    validator = new TokenOwnershipValidator(storage);
+    validator = new TokenOwnershipValidator(converter, storage);
   });
 
   it('errors if no token is stored in the storage.', async(): Promise<void> => {
     // Even if the token is in the WebId, it will error since it's not in the storage
-    triples = [ tokenTriple ];
-    await expect(validator.handle({ webId })).rejects.toThrow(quadToString(tokenTriple));
+    mockFetch(tokenString);
+    await expect(validator.handle({ webId })).rejects.toThrow(tokenString);
     expect(fetch).toHaveBeenCalledTimes(0);
   });
 
   it('errors if the expected triple is missing.', async(): Promise<void> => {
     // First call will add the token to the storage
-    await expect(validator.handle({ webId })).rejects.toThrow(quadToString(tokenTriple));
+    await expect(validator.handle({ webId })).rejects.toThrow(tokenString);
     expect(fetch).toHaveBeenCalledTimes(0);
     // Second call will fetch the WebId
-    await expect(validator.handle({ webId })).rejects.toThrow(quadToString(tokenTriple));
+    await expect(validator.handle({ webId })).rejects.toThrow(tokenString);
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
   it('resolves if the WebId contains the verification triple.', async(): Promise<void> => {
-    triples = [ tokenTriple ];
+    mockFetch(tokenString);
     // First call will add the token to the storage
-    await expect(validator.handle({ webId })).rejects.toThrow(quadToString(tokenTriple));
+    await expect(validator.handle({ webId })).rejects.toThrow(tokenString);
     // Second call will succeed since it has the verification triple
     await expect(validator.handle({ webId })).resolves.toBeUndefined();
   });
 
   it('fails if the WebId contains the wrong verification triple.', async(): Promise<void> => {
-    triples = [ quad(namedNode(webId), SOLID.terms.oidcIssuerRegistrationToken, literal('wrongToken')) ];
+    const wrongQuad = quad(namedNode(webId), SOLID.terms.oidcIssuerRegistrationToken, literal('wrongToken'));
+    mockFetch(`${quadToString(wrongQuad)} .`);
     // First call will add the token to the storage
-    await expect(validator.handle({ webId })).rejects.toThrow(quadToString(tokenTriple));
+    await expect(validator.handle({ webId })).rejects.toThrow(tokenString);
     // Second call will fail since it has the wrong verification triple
-    await expect(validator.handle({ webId })).rejects.toThrow(quadToString(tokenTriple));
+    await expect(validator.handle({ webId })).rejects.toThrow(tokenString);
   });
 });


### PR DESCRIPTION
This way we use our own converters (and we remove a bunch of dependencies).