### PR TITLE
chore: Clean up unnecessary imports

### DIFF
--- a/config/util/representation-conversion/converters/errors.json
+++ b/config/util/representation-conversion/converters/errors.json
@@ -1,11 +1,5 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
-  "import": [
-    "files-scs:config/util/representation-conversion/converters/content-type-replacer.json",
-    "files-scs:config/util/representation-conversion/converters/quad-to-rdf.json",
-    "files-scs:config/util/representation-conversion/converters/rdf-to-quad.json",
-    "files-scs:config/util/representation-conversion/converters/markdown.json"
-  ],
   "@graph": [
     {
       "@id": "urn:solid-server:default:ErrorToQuadConverter",

--- a/config/util/representation-conversion/converters/markdown.json
+++ b/config/util/representation-conversion/converters/markdown.json
@@ -1,10 +1,5 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
-  "import": [
-    "files-scs:config/util/representation-conversion/converters/content-type-replacer.json",
-    "files-scs:config/util/representation-conversion/converters/quad-to-rdf.json",
-    "files-scs:config/util/representation-conversion/converters/rdf-to-quad.json"
-  ],
   "@graph": [
     {
       "comment": "Renders Markdown snippets into the main page template.",


### PR DESCRIPTION
Noticed some imports in configs that shouldn't be there.

Technically this is breaking if someone is importing those specifically and depends on those imports 😅 . If that is an issue this should be merged in a different branch.