### PR TITLE
chore: Update access token verifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@comunica/actor-init-sparql": "^1.21.3",
         "@rdfjs/data-model": "^1.2.0",
-        "@solid/access-token-verifier": "^0.10.0",
+        "@solid/access-token-verifier": "^0.11.0",
         "@types/arrayify-stream": "^1.0.0",
         "@types/async-lock": "^1.1.2",
         "@types/bcrypt": "^5.0.0",
@@ -4763,9 +4763,9 @@
       }
     },
     "node_modules/@solid/access-token-verifier": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@solid/access-token-verifier/-/access-token-verifier-0.10.0.tgz",
-      "integrity": "sha512-G+kpyEQmBTrjsx8FjlIx34ulPdS/6u/mXW7I/tfhJtMqzIQTU7JUk8l6jCFxaO9aHRfWg3uB6n8zbrO1vbsnjg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@solid/access-token-verifier/-/access-token-verifier-0.11.0.tgz",
+      "integrity": "sha512-L5XG5qk77FfgfM9uGL16qe08MWt0u5IHz7NsmXEZy8P260RRyt99a2b+nJyb1siXsNC1Z25CtOn1OrPa4Mqjng==",
       "dependencies": {
         "cross-fetch": "^3.1.4",
         "jose": "^3.14.3",
@@ -20893,9 +20893,9 @@
       }
     },
     "@solid/access-token-verifier": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@solid/access-token-verifier/-/access-token-verifier-0.10.0.tgz",
-      "integrity": "sha512-G+kpyEQmBTrjsx8FjlIx34ulPdS/6u/mXW7I/tfhJtMqzIQTU7JUk8l6jCFxaO9aHRfWg3uB6n8zbrO1vbsnjg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@solid/access-token-verifier/-/access-token-verifier-0.11.0.tgz",
+      "integrity": "sha512-L5XG5qk77FfgfM9uGL16qe08MWt0u5IHz7NsmXEZy8P260RRyt99a2b+nJyb1siXsNC1Z25CtOn1OrPa4Mqjng==",
       "requires": {
         "cross-fetch": "^3.1.4",
         "jose": "^3.14.3",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@comunica/actor-init-sparql": "^1.21.3",
     "@rdfjs/data-model": "^1.2.0",
-    "@solid/access-token-verifier": "^0.10.0",
+    "@solid/access-token-verifier": "^0.11.0",
     "@types/arrayify-stream": "^1.0.0",
     "@types/async-lock": "^1.1.2",
     "@types/bcrypt": "^5.0.0",


### PR DESCRIPTION
The 0.11.0 release of https://github.com/solid/access-token-verifier is a serious rewrite improving quality of tests as well as organisation and readability of the project. It shouldn't introduce any breaking changes and all tests are passing, but I'd like to have it in production for a little bit of time before calling it a 1.0. Ideally, the code base would be checked by a second pair of eyes which should be much more doable in its current state than previously.