### PR TITLE
feat: Add support for groups in WebAclAuthorizer

### DIFF
--- a/config/ldp/authorization/authorizers/access-checkers/agent.json
+++ b/config/ldp/authorization/authorizers/access-checkers/agent.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "@id": "urn:solid-server:default:AgentAccessChecker",
+      "@type": "AgentAccessChecker"
+    }
+  ]
+}

--- a/config/ldp/authorization/authorizers/access-checkers/agentClass.json
+++ b/config/ldp/authorization/authorizers/access-checkers/agentClass.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "@id": "urn:solid-server:default:AgentClassAccessChecker",
+      "@type": "AgentClassAccessChecker"
+    }
+  ]
+}

--- a/config/ldp/authorization/authorizers/access-checkers/agentGroup.json
+++ b/config/ldp/authorization/authorizers/access-checkers/agentGroup.json
@@ -1,0 +1,10 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "@id": "urn:solid-server:default:AgentGroupAccessChecker",
+      "@type": "AgentGroupAccessChecker",
+      "converter": { "@id": "urn:solid-server:default:RepresentationConverter" }
+    }
+  ]
+}

--- a/config/ldp/authorization/authorizers/acl.json
+++ b/config/ldp/authorization/authorizers/acl.json
@@ -1,5 +1,9 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
+  "import": [
+    "files-scs:config/ldp/authorization/authorizers/access-checkers/agent.json",
+    "files-scs:config/ldp/authorization/authorizers/access-checkers/agentClass.json"
+  ],
   "@graph": [
     {
       "@id": "urn:solid-server:default:WebAclAuthorizer",
@@ -12,6 +16,13 @@
       },
       "identifierStrategy": {
         "@id": "urn:solid-server:default:IdentifierStrategy"
+      },
+      "accessChecker": {
+        "@type": "BooleanHandler",
+        "handlers": [
+          { "@id": "urn:solid-server:default:AgentAccessChecker" },
+          { "@id": "urn:solid-server:default:AgentClassAccessChecker" }
+        ]
       }
     }
   ]

--- a/config/ldp/authorization/authorizers/acl.json
+++ b/config/ldp/authorization/authorizers/acl.json
@@ -2,7 +2,8 @@
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
   "import": [
     "files-scs:config/ldp/authorization/authorizers/access-checkers/agent.json",
-    "files-scs:config/ldp/authorization/authorizers/access-checkers/agentClass.json"
+    "files-scs:config/ldp/authorization/authorizers/access-checkers/agentClass.json",
+    "files-scs:config/ldp/authorization/authorizers/access-checkers/agentGroup.json"
   ],
   "@graph": [
     {
@@ -21,7 +22,8 @@
         "@type": "BooleanHandler",
         "handlers": [
           { "@id": "urn:solid-server:default:AgentAccessChecker" },
-          { "@id": "urn:solid-server:default:AgentClassAccessChecker" }
+          { "@id": "urn:solid-server:default:AgentClassAccessChecker" },
+          { "@id": "urn:solid-server:default:AgentGroupAccessChecker" }
         ]
       }
     }

--- a/src/authorization/WebAclAuthorizer.ts
+++ b/src/authorization/WebAclAuthorizer.ts
@@ -24,8 +24,9 @@ import { WebAclAuthorization } from './WebAclAuthorization';
 
 /**
  * Handles most web access control predicates such as
- * `acl:mode`, `acl:agentClass`, `acl:agent`, `acl:default` and `acl:accessTo`.
- * Does not support `acl:agentGroup`, `acl:origin` and `acl:trustedApp` yet.
+ * `acl:mode`, `acl:agentClass`, `acl:agent`, `acl:default`,
+ * `acl:accessTo` and `acl:agentGroup`.
+ * Does not support `acl:origin` and `acl:trustedApp` yet.
  */
 export class WebAclAuthorizer extends Authorizer {
   protected readonly logger = getLoggerFor(this);

--- a/src/authorization/WebAclAuthorizer.ts
+++ b/src/authorization/WebAclAuthorizer.ts
@@ -16,7 +16,8 @@ import { NotImplementedHttpError } from '../util/errors/NotImplementedHttpError'
 import { UnauthorizedHttpError } from '../util/errors/UnauthorizedHttpError';
 import type { IdentifierStrategy } from '../util/identifiers/IdentifierStrategy';
 import { readableToQuads } from '../util/StreamUtil';
-import { ACL, FOAF } from '../util/Vocabularies';
+import { ACL, RDF } from '../util/Vocabularies';
+import type { AccessChecker } from './access-checkers/AccessChecker';
 import type { AuthorizerArgs } from './Authorizer';
 import { Authorizer } from './Authorizer';
 import { WebAclAuthorization } from './WebAclAuthorization';
@@ -29,16 +30,25 @@ import { WebAclAuthorization } from './WebAclAuthorization';
 export class WebAclAuthorizer extends Authorizer {
   protected readonly logger = getLoggerFor(this);
 
+  private readonly modesMap: Record<string, keyof PermissionSet> = {
+    [ACL.Read]: 'read',
+    [ACL.Write]: 'write',
+    [ACL.Append]: 'append',
+    [ACL.Control]: 'control',
+  };
+
   private readonly aclStrategy: AuxiliaryIdentifierStrategy;
   private readonly resourceStore: ResourceStore;
   private readonly identifierStrategy: IdentifierStrategy;
+  private readonly accessChecker: AccessChecker;
 
   public constructor(aclStrategy: AuxiliaryIdentifierStrategy, resourceStore: ResourceStore,
-    identifierStrategy: IdentifierStrategy) {
+    identifierStrategy: IdentifierStrategy, accessChecker: AccessChecker) {
     super();
     this.aclStrategy = aclStrategy;
     this.resourceStore = resourceStore;
     this.identifierStrategy = identifierStrategy;
+    this.accessChecker = accessChecker;
   }
 
   public async canHandle({ identifier }: AuthorizerArgs): Promise<void> {
@@ -59,7 +69,7 @@ export class WebAclAuthorizer extends Authorizer {
 
     // Determine the full authorization for the agent granted by the applicable ACL
     const acl = await this.getAclRecursive(identifier);
-    const authorization = this.createAuthorization(credentials, acl);
+    const authorization = await this.createAuthorization(credentials, acl);
 
     // Verify that the authorization allows all required modes
     for (const mode of modes) {
@@ -82,11 +92,11 @@ export class WebAclAuthorizer extends Authorizer {
    * @param agent - Agent whose credentials will be used for the `user` field.
    * @param acl - Store containing all relevant authorization triples.
    */
-  private createAuthorization(agent: Credentials, acl: Store): WebAclAuthorization {
-    const publicPermissions = this.determinePermissions({}, acl);
-    const userPermissions = this.determinePermissions(agent, acl);
+  private async createAuthorization(agent: Credentials, acl: Store): Promise<WebAclAuthorization> {
+    const publicPermissions = await this.determinePermissions({}, acl);
+    const agentPermissions = await this.determinePermissions(agent, acl);
 
-    return new WebAclAuthorization(userPermissions, publicPermissions);
+    return new WebAclAuthorization(agentPermissions, publicPermissions);
   }
 
   /**
@@ -94,16 +104,35 @@ export class WebAclAuthorizer extends Authorizer {
    * @param credentials - Credentials to find the permissions for.
    * @param acl - Store containing all relevant authorization triples.
    */
-  private determinePermissions(credentials: Credentials, acl: Store): PermissionSet {
-    const permissions: PermissionSet = {
+  private async determinePermissions(credentials: Credentials, acl: Store): Promise<PermissionSet> {
+    const permissions = {
       read: false,
       write: false,
       append: false,
       control: false,
     };
-    for (const mode of (Object.keys(permissions) as (keyof PermissionSet)[])) {
-      permissions[mode] = this.hasPermission(credentials, acl, mode);
+
+    const aclRules = acl.getSubjects(RDF.type, ACL.Authorization, null);
+
+    for (const rule of aclRules) {
+      const hasAccess = await this.accessChecker.handleSafe({ acl, rule, credentials });
+
+      if (hasAccess) {
+        const modes = acl.getObjects(rule, ACL.mode, null);
+        modes.forEach((mode): void => {
+          if (mode.value in this.modesMap) {
+            const modeProperty = this.modesMap[mode.value];
+            permissions[modeProperty] = true;
+          }
+        });
+      }
     }
+
+    if (permissions.write) {
+      // Write permission implies Append permission
+      permissions.append = true;
+    }
+
     return permissions;
   }
 
@@ -128,75 +157,6 @@ export class WebAclAuthorizer extends Authorizer {
         throw new UnauthorizedHttpError();
       }
     }
-  }
-
-  /**
-   * Checks if the given agent has permission to execute the given mode based on the triples in the ACL.
-   * @param agent - Agent that wants access.
-   * @param acl - A store containing the relevant triples for authorization.
-   * @param mode - Which mode is requested.
-   */
-  private hasPermission(agent: Credentials, acl: Store, mode: keyof PermissionSet): boolean {
-    // Collect all authorization blocks for this specific mode
-    const modeString = ACL[this.capitalize(mode) as 'Write' | 'Read' | 'Append' | 'Control'];
-    const auths = this.getModePermissions(acl, modeString);
-
-    // Append permissions are implied by Write permissions
-    if (modeString === ACL.Append) {
-      auths.push(...this.getModePermissions(acl, ACL.Write));
-    }
-
-    // Check if any collected authorization block allows the specific agent
-    return auths.some((term): boolean => this.hasAccess(agent, term, acl));
-  }
-
-  /**
-   * Capitalizes the input string.
-   * @param mode - String to transform.
-   *
-   * @returns The capitalized string.
-   */
-  private capitalize(mode: string): string {
-    return `${mode[0].toUpperCase()}${mode.slice(1).toLowerCase()}`;
-  }
-
-  /**
-   * Returns the identifiers of all authorizations that grant the given mode access for a resource.
-   * @param acl - The store containing the quads of the ACL resource.
-   * @param aclMode - A valid acl mode (ACL.Write/Read/...)
-   */
-  private getModePermissions(acl: Store, aclMode: string): Term[] {
-    return acl.getQuads(null, ACL.mode, aclMode, null).map((quad: Quad): Term => quad.subject);
-  }
-
-  /**
-   * Checks if the given agent has access to the modes specified by the given authorization.
-   * @param agent - Credentials of agent that needs access.
-   * @param auth - acl:Authorization that needs to be checked.
-   * @param acl - A store containing the relevant triples of the authorization.
-   *
-   * @returns If the agent has access.
-   */
-  private hasAccess(agent: Credentials, auth: Term, acl: Store): boolean {
-    // Check if public access is allowed
-    if (acl.countQuads(auth, ACL.agentClass, FOAF.Agent, null) !== 0) {
-      return true;
-    }
-
-    // Check if authenticated access is allowed
-    if (this.isAuthenticated(agent)) {
-      // Check if any authenticated agent is allowed
-      if (acl.countQuads(auth, ACL.agentClass, ACL.AuthenticatedAgent, null) !== 0) {
-        return true;
-      }
-      // Check if this specific agent is allowed
-      if (acl.countQuads(auth, ACL.agent, agent.webId, null) !== 0) {
-        return true;
-      }
-    }
-
-    // Neither unauthenticated nor authenticated access are allowed
-    return false;
   }
 
   /**

--- a/src/authorization/WebAclAuthorizer.ts
+++ b/src/authorization/WebAclAuthorizer.ts
@@ -15,6 +15,7 @@ import { NotFoundHttpError } from '../util/errors/NotFoundHttpError';
 import { NotImplementedHttpError } from '../util/errors/NotImplementedHttpError';
 import { UnauthorizedHttpError } from '../util/errors/UnauthorizedHttpError';
 import type { IdentifierStrategy } from '../util/identifiers/IdentifierStrategy';
+import { readableToQuads } from '../util/StreamUtil';
 import { ACL, FOAF } from '../util/Vocabularies';
 import type { AuthorizerArgs } from './Authorizer';
 import { Authorizer } from './Authorizer';
@@ -254,12 +255,7 @@ export class WebAclAuthorizer extends Authorizer {
    */
   private async filterData(data: Representation, predicate: string, object: string): Promise<Store> {
     // Import all triples from the representation into a queryable store
-    const quads = new Store();
-    const importer = quads.import(data.data);
-    await new Promise((resolve, reject): void => {
-      importer.on('end', resolve);
-      importer.on('error', reject);
-    });
+    const quads = await readableToQuads(data.data);
 
     // Find subjects that occur with a given predicate/object, and collect all their triples
     const subjectData = new Store();

--- a/src/authorization/access-checkers/AccessChecker.ts
+++ b/src/authorization/access-checkers/AccessChecker.ts
@@ -1,0 +1,25 @@
+import type { Store, Term } from 'n3';
+import type { Credentials } from '../../authentication/Credentials';
+import { AsyncHandler } from '../../util/handlers/AsyncHandler';
+
+/**
+ * Performs an authorization check against the given acl resource.
+ */
+export abstract class AccessChecker extends AsyncHandler<AccessCheckerArgs, boolean> {}
+
+export interface AccessCheckerArgs {
+  /**
+   *  A store containing the relevant triples of the authorization.
+   */
+  acl: Store;
+
+  /**
+   * Authorization rule to be processed.
+   */
+  rule: Term;
+
+  /**
+   * Credentials of the entity that wants to use the resource.
+   */
+  credentials: Credentials;
+}

--- a/src/authorization/access-checkers/AgentAccessChecker.ts
+++ b/src/authorization/access-checkers/AgentAccessChecker.ts
@@ -1,0 +1,12 @@
+import { ACL } from '../../util/Vocabularies';
+import type { AccessCheckerArgs } from './AccessChecker';
+import { AccessChecker } from './AccessChecker';
+
+export class AgentAccessChecker extends AccessChecker {
+  public async handle({ acl, rule, credentials }: AccessCheckerArgs): Promise<boolean> {
+    if (typeof credentials.webId === 'string') {
+      return acl.countQuads(rule, ACL.agent, credentials.webId, null) !== 0;
+    }
+    return false;
+  }
+}

--- a/src/authorization/access-checkers/AgentClassAccessChecker.ts
+++ b/src/authorization/access-checkers/AgentClassAccessChecker.ts
@@ -1,0 +1,15 @@
+import { ACL, FOAF } from '../../util/Vocabularies';
+import type { AccessCheckerArgs } from './AccessChecker';
+import { AccessChecker } from './AccessChecker';
+
+export class AgentClassAccessChecker extends AccessChecker {
+  public async handle({ acl, rule, credentials }: AccessCheckerArgs): Promise<boolean> {
+    if (acl.countQuads(rule, ACL.agentClass, FOAF.Agent, null) !== 0) {
+      return true;
+    }
+    if (typeof credentials.webId === 'string') {
+      return acl.countQuads(rule, ACL.agentClass, ACL.AuthenticatedAgent, null) !== 0;
+    }
+    return false;
+  }
+}

--- a/src/authorization/access-checkers/AgentGroupAccessChecker.ts
+++ b/src/authorization/access-checkers/AgentGroupAccessChecker.ts
@@ -1,0 +1,46 @@
+import type { Term } from 'n3';
+import type { ResourceIdentifier } from '../../ldp/representation/ResourceIdentifier';
+import type { RepresentationConverter } from '../../storage/conversion/RepresentationConverter';
+import { fetchDataset } from '../../util/FetchUtil';
+import { promiseAny } from '../../util/PromiseUtil';
+import { readableToQuads } from '../../util/StreamUtil';
+import { ACL, VCARD } from '../../util/Vocabularies';
+import type { AccessCheckerArgs } from './AccessChecker';
+import { AccessChecker } from './AccessChecker';
+
+export class AgentGroupAccessChecker extends AccessChecker {
+  private readonly converter: RepresentationConverter;
+
+  public constructor(converter: RepresentationConverter) {
+    super();
+    this.converter = converter;
+  }
+
+  public async handle({ acl, rule, credentials }: AccessCheckerArgs): Promise<boolean> {
+    if (typeof credentials.webId === 'string') {
+      const { webId } = credentials;
+      const groups = acl.getObjects(rule, ACL.agentGroup, null);
+
+      return await promiseAny(groups.map(async(group: Term): Promise<boolean> =>
+        this.isMemberOfGroup(webId, group)));
+    }
+    return false;
+  }
+
+  /**
+   * Checks if the given agent is member of a given vCard group.
+   * @param webId - WebID of the agent that needs access.
+   * @param group - URL of the vCard group that needs to be checked.
+   *
+   * @returns If the agent is member of the given vCard group.
+   */
+  private async isMemberOfGroup(webId: string, group: Term): Promise<boolean> {
+    const groupDocument: ResourceIdentifier = { path: /^[^#]*/u.exec(group.value)![0] };
+
+    // Fetch the required vCard group file
+    const dataset = await fetchDataset(groupDocument.path, this.converter);
+
+    const quads = await readableToQuads(dataset.data);
+    return quads.countQuads(group, VCARD.hasMember, webId, null) !== 0;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -318,6 +318,7 @@ export * from './util/FetchUtil';
 export * from './util/GuardedStream';
 export * from './util/HeaderUtil';
 export * from './util/PathUtil';
+export * from './util/PromiseUtil';
 export * from './util/QuadUtil';
 export * from './util/RecordObject';
 export * from './util/ResourceUtil';

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export * from './authorization/WebAclAuthorizer';
 export * from './authorization/access-checkers/AccessChecker';
 export * from './authorization/access-checkers/AgentAccessChecker';
 export * from './authorization/access-checkers/AgentClassAccessChecker';
+export * from './authorization/access-checkers/AgentGroupAccessChecker';
 
 // Identity/Configuration
 export * from './identity/configuration/IdentityProviderFactory';

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,6 +285,7 @@ export * from './util/errors/UnsupportedMediaTypeHttpError';
 
 // Util/Handlers
 export * from './util/handlers/AsyncHandler';
+export * from './util/handlers/BooleanHandler';
 export * from './util/handlers/ParallelHandler';
 export * from './util/handlers/SequenceHandler';
 export * from './util/handlers/UnsupportedAsyncHandler';

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,11 @@ export * from './authorization/PathBasedAuthorizer';
 export * from './authorization/WebAclAuthorization';
 export * from './authorization/WebAclAuthorizer';
 
+// Authorization/access-checkers
+export * from './authorization/access-checkers/AccessChecker';
+export * from './authorization/access-checkers/AgentAccessChecker';
+export * from './authorization/access-checkers/AgentClassAccessChecker';
+
 // Identity/Configuration
 export * from './identity/configuration/IdentityProviderFactory';
 export * from './identity/configuration/ProviderFactory';

--- a/src/util/PromiseUtil.ts
+++ b/src/util/PromiseUtil.ts
@@ -1,0 +1,47 @@
+/**
+ * A replacement for the Promise.any() function, which is only supported
+ * by NodeJs starting from version 15.0.0.
+ *
+ * @remarks
+ *
+ * Predicates provided as input must be implemented considering
+ * the following points:
+ * 1. if they throw an error, it won't be propagated;
+ * 2. throwing an error should be logically equivalent to return false.
+ */
+export async function promiseAny(predicates: Promise<boolean>[]): Promise<boolean> {
+  try {
+    await Promise.all(predicates.map(async(predicate): Promise<boolean> => {
+      try {
+        if (await predicate) {
+          /**
+           * The predicate returned true: we return a rejected promise
+           * so that Promise.all() will immediately stop.
+           */
+          return Promise.reject(new Error('At least a promise was fulfilled with true.'));
+        }
+        /**
+         * The predicate returned false: we return a resolved promise
+         * so that Promise.all() will continue executing.
+         */
+        return Promise.resolve(false);
+      } catch {
+        // The predicate threw an error: we treat it as if it returned false.
+        return Promise.resolve(false);
+      }
+    }));
+
+    /**
+     * Promise.all() terminated successfully: this means that
+     * every promise was fulfilled with false.
+     */
+    return false;
+  } catch {
+    /**
+     * Promise.all() terminated earlier then expected because
+     * of a rejected promise: this means that at least one
+     * promise was fulfilled with true.
+     */
+    return true;
+  }
+}

--- a/src/util/StreamUtil.ts
+++ b/src/util/StreamUtil.ts
@@ -3,6 +3,7 @@ import { Readable, Transform } from 'stream';
 import { promisify } from 'util';
 import arrayifyStream from 'arrayify-stream';
 import eos from 'end-of-stream';
+import { Store } from 'n3';
 import pump from 'pump';
 import { getLoggerFor } from '../logging/LogUtil';
 import { isHttpRequest } from '../server/HttpRequest';
@@ -21,6 +22,19 @@ const logger = getLoggerFor('StreamUtil');
  */
 export async function readableToString(stream: Readable): Promise<string> {
   return (await arrayifyStream(stream)).join('');
+}
+
+/**
+ * Imports quads from a stream into a Store.
+ * @param stream - Stream of quads.
+ *
+ * @returns A Store containing all the quads.
+ */
+export async function readableToQuads(stream: Readable): Promise<Store> {
+  const quads = new Store();
+  quads.import(stream);
+  await endOfStream(stream);
+  return quads;
 }
 
 // These error messages usually indicate expected behaviour so should not give a warning.

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -59,6 +59,7 @@ export const ACL = createUriAndTermNamespace('http://www.w3.org/ns/auth/acl#',
   'accessTo',
   'agent',
   'agentClass',
+  'agentGroup',
   'AuthenticatedAgent',
   'Authorization',
   'default',
@@ -140,6 +141,10 @@ export const SOLID_META = createUriAndTermNamespace('urn:npm:solid:community-ser
 
 export const VANN = createUriAndTermNamespace('http://purl.org/vocab/vann/',
   'preferredNamespacePrefix',
+);
+
+export const VCARD = createUriAndTermNamespace('http://www.w3.org/2006/vcard/ns#',
+  'hasMember',
 );
 
 export const XSD = createUriAndTermNamespace('http://www.w3.org/2001/XMLSchema#',

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -60,6 +60,7 @@ export const ACL = createUriAndTermNamespace('http://www.w3.org/ns/auth/acl#',
   'agent',
   'agentClass',
   'AuthenticatedAgent',
+  'Authorization',
   'default',
   'mode',
 

--- a/src/util/handlers/BooleanHandler.ts
+++ b/src/util/handlers/BooleanHandler.ts
@@ -1,0 +1,48 @@
+import { getLoggerFor } from '../../logging/LogUtil';
+import { InternalServerError } from '../errors/InternalServerError';
+import { AsyncHandler } from './AsyncHandler';
+
+/**
+ * A composite handler that tries multiple handlers one by one
+ * until it finds a handler that returns true.
+ * The handlers will be checked in the order they appear in the input array,
+ * allowing for more fine-grained handlers to check before catch-all handlers.
+ */
+export class BooleanHandler<TIn> extends AsyncHandler<TIn, boolean> {
+  protected readonly logger = getLoggerFor(this);
+
+  private readonly handlers: AsyncHandler<TIn, boolean>[];
+
+  /**
+   * Creates a new BooleanHandler that stores the given handlers.
+   * @param handlers - Handlers over which it will run.
+   */
+  public constructor(handlers: AsyncHandler<TIn, boolean>[]) {
+    super();
+    this.handlers = handlers;
+  }
+
+  /**
+   * Loops over every handler until it finds one that returns true.
+   * @param input - The data that needs to be handled.
+   *
+   * @returns A promise corresponding to the existence of an handler that returns
+   * true with the given input data.
+   * It rejects if a handler throws an error.
+   */
+  public async handle(input: TIn): Promise<boolean> {
+    for (const handler of this.handlers) {
+      try {
+        const result = await handler.handleSafe(input);
+        if (result) {
+          return true;
+        }
+      } catch (error: unknown) {
+        this.logger.warn('A handler failed.');
+        throw new InternalServerError('A handler failed', { cause: error });
+      }
+    }
+
+    return false;
+  }
+}

--- a/test/unit/util/PromiseUtil.test.ts
+++ b/test/unit/util/PromiseUtil.test.ts
@@ -1,0 +1,33 @@
+import { promiseAny } from '../../../src/util/PromiseUtil';
+
+describe('PromiseUtil', (): void => {
+  describe('#promiseAny', (): void => {
+    it('returns false if no promise is provided.', async(): Promise<void> => {
+      await expect(promiseAny([])).resolves.toEqual(false);
+    });
+
+    it('returns false if no promise returns true.', async(): Promise<void> => {
+      const promise1 = Promise.resolve(false);
+      const promise2 = Promise.resolve(false);
+      const promise3 = Promise.resolve(false);
+
+      await expect(promiseAny([ promise1, promise2, promise3 ])).resolves.toEqual(false);
+    });
+
+    it('returns true if at least a promise returns true.', async(): Promise<void> => {
+      const promise1 = Promise.resolve(false);
+      const promise2 = Promise.resolve(true);
+      const promise3 = Promise.resolve(false);
+
+      await expect(promiseAny([ promise1, promise2, promise3 ])).resolves.toEqual(true);
+    });
+
+    it('does not propagate errors.', async(): Promise<void> => {
+      const promise1 = Promise.reject(new Error('generic error'));
+      const promise2 = Promise.resolve(false);
+      const promise3 = Promise.resolve(false);
+
+      await expect(promiseAny([ promise1, promise2, promise3 ])).resolves.toEqual(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #239.

Hi everyone!
Together with @LudovicoGranata, we've implemented the `ACL.agentGroup` feature for the `WebAclAuthorizer.ts` module.
In our use case, we needed the possibility to define groups of users so that giving them permissions could become easier.

We are definitely aware that our implementation is still not 100% foolproof, as we decided (for the moment) not to tackle the ["Infinite Request Loops in Group Listings" problem](https://github.com/solid/web-access-control-spec/blob/main/README-v0.5.0.md#infinite-request-loops-in-group-listings).

This implementation works for us, with some limitations:
- vCard group files are not syntactically validated;
- vCard group files MUST be publicly accessible: unauthenticated requests will be made to fetch them, avoiding at the root the _"Infinite Request Loops"_ problem cited above. <ins>**Future changes removing this limitation should also deal with finding a solution to that problem.**</ins>

We hope that this contribution could be useful for the CSS project and we're open for suggestions on how to improve it!