### PR TITLE
Support Conditions

### DIFF
--- a/.componentsignore
+++ b/.componentsignore
@@ -1,5 +1,6 @@
 [
   "Adapter",
+  "BasicConditions",
   "BasicRepresentation",
   "Error",
   "EventEmitter",

--- a/config/http/middleware/handlers/cors.json
+++ b/config/http/middleware/handlers/cors.json
@@ -17,6 +17,8 @@
       "options_credentials": true,
       "options_exposedHeaders": [
         "Accept-Patch",
+        "ETag",
+        "Last-Modified",
         "Link",
         "Location",
         "MS-Author-Via",

--- a/config/ldp/handler/components/request-parser.json
+++ b/config/ldp/handler/components/request-parser.json
@@ -11,6 +11,7 @@
       },
       "args_preferenceParser": { "@type": "AcceptPreferenceParser" },
       "args_metadataParser": { "@id": "urn:solid-server:default:MetadataParser" },
+      "args_conditionsParser": { "@type": "BasicConditionsParser" },
       "args_bodyParser": {
         "@type": "WaterfallHandler",
         "handlers": [

--- a/config/ldp/metadata-writer/default.json
+++ b/config/ldp/metadata-writer/default.json
@@ -4,6 +4,7 @@
     "files-scs:config/ldp/metadata-writer/writers/constant.json",
     "files-scs:config/ldp/metadata-writer/writers/link-rel.json",
     "files-scs:config/ldp/metadata-writer/writers/mapped.json",
+    "files-scs:config/ldp/metadata-writer/writers/modified.json",
     "files-scs:config/ldp/metadata-writer/writers/wac-allow.json",
     "files-scs:config/ldp/metadata-writer/writers/www-auth.json"
   ],
@@ -15,6 +16,7 @@
       "handlers": [
         { "@id": "urn:solid-server:default:MetadataWriter_Constant" },
         { "@id": "urn:solid-server:default:MetadataWriter_Mapped" },
+        { "@id": "urn:solid-server:default:MetadataWriter_Modified" },
         { "@id": "urn:solid-server:default:MetadataWriter_LinkRel" },
         { "@id": "urn:solid-server:default:MetadataWriter_WacAllow" },
         { "@id": "urn:solid-server:default:MetadataWriter_WwwAuth" }

--- a/config/ldp/metadata-writer/writers/modified.json
+++ b/config/ldp/metadata-writer/writers/modified.json
@@ -1,0 +1,10 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": "Adds the Last-Modified and ETag headers.",
+      "@id": "urn:solid-server:default:MetadataWriter_Modified",
+      "@type": "ModifiedMetadataWriter"
+    }
+  ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ export * from './ldp/http/metadata/LinkTypeParser';
 export * from './ldp/http/metadata/MappedMetadataWriter';
 export * from './ldp/http/metadata/MetadataParser';
 export * from './ldp/http/metadata/MetadataWriter';
+export * from './ldp/http/metadata/ModifiedMetadataWriter';
 export * from './ldp/http/metadata/SlugParser';
 export * from './ldp/http/metadata/WacAllowMetadataWriter';
 export * from './ldp/http/metadata/WwwAuthMetadataWriter';

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,6 +285,7 @@ export * from './util/errors/InternalServerError';
 export * from './util/errors/MethodNotAllowedHttpError';
 export * from './util/errors/NotFoundHttpError';
 export * from './util/errors/NotImplementedHttpError';
+export * from './util/errors/PreconditionFailedHttpError';
 export * from './util/errors/SystemError';
 export * from './util/errors/UnauthorizedHttpError';
 export * from './util/errors/UnsupportedMediaTypeHttpError';

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,10 @@ export * from './ldp/auxiliary/RoutingAuxiliaryStrategy';
 export * from './ldp/auxiliary/SuffixAuxiliaryIdentifierStrategy';
 export * from './ldp/auxiliary/Validator';
 
+// LDP/HTTP/Conditions
+export * from './ldp/http/conditions/BasicConditionsParser';
+export * from './ldp/http/conditions/ConditionsParser';
+
 // LDP/HTTP/Metadata
 export * from './ldp/http/metadata/ConstantMetadataWriter';
 export * from './ldp/http/metadata/ContentTypeParser';
@@ -258,6 +262,7 @@ export * from './storage/routing/RouterRule';
 // Storage
 export * from './storage/AtomicResourceStore';
 export * from './storage/BaseResourceStore';
+export * from './storage/BasicConditions';
 export * from './storage/Conditions';
 export * from './storage/DataAccessorBasedStore';
 export * from './storage/IndexRepresentationStore';

--- a/src/ldp/http/BasicRequestParser.ts
+++ b/src/ldp/http/BasicRequestParser.ts
@@ -3,6 +3,7 @@ import { InternalServerError } from '../../util/errors/InternalServerError';
 import type { Operation } from '../operations/Operation';
 import { RepresentationMetadata } from '../representation/RepresentationMetadata';
 import type { BodyParser } from './BodyParser';
+import type { ConditionsParser } from './conditions/ConditionsParser';
 import type { MetadataParser } from './metadata/MetadataParser';
 import type { PreferenceParser } from './PreferenceParser';
 import { RequestParser } from './RequestParser';
@@ -15,17 +16,20 @@ export interface BasicRequestParserArgs {
   targetExtractor: TargetExtractor;
   preferenceParser: PreferenceParser;
   metadataParser: MetadataParser;
+  conditionsParser: ConditionsParser;
   bodyParser: BodyParser;
 }
 
 /**
  * Creates an {@link Operation} from an incoming {@link HttpRequest} by aggregating the results
- * of a {@link TargetExtractor}, {@link PreferenceParser}, {@link MetadataParser}, and {@link BodyParser}.
+ * of a {@link TargetExtractor}, {@link PreferenceParser}, {@link MetadataParser},
+ * {@link ConditionsParser} and {@link BodyParser}.
  */
 export class BasicRequestParser extends RequestParser {
   private readonly targetExtractor!: TargetExtractor;
   private readonly preferenceParser!: PreferenceParser;
   private readonly metadataParser!: MetadataParser;
+  private readonly conditionsParser!: ConditionsParser;
   private readonly bodyParser!: BodyParser;
 
   public constructor(args: BasicRequestParserArgs) {
@@ -42,8 +46,9 @@ export class BasicRequestParser extends RequestParser {
     const preferences = await this.preferenceParser.handleSafe({ request });
     const metadata = new RepresentationMetadata(target);
     await this.metadataParser.handleSafe({ request, metadata });
+    const conditions = await this.conditionsParser.handleSafe(request);
     const body = await this.bodyParser.handleSafe({ request, metadata });
 
-    return { method, target, preferences, body };
+    return { method, target, preferences, conditions, body };
   }
 }

--- a/src/ldp/http/conditions/BasicConditionsParser.ts
+++ b/src/ldp/http/conditions/BasicConditionsParser.ts
@@ -1,0 +1,63 @@
+import { getLoggerFor } from '../../../logging/LogUtil';
+import type { HttpRequest } from '../../../server/HttpRequest';
+import type { BasicConditionsOptions } from '../../../storage/BasicConditions';
+import { BasicConditions } from '../../../storage/BasicConditions';
+import type { Conditions } from '../../../storage/Conditions';
+import { ConditionsParser } from './ConditionsParser';
+
+/**
+ * Creates a Conditions object based on the the following headers:
+ *  - If-Modified-Since
+ *  - If-Unmodified-Since
+ *  - If-Match
+ *  - If-None-Match
+ *
+ * Implementation based on RFC7232
+ */
+export class BasicConditionsParser extends ConditionsParser {
+  protected readonly logger = getLoggerFor(this);
+
+  public async handle(request: HttpRequest): Promise<Conditions | undefined> {
+    const options: BasicConditionsOptions = {
+      matchesETag: this.parseTagHeader(request, 'if-match'),
+      notMatchesETag: this.parseTagHeader(request, 'if-none-match'),
+    };
+
+    // A recipient MUST ignore If-Modified-Since if the request contains an If-None-Match header field
+    // A recipient MUST ignore the If-Modified-Since header field ... if the request method is neither GET nor HEAD.
+    if (!options.notMatchesETag && (request.method === 'GET' || request.method === 'HEAD')) {
+      options.modifiedSince = this.parseDateHeader(request, 'if-modified-since');
+    }
+
+    // A recipient MUST ignore If-Unmodified-Since if the request contains an If-Match header field
+    if (!options.matchesETag) {
+      options.unmodifiedSince = this.parseDateHeader(request, 'if-unmodified-since');
+    }
+
+    // Only return a Conditions object if there is at least one condition; undefined otherwise
+    this.logger.debug(`Found the following conditions: ${JSON.stringify(options)}`);
+    if (Object.values(options).some((val): boolean => typeof val !== 'undefined')) {
+      return new BasicConditions(options);
+    }
+  }
+
+  /**
+   * Converts a request header containing a datetime string to an actual Date object.
+   * Undefined if there is no value for the given header name.
+   */
+  private parseDateHeader(request: HttpRequest, header: 'if-modified-since' | 'if-unmodified-since'): Date | undefined {
+    const headerVal = request.headers[header];
+    if (headerVal) {
+      const timestamp = Date.parse(headerVal);
+      return Number.isNaN(timestamp) ? undefined : new Date(timestamp);
+    }
+  }
+
+  /**
+   * Converts a request header containing ETags to an array of ETags.
+   * Undefined if there is no value for the given header name.
+   */
+  private parseTagHeader(request: HttpRequest, header: 'if-match' | 'if-none-match'): string[] | undefined {
+    return request.headers[header]?.trim().split(/\s*,\s*/u);
+  }
+}

--- a/src/ldp/http/conditions/ConditionsParser.ts
+++ b/src/ldp/http/conditions/ConditionsParser.ts
@@ -1,0 +1,8 @@
+import type { HttpRequest } from '../../../server/HttpRequest';
+import type { Conditions } from '../../../storage/Conditions';
+import { AsyncHandler } from '../../../util/handlers/AsyncHandler';
+
+/**
+ * Creates a Conditions object based on the input HttpRequest.
+ */
+export abstract class ConditionsParser extends AsyncHandler<HttpRequest, Conditions | undefined> {}

--- a/src/ldp/http/metadata/ModifiedMetadataWriter.ts
+++ b/src/ldp/http/metadata/ModifiedMetadataWriter.ts
@@ -1,0 +1,23 @@
+import type { HttpResponse } from '../../../server/HttpResponse';
+import { getETag } from '../../../storage/Conditions';
+import { addHeader } from '../../../util/HeaderUtil';
+import { DC } from '../../../util/Vocabularies';
+import type { RepresentationMetadata } from '../../representation/RepresentationMetadata';
+import { MetadataWriter } from './MetadataWriter';
+
+/**
+ * A {@link MetadataWriter} that generates all the necessary headers related to the modification date of a resource.
+ */
+export class ModifiedMetadataWriter extends MetadataWriter {
+  public async handle(input: { response: HttpResponse; metadata: RepresentationMetadata }): Promise<void> {
+    const modified = input.metadata.get(DC.terms.modified);
+    if (modified) {
+      const date = new Date(modified.value);
+      addHeader(input.response, 'Last-Modified', date.toUTCString());
+    }
+    const etag = getETag(input.metadata);
+    if (etag) {
+      addHeader(input.response, 'ETag', etag);
+    }
+  }
+}

--- a/src/ldp/operations/DeleteOperationHandler.ts
+++ b/src/ldp/operations/DeleteOperationHandler.ts
@@ -24,7 +24,7 @@ export class DeleteOperationHandler extends OperationHandler {
   }
 
   public async handle(input: Operation): Promise<ResponseDescription> {
-    await this.store.deleteResource(input.target);
+    await this.store.deleteResource(input.target, input.conditions);
     return new ResetResponseDescription();
   }
 }

--- a/src/ldp/operations/GetOperationHandler.ts
+++ b/src/ldp/operations/GetOperationHandler.ts
@@ -24,7 +24,7 @@ export class GetOperationHandler extends OperationHandler {
   }
 
   public async handle(input: Operation): Promise<ResponseDescription> {
-    const body = await this.store.getRepresentation(input.target, input.preferences);
+    const body = await this.store.getRepresentation(input.target, input.preferences, input.conditions);
 
     input.authorization?.addMetadata(body.metadata);
 

--- a/src/ldp/operations/HeadOperationHandler.ts
+++ b/src/ldp/operations/HeadOperationHandler.ts
@@ -24,7 +24,7 @@ export class HeadOperationHandler extends OperationHandler {
   }
 
   public async handle(input: Operation): Promise<ResponseDescription> {
-    const body = await this.store.getRepresentation(input.target, input.preferences);
+    const body = await this.store.getRepresentation(input.target, input.preferences, input.conditions);
 
     // Close the Readable as we will not return it.
     body.data.destroy();

--- a/src/ldp/operations/Operation.ts
+++ b/src/ldp/operations/Operation.ts
@@ -1,4 +1,5 @@
 import type { Authorization } from '../../authorization/Authorization';
+import type { Conditions } from '../../storage/Conditions';
 import type { Representation } from '../representation/Representation';
 import type { RepresentationPreferences } from '../representation/RepresentationPreferences';
 import type { ResourceIdentifier } from '../representation/ResourceIdentifier';
@@ -19,6 +20,10 @@ export interface Operation {
    * Representation preferences of the response. Will be empty if there are none.
    */
   preferences: RepresentationPreferences;
+  /**
+   * Conditions the resource must fulfill for a valid operation.
+   */
+  conditions?: Conditions;
   /**
    * This value will be set if the Operation was authorized by an Authorizer.
    */

--- a/src/ldp/operations/PatchOperationHandler.ts
+++ b/src/ldp/operations/PatchOperationHandler.ts
@@ -36,7 +36,7 @@ export class PatchOperationHandler extends OperationHandler {
       this.logger.warn('No Content-Type header specified on PATCH request');
       throw new BadRequestHttpError('No Content-Type header specified on PATCH request');
     }
-    await this.store.modifyResource(input.target, input.body as Patch);
+    await this.store.modifyResource(input.target, input.body as Patch, input.conditions);
     return new ResetResponseDescription();
   }
 }

--- a/src/ldp/operations/PostOperationHandler.ts
+++ b/src/ldp/operations/PostOperationHandler.ts
@@ -35,7 +35,7 @@ export class PostOperationHandler extends OperationHandler {
       this.logger.warn('No Content-Type header specified on POST request');
       throw new BadRequestHttpError('No Content-Type header specified on POST request');
     }
-    const identifier = await this.store.addResource(input.target, input.body);
+    const identifier = await this.store.addResource(input.target, input.body, input.conditions);
     return new CreatedResponseDescription(identifier);
   }
 }

--- a/src/ldp/operations/PutOperationHandler.ts
+++ b/src/ldp/operations/PutOperationHandler.ts
@@ -35,7 +35,7 @@ export class PutOperationHandler extends OperationHandler {
       this.logger.warn('No Content-Type header specified on PUT request');
       throw new BadRequestHttpError('No Content-Type header specified on PUT request');
     }
-    await this.store.setRepresentation(input.target, input.body);
+    await this.store.setRepresentation(input.target, input.body, input.conditions);
     return new ResetResponseDescription();
   }
 }

--- a/src/storage/BasicConditions.ts
+++ b/src/storage/BasicConditions.ts
@@ -1,0 +1,69 @@
+import type { RepresentationMetadata } from '../ldp/representation/RepresentationMetadata';
+import { DC } from '../util/Vocabularies';
+import { getETag } from './Conditions';
+import type { Conditions } from './Conditions';
+
+export interface BasicConditionsOptions {
+  matchesETag?: string[];
+  notMatchesETag?: string[];
+  modifiedSince?: Date;
+  unmodifiedSince?: Date;
+}
+
+/**
+ * Stores all the relevant Conditions values and matches them based on RFC7232.
+ */
+export class BasicConditions implements Conditions {
+  public readonly matchesETag?: string[];
+  public readonly notMatchesETag?: string[];
+  public readonly modifiedSince?: Date;
+  public readonly unmodifiedSince?: Date;
+
+  public constructor(options: BasicConditionsOptions) {
+    this.matchesETag = options.matchesETag;
+    this.notMatchesETag = options.notMatchesETag;
+    this.modifiedSince = options.modifiedSince;
+    this.unmodifiedSince = options.unmodifiedSince;
+  }
+
+  public matchesMetadata(metadata?: RepresentationMetadata): boolean {
+    if (!metadata) {
+      // RFC7232: ...If-Match... If the field-value is "*", the condition is false if the origin server
+      // does not have a current representation for the target resource.
+      return !this.matchesETag?.includes('*');
+    }
+
+    const modified = metadata.get(DC.terms.modified);
+    const modifiedDate = modified ? new Date(modified.value) : undefined;
+    const etag = getETag(metadata);
+    return this.matches(etag, modifiedDate);
+  }
+
+  public matches(eTag?: string, lastModified?: Date): boolean {
+    // RFC7232: ...If-None-Match... If the field-value is "*", the condition is false if the origin server
+    // has a current representation for the target resource.
+    if (this.notMatchesETag?.includes('*')) {
+      return false;
+    }
+
+    if (eTag) {
+      if (this.matchesETag && !this.matchesETag.includes(eTag) && !this.matchesETag.includes('*')) {
+        return false;
+      }
+      if (this.notMatchesETag?.includes(eTag)) {
+        return false;
+      }
+    }
+
+    if (lastModified) {
+      if (this.modifiedSince && lastModified < this.modifiedSince) {
+        return false;
+      }
+      if (this.unmodifiedSince && lastModified > this.unmodifiedSince) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}

--- a/src/storage/Conditions.ts
+++ b/src/storage/Conditions.ts
@@ -1,4 +1,5 @@
 import type { RepresentationMetadata } from '../ldp/representation/RepresentationMetadata';
+import { DC } from '../util/Vocabularies';
 
 /**
  * The conditions of an HTTP conditional request.
@@ -7,11 +8,11 @@ export interface Conditions {
   /**
    * Valid if matching any of the given ETags.
    */
-  matchesEtag: string[];
+  matchesETag?: string[];
   /**
    * Valid if not matching any of the given ETags.
    */
-  notMatchesEtag: string[];
+  notMatchesETag?: string[];
   /**
    * Valid if modified since the given date.
    */
@@ -27,9 +28,23 @@ export interface Conditions {
    */
   matchesMetadata: (metadata: RepresentationMetadata) => boolean;
   /**
-   * Checks validity based on the given ETag and/org date.
+   * Checks validity based on the given ETag and/or date.
    * @param eTag - Condition based on ETag.
    * @param lastModified - Condition based on last modified date.
    */
   matches: (eTag?: string, lastModified?: Date) => boolean;
+}
+
+/**
+ * Generates an ETag based on the last modified date of a resource.
+ * @param metadata - Metadata of the resource.
+ *
+ * @returns the generated ETag. Undefined if no last modified date was found.
+ */
+export function getETag(metadata: RepresentationMetadata): string | undefined {
+  const modified = metadata.get(DC.terms.modified);
+  if (modified) {
+    const date = new Date(modified.value);
+    return `"${date.getTime()}"`;
+  }
 }

--- a/src/storage/Conditions.ts
+++ b/src/storage/Conditions.ts
@@ -24,11 +24,13 @@ export interface Conditions {
 
   /**
    * Checks validity based on the given metadata.
-   * @param metadata - Metadata of the representation.
+   * @param metadata - Metadata of the representation. Undefined if the resource does not exist.
    */
-  matchesMetadata: (metadata: RepresentationMetadata) => boolean;
+  matchesMetadata: (metadata?: RepresentationMetadata) => boolean;
   /**
    * Checks validity based on the given ETag and/or date.
+   * This function assumes the resource being checked exists.
+   * If not, the `matchesMetadata` function should be used.
    * @param eTag - Condition based on ETag.
    * @param lastModified - Condition based on last modified date.
    */

--- a/src/storage/PatchingStore.ts
+++ b/src/storage/PatchingStore.ts
@@ -1,5 +1,6 @@
 import type { Patch } from '../ldp/http/Patch';
 import type { ResourceIdentifier } from '../ldp/representation/ResourceIdentifier';
+import { NotImplementedHttpError } from '../util/errors/NotImplementedHttpError';
 import type { Conditions } from './Conditions';
 import { PassthroughStore } from './PassthroughStore';
 import type { PatchHandler } from './patch/PatchHandler';
@@ -22,8 +23,11 @@ export class PatchingStore<T extends ResourceStore = ResourceStore> extends Pass
     conditions?: Conditions): Promise<ResourceIdentifier[]> {
     try {
       return await this.source.modifyResource(identifier, patch, conditions);
-    } catch {
-      return this.patcher.handleSafe({ source: this.source, identifier, patch });
+    } catch (error: unknown) {
+      if (NotImplementedHttpError.isInstance(error)) {
+        return this.patcher.handleSafe({ source: this.source, identifier, patch });
+      }
+      throw error;
     }
   }
 }

--- a/src/storage/accessors/FileDataAccessor.ts
+++ b/src/storage/accessors/FileDataAccessor.ts
@@ -12,7 +12,7 @@ import { guardStream } from '../../util/GuardedStream';
 import type { Guarded } from '../../util/GuardedStream';
 import { joinFilePath, isContainerIdentifier } from '../../util/PathUtil';
 import { parseQuads, serializeQuads } from '../../util/QuadUtil';
-import { addResourceMetadata } from '../../util/ResourceUtil';
+import { addResourceMetadata, updateModifiedDate } from '../../util/ResourceUtil';
 import { toLiteral } from '../../util/TermUtil';
 import { CONTENT_TYPE, DC, LDP, POSIX, RDF, SOLID_META, XSD } from '../../util/Vocabularies';
 import type { FileIdentifierMapper, ResourceLink } from '../mapping/FileIdentifierMapper';
@@ -193,9 +193,10 @@ export class FileDataAccessor implements DataAccessor {
    */
   private async writeMetadata(link: ResourceLink, metadata: RepresentationMetadata): Promise<boolean> {
     // These are stored by file system conventions
-    metadata.remove(RDF.type, LDP.terms.Resource);
-    metadata.remove(RDF.type, LDP.terms.Container);
-    metadata.remove(RDF.type, LDP.terms.BasicContainer);
+    metadata.remove(RDF.terms.type, LDP.terms.Resource);
+    metadata.remove(RDF.terms.type, LDP.terms.Container);
+    metadata.remove(RDF.terms.type, LDP.terms.BasicContainer);
+    metadata.removeAll(DC.terms.modified);
     metadata.removeAll(CONTENT_TYPE);
     const quads = metadata.quads();
     const metadataLink = await this.resourceMapper.mapUrlToFilePath(link.identifier, true);
@@ -303,9 +304,7 @@ export class FileDataAccessor implements DataAccessor {
    * @param stats - Stats of the file/directory corresponding to the resource.
    */
   private addPosixMetadata(metadata: RepresentationMetadata, stats: Stats): void {
-    metadata.add(DC.terms.modified,
-      toLiteral(stats.mtime.toISOString(), XSD.terms.dateTime),
-      SOLID_META.terms.ResponseMetadata);
+    updateModifiedDate(metadata, stats.mtime);
     metadata.add(POSIX.terms.mtime,
       toLiteral(Math.floor(stats.mtime.getTime() / 1000), XSD.terms.integer),
       SOLID_META.terms.ResponseMetadata);

--- a/src/util/ResourceUtil.ts
+++ b/src/util/ResourceUtil.ts
@@ -3,8 +3,9 @@ import { BasicRepresentation } from '../ldp/representation/BasicRepresentation';
 import type { Representation } from '../ldp/representation/Representation';
 import { RepresentationMetadata } from '../ldp/representation/RepresentationMetadata';
 import { guardedStreamFrom } from './StreamUtil';
+import { toLiteral } from './TermUtil';
 
-import { LDP, RDF } from './Vocabularies';
+import { DC, LDP, RDF, XSD } from './Vocabularies';
 
 /**
  * Helper function to generate type quads for a Container or Resource.
@@ -19,6 +20,18 @@ export function addResourceMetadata(metadata: RepresentationMetadata, isContaine
     metadata.add(RDF.terms.type, LDP.terms.BasicContainer);
   }
   metadata.add(RDF.terms.type, LDP.terms.Resource);
+}
+
+/**
+ * Updates the dc:modified time to the given time.
+ * @param metadata - Metadata to update.
+ * @param date - Last modified date. Defaults to current time.
+ */
+export function updateModifiedDate(metadata: RepresentationMetadata, date = new Date()): void {
+  // Milliseconds get lost in some serializations, potentially causing mismatches
+  const lastModified = new Date(date);
+  lastModified.setMilliseconds(0);
+  metadata.set(DC.terms.modified, toLiteral(lastModified.toISOString(), XSD.terms.dateTime));
 }
 
 /**

--- a/src/util/errors/PreconditionFailedHttpError.ts
+++ b/src/util/errors/PreconditionFailedHttpError.ts
@@ -1,0 +1,15 @@
+import type { HttpErrorOptions } from './HttpError';
+import { HttpError } from './HttpError';
+
+/**
+ * An error thrown when access was denied due to the conditions on the request.
+ */
+export class PreconditionFailedHttpError extends HttpError {
+  public constructor(message?: string, options?: HttpErrorOptions) {
+    super(412, 'PreconditionFailedHttpError', message, options);
+  }
+
+  public static isInstance(error: any): error is PreconditionFailedHttpError {
+    return HttpError.isInstance(error) && error.statusCode === 412;
+  }
+}

--- a/test/integration/Conditions.test.ts
+++ b/test/integration/Conditions.test.ts
@@ -1,0 +1,200 @@
+import fetch from 'cross-fetch';
+import { DataFactory } from 'n3';
+import type { App } from '../../src/init/App';
+import { deleteResource, expectQuads, getResource, patchResource, putResource } from '../util/FetchUtil';
+import { getPort } from '../util/Util';
+import {
+  getDefaultVariables,
+  getPresetConfigPath,
+  getTestConfigPath,
+  getTestFolder,
+  instantiateFromConfig,
+  removeFolder,
+} from './Config';
+const { namedNode, quad } = DataFactory;
+
+const port = getPort('Conditions');
+const baseUrl = `http://localhost:${port}/`;
+
+// File stores handle last-modified dates differently so need to test both
+const rootFilePath = getTestFolder('conditions');
+const stores: [string, any][] = [
+  [ 'in-memory storage', {
+    storeConfig: 'storage/backend/memory.json',
+    teardown: jest.fn(),
+  }],
+  [ 'on-disk storage', {
+    storeConfig: 'storage/backend/file.json',
+    teardown: async(): Promise<void> => removeFolder(rootFilePath),
+  }],
+];
+
+describe.each(stores)('A server supporting conditions with %s', (name, { storeConfig, teardown }): void => {
+  let app: App;
+
+  beforeAll(async(): Promise<void> => {
+    const variables = {
+      ...getDefaultVariables(port, baseUrl),
+      'urn:solid-server:default:variable:rootFilePath': rootFilePath,
+    };
+
+    // Create and start the server
+    const instances = await instantiateFromConfig(
+      'urn:solid-server:test:Instances',
+      [
+        getPresetConfigPath(storeConfig),
+        getTestConfigPath('ldp-with-auth.json'),
+      ],
+      variables,
+    ) as Record<string, any>;
+    ({ app } = instances);
+
+    await app.start();
+  });
+
+  afterAll(async(): Promise<void> => {
+    await teardown();
+    await app.stop();
+  });
+
+  it('prevents operations on existing resources with "if-none-match: *" header.', async(): Promise<void> => {
+    const documentUrl = `${baseUrl}document1.txt`;
+    // PUT
+    await putResource(documentUrl, { contentType: 'text/plain', body: 'TESTFILE' });
+
+    // Overwrite fails because of header
+    let response = await fetch(documentUrl, {
+      method: 'PUT',
+      headers: { 'content-type': 'text/plain', 'if-none-match': '*' },
+      body: 'TESTFILE1',
+    });
+    expect(response.status).toBe(412);
+
+    // Verify original contents stayed the same
+    response = await getResource(documentUrl);
+    await expect(response.text()).resolves.toBe('TESTFILE');
+
+    // DELETE
+    expect(await deleteResource(documentUrl)).toBeUndefined();
+  });
+
+  it('prevents creating new resources with "if-match: *" header.', async(): Promise<void> => {
+    const documentUrl = `${baseUrl}document2.txt`;
+    const query = 'INSERT {<http://test.com/s1> <http://test.com/p1> <http://test.com/o1>} WHERE {}';
+
+    // PATCH fails because of header
+    let response = await fetch(documentUrl, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/sparql-update', 'if-match': '*' },
+      body: query,
+    });
+    expect(response.status).toBe(412);
+
+    // PUT
+    await patchResource(documentUrl, query);
+
+    // PUT with header now succeeds
+    const query2 = 'INSERT {<http://test.com/s2> <http://test.com/p2> <http://test.com/o2>} WHERE {}';
+    response = await fetch(documentUrl, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/sparql-update', 'if-match': '*' },
+      body: query2,
+    });
+    expect(response.status).toBe(205);
+
+    // Verify the contents got updated
+    response = await getResource(documentUrl);
+    const expected = [
+      quad(namedNode('http://test.com/s1'), namedNode('http://test.com/p1'), namedNode('http://test.com/o1')),
+      quad(namedNode('http://test.com/s2'), namedNode('http://test.com/p2'), namedNode('http://test.com/o2')),
+    ];
+    await expectQuads(response, expected, true);
+
+    // DELETE
+    expect(await deleteResource(documentUrl)).toBeUndefined();
+  });
+
+  it('prevents operations if the "if-match" header does not match.', async(): Promise<void> => {
+    // GET root ETag
+    let response = await getResource(baseUrl);
+    const eTag = response.headers.get('ETag');
+    expect(typeof eTag).toBe('string');
+
+    // POST fails because of header
+    response = await fetch(baseUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain', 'if-match': '"notAMatchingETag"' },
+      body: 'TESTFILE',
+    });
+    expect(response.status).toBe(412);
+
+    // POST succeeds with correct header
+    response = await fetch(baseUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain', 'if-match': eTag! },
+      body: 'TESTFILE1',
+    });
+    expect(response.status).toBe(201);
+    const documentUrl = response.headers.get('location');
+    expect(typeof documentUrl).toBe('string');
+
+    // DELETE
+    expect(await deleteResource(documentUrl!)).toBeUndefined();
+  });
+
+  it('prevents operations if the "if-none-match" header does match.', async(): Promise<void> => {
+    // GET root ETag
+    let response = await getResource(baseUrl);
+    const eTag = response.headers.get('ETag');
+    expect(typeof eTag).toBe('string');
+
+    // POST fails because of header
+    response = await fetch(baseUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain', 'if-none-match': eTag! },
+      body: 'TESTFILE',
+    });
+    expect(response.status).toBe(412);
+
+    // POST succeeds with correct header
+    response = await fetch(baseUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain', 'if-none-match': '"notAMatchingETag"' },
+      body: 'TESTFILE1',
+    });
+    expect(response.status).toBe(201);
+    const documentUrl = response.headers.get('location');
+    expect(typeof documentUrl).toBe('string');
+
+    // DELETE
+    expect(await deleteResource(documentUrl!)).toBeUndefined();
+  });
+
+  it('prevents operations if the "if-unmodified-since" header is before the modified date.', async(): Promise<void> => {
+    const documentUrl = `${baseUrl}document3.txt`;
+    // PUT
+    let response = await putResource(documentUrl, { contentType: 'text/plain', body: 'TESTFILE' });
+
+    // GET last-modified header
+    response = await getResource(documentUrl);
+    const lastModifiedVal = response.headers.get('last-modified');
+    expect(typeof lastModifiedVal).toBe('string');
+    const lastModified = new Date(lastModifiedVal!);
+
+    const oldDate = new Date(Date.now() - 10000);
+
+    // DELETE fails because oldDate < lastModified
+    response = await fetch(documentUrl, {
+      method: 'DELETE',
+      headers: { 'if-unmodified-since': oldDate.toUTCString() },
+    });
+    expect(response.status).toBe(412);
+
+    // DELETE succeeds because lastModified date matches
+    response = await fetch(documentUrl, {
+      method: 'DELETE',
+      headers: { 'if-unmodified-since': lastModified.toUTCString() },
+    });
+    expect(response.status).toBe(205);
+  });
+});

--- a/test/integration/Middleware.test.ts
+++ b/test/integration/Middleware.test.ts
@@ -99,6 +99,13 @@ describe('An http server with middleware', (): void => {
     expect(exposed.split(/\s*,\s*/u)).toContain('Accept-Patch');
   });
 
+  it('exposes the Last-Modified and ETag headers via CORS.', async(): Promise<void> => {
+    const res = await request(server).get('/').expect(200);
+    const exposed = res.header['access-control-expose-headers'];
+    expect(exposed.split(/\s*,\s*/u)).toContain('ETag');
+    expect(exposed.split(/\s*,\s*/u)).toContain('Last-Modified');
+  });
+
   it('exposes the Link header via CORS.', async(): Promise<void> => {
     const res = await request(server).get('/').expect(200);
     const exposed = res.header['access-control-expose-headers'];

--- a/test/integration/RequestParser.test.ts
+++ b/test/integration/RequestParser.test.ts
@@ -2,19 +2,24 @@ import { Readable } from 'stream';
 import arrayifyStream from 'arrayify-stream';
 import { AcceptPreferenceParser } from '../../src/ldp/http/AcceptPreferenceParser';
 import { BasicRequestParser } from '../../src/ldp/http/BasicRequestParser';
+import { BasicConditionsParser } from '../../src/ldp/http/conditions/BasicConditionsParser';
 import { ContentTypeParser } from '../../src/ldp/http/metadata/ContentTypeParser';
 import { OriginalUrlExtractor } from '../../src/ldp/http/OriginalUrlExtractor';
 import { RawBodyParser } from '../../src/ldp/http/RawBodyParser';
 import { RepresentationMetadata } from '../../src/ldp/representation/RepresentationMetadata';
 import type { HttpRequest } from '../../src/server/HttpRequest';
+import { BasicConditions } from '../../src/storage/BasicConditions';
 import { guardedStreamFrom } from '../../src/util/StreamUtil';
 
 describe('A BasicRequestParser with simple input parsers', (): void => {
   const targetExtractor = new OriginalUrlExtractor();
   const preferenceParser = new AcceptPreferenceParser();
   const metadataParser = new ContentTypeParser();
+  const conditionsParser = new BasicConditionsParser();
   const bodyParser = new RawBodyParser();
-  const requestParser = new BasicRequestParser({ targetExtractor, preferenceParser, metadataParser, bodyParser });
+  const requestParser = new BasicRequestParser(
+    { targetExtractor, preferenceParser, metadataParser, conditionsParser, bodyParser },
+  );
 
   it('can parse an incoming request.', async(): Promise<void> => {
     const request = guardedStreamFrom([ '<http://test.com/s> <http://test.com/p> <http://test.com/o>.' ]) as HttpRequest;
@@ -24,6 +29,8 @@ describe('A BasicRequestParser with simple input parsers', (): void => {
       accept: 'text/turtle; q=0.8',
       'accept-language': 'en-gb, en;q=0.5',
       'content-type': 'text/turtle',
+      'if-unmodified-since': 'Wed, 21 Oct 2015 07:28:00 UTC',
+      'if-none-match': '12345',
       'transfer-encoding': 'chunked',
       host: 'test.com',
     };
@@ -36,6 +43,10 @@ describe('A BasicRequestParser with simple input parsers', (): void => {
         type: { 'text/turtle': 0.8 },
         language: { 'en-gb': 1, en: 0.5 },
       },
+      conditions: new BasicConditions({
+        unmodifiedSince: new Date('2015-10-21T07:28:00.000Z'),
+        notMatchesETag: [ '12345' ],
+      }),
       body: {
         data: expect.any(Readable),
         binary: true,

--- a/test/unit/ldp/http/BasicRequestParser.test.ts
+++ b/test/unit/ldp/http/BasicRequestParser.test.ts
@@ -1,5 +1,6 @@
 import { BasicRequestParser } from '../../../../src/ldp/http/BasicRequestParser';
 import type { BodyParser } from '../../../../src/ldp/http/BodyParser';
+import type { ConditionsParser } from '../../../../src/ldp/http/conditions/ConditionsParser';
 import type { MetadataParser } from '../../../../src/ldp/http/metadata/MetadataParser';
 import type { PreferenceParser } from '../../../../src/ldp/http/PreferenceParser';
 import type { TargetExtractor } from '../../../../src/ldp/http/TargetExtractor';
@@ -10,6 +11,7 @@ describe('A BasicRequestParser', (): void => {
   let targetExtractor: TargetExtractor;
   let preferenceParser: PreferenceParser;
   let metadataParser: MetadataParser;
+  let conditionsParser: ConditionsParser;
   let bodyParser: BodyParser;
   let requestParser: BasicRequestParser;
 
@@ -17,8 +19,11 @@ describe('A BasicRequestParser', (): void => {
     targetExtractor = new StaticAsyncHandler(true, 'target' as any);
     preferenceParser = new StaticAsyncHandler(true, 'preference' as any);
     metadataParser = new StaticAsyncHandler(true, undefined);
+    conditionsParser = new StaticAsyncHandler(true, 'conditions' as any);
     bodyParser = new StaticAsyncHandler(true, 'body' as any);
-    requestParser = new BasicRequestParser({ targetExtractor, preferenceParser, metadataParser, bodyParser });
+    requestParser = new BasicRequestParser(
+      { targetExtractor, preferenceParser, metadataParser, conditionsParser, bodyParser },
+    );
   });
 
   it('can handle any input.', async(): Promise<void> => {
@@ -36,6 +41,7 @@ describe('A BasicRequestParser', (): void => {
       method: 'GET',
       target: 'target',
       preferences: 'preference',
+      conditions: 'conditions',
       body: { data: 'body', metadata: new RepresentationMetadata('target') },
     });
   });

--- a/test/unit/ldp/http/conditions/BasicConditionsParser.test.ts
+++ b/test/unit/ldp/http/conditions/BasicConditionsParser.test.ts
@@ -1,0 +1,60 @@
+import { BasicConditionsParser } from '../../../../../src/ldp/http/conditions/BasicConditionsParser';
+import type { HttpRequest } from '../../../../../src/server/HttpRequest';
+
+describe('A BasicConditionsParser', (): void => {
+  const dateString = 'Wed, 21 Oct 2015 07:28:00 UTC';
+  const date = new Date('2015-10-21T07:28:00.000Z');
+  let request: HttpRequest;
+  const parser = new BasicConditionsParser();
+
+  beforeEach(async(): Promise<void> => {
+    request = { headers: {}, method: 'GET' } as HttpRequest;
+  });
+
+  it('returns undefined if there are no relevant headers.', async(): Promise<void> => {
+    await expect(parser.handleSafe(request)).resolves.toBeUndefined();
+  });
+
+  it('parses the if-modified-since header.', async(): Promise<void> => {
+    request.headers['if-modified-since'] = dateString;
+    await expect(parser.handleSafe(request)).resolves.toEqual({ modifiedSince: date });
+  });
+
+  it('parses the if-unmodified-since header.', async(): Promise<void> => {
+    request.headers['if-unmodified-since'] = dateString;
+    await expect(parser.handleSafe(request)).resolves.toEqual({ unmodifiedSince: date });
+  });
+
+  it('parses the if-match header.', async(): Promise<void> => {
+    request.headers['if-match'] = '"1234567", "abcdefg"';
+    await expect(parser.handleSafe(request)).resolves.toEqual({ matchesETag: [ '"1234567"', '"abcdefg"' ]});
+  });
+
+  it('parses the if-none-match header.', async(): Promise<void> => {
+    request.headers['if-none-match'] = '*';
+    await expect(parser.handleSafe(request)).resolves.toEqual({ notMatchesETag: [ '*' ]});
+  });
+
+  it('does not parse the if-modified-since header if there is an if-none-match header.', async(): Promise<void> => {
+    request.headers['if-modified-since'] = dateString;
+    request.headers['if-none-match'] = '*';
+    await expect(parser.handleSafe(request)).resolves.toEqual({ notMatchesETag: [ '*' ]});
+  });
+
+  it('only parses the if-modified-since header for GET and HEAD requests.', async(): Promise<void> => {
+    request.headers['if-modified-since'] = dateString;
+    request.method = 'PUT';
+    await expect(parser.handleSafe(request)).resolves.toBeUndefined();
+  });
+
+  it('does not parse the if-unmodified-since header if there is an if-match header.', async(): Promise<void> => {
+    request.headers['if-unmodified-since'] = dateString;
+    request.headers['if-match'] = '*';
+    await expect(parser.handleSafe(request)).resolves.toEqual({ matchesETag: [ '*' ]});
+  });
+
+  it('ignores invalid dates.', async(): Promise<void> => {
+    request.headers['if-modified-since'] = 'notADate';
+    await expect(parser.handleSafe(request)).resolves.toBeUndefined();
+  });
+});

--- a/test/unit/ldp/http/metadata/ModifiedMetadataWriter.test.ts
+++ b/test/unit/ldp/http/metadata/ModifiedMetadataWriter.test.ts
@@ -1,0 +1,29 @@
+import { createResponse } from 'node-mocks-http';
+import { ModifiedMetadataWriter } from '../../../../../src/ldp/http/metadata/ModifiedMetadataWriter';
+import { RepresentationMetadata } from '../../../../../src/ldp/representation/RepresentationMetadata';
+import type { HttpResponse } from '../../../../../src/server/HttpResponse';
+import { updateModifiedDate } from '../../../../../src/util/ResourceUtil';
+import { DC } from '../../../../../src/util/Vocabularies';
+
+describe('A ModifiedMetadataWriter', (): void => {
+  const writer = new ModifiedMetadataWriter();
+
+  it('adds the Last-Modified and ETag header if there is dc:modified metadata.', async(): Promise<void> => {
+    const response = createResponse() as HttpResponse;
+    const metadata = new RepresentationMetadata();
+    updateModifiedDate(metadata);
+    const dateTime = metadata.get(DC.terms.modified)!.value;
+    await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
+    expect(response.getHeaders()).toEqual({
+      'last-modified': new Date(dateTime).toUTCString(),
+      etag: `"${new Date(dateTime).getTime()}"`,
+    });
+  });
+
+  it('does nothing if there is no matching metadata.', async(): Promise<void> => {
+    const response = createResponse() as HttpResponse;
+    const metadata = new RepresentationMetadata();
+    await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
+    expect(response.getHeaders()).toEqual({});
+  });
+});

--- a/test/unit/ldp/operations/DeleteOperationHandler.test.ts
+++ b/test/unit/ldp/operations/DeleteOperationHandler.test.ts
@@ -1,9 +1,11 @@
 import { DeleteOperationHandler } from '../../../../src/ldp/operations/DeleteOperationHandler';
 import type { Operation } from '../../../../src/ldp/operations/Operation';
+import { BasicConditions } from '../../../../src/storage/BasicConditions';
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
 import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
 
 describe('A DeleteOperationHandler', (): void => {
+  const conditions = new BasicConditions({});
   const store = {} as unknown as ResourceStore;
   const handler = new DeleteOperationHandler(store);
   beforeEach(async(): Promise<void> => {
@@ -16,9 +18,9 @@ describe('A DeleteOperationHandler', (): void => {
   });
 
   it('deletes the resource from the store and returns the correct response.', async(): Promise<void> => {
-    const result = await handler.handle({ target: { path: 'url' }} as Operation);
+    const result = await handler.handle({ target: { path: 'url' }, conditions } as Operation);
     expect(store.deleteResource).toHaveBeenCalledTimes(1);
-    expect(store.deleteResource).toHaveBeenLastCalledWith({ path: 'url' });
+    expect(store.deleteResource).toHaveBeenLastCalledWith({ path: 'url' }, conditions);
     expect(result.statusCode).toBe(205);
     expect(result.metadata).toBeUndefined();
     expect(result.data).toBeUndefined();

--- a/test/unit/ldp/operations/GetOperationHandler.test.ts
+++ b/test/unit/ldp/operations/GetOperationHandler.test.ts
@@ -2,15 +2,24 @@ import type { Authorization } from '../../../../src/authorization/Authorization'
 import { GetOperationHandler } from '../../../../src/ldp/operations/GetOperationHandler';
 import type { Operation } from '../../../../src/ldp/operations/Operation';
 import type { Representation } from '../../../../src/ldp/representation/Representation';
+import { BasicConditions } from '../../../../src/storage/BasicConditions';
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
 import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
 
 describe('A GetOperationHandler', (): void => {
-  const store = {
-    getRepresentation: async(): Promise<Representation> =>
-      ({ binary: false, data: 'data', metadata: 'metadata' } as any),
-  } as unknown as ResourceStore;
-  const handler = new GetOperationHandler(store);
+  const conditions = new BasicConditions({});
+  const preferences = {};
+  let store: ResourceStore;
+  let handler: GetOperationHandler;
+
+  beforeEach(async(): Promise<void> => {
+    store = {
+      getRepresentation: jest.fn(async(): Promise<Representation> =>
+        ({ binary: false, data: 'data', metadata: 'metadata' } as any)),
+    } as unknown as ResourceStore;
+
+    handler = new GetOperationHandler(store);
+  });
 
   it('only supports GET operations.', async(): Promise<void> => {
     await expect(handler.canHandle({ method: 'GET' } as Operation)).resolves.toBeUndefined();
@@ -18,16 +27,22 @@ describe('A GetOperationHandler', (): void => {
   });
 
   it('returns the representation from the store with the correct response.', async(): Promise<void> => {
-    const result = await handler.handle({ target: { path: 'url' }} as Operation);
+    const result = await handler.handle({ target: { path: 'url' }, preferences, conditions } as Operation);
     expect(result.statusCode).toBe(200);
     expect(result.metadata).toBe('metadata');
     expect(result.data).toBe('data');
+    expect(store.getRepresentation).toHaveBeenCalledTimes(1);
+    expect(store.getRepresentation).toHaveBeenLastCalledWith({ path: 'url' }, preferences, conditions);
   });
 
   it('adds authorization metadata in case the operation is an AuthorizedOperation.', async(): Promise<void> => {
     const authorization: Authorization = { addMetadata: jest.fn() };
-    const result = await handler.handle({ target: { path: 'url' }, authorization } as Operation);
+    const result = await handler.handle(
+      { target: { path: 'url' }, preferences, conditions, authorization } as Operation,
+    );
     expect(result.statusCode).toBe(200);
+    expect(store.getRepresentation).toHaveBeenCalledTimes(1);
+    expect(store.getRepresentation).toHaveBeenLastCalledWith({ path: 'url' }, preferences, conditions);
     expect(authorization.addMetadata).toHaveBeenCalledTimes(1);
     expect(authorization.addMetadata).toHaveBeenLastCalledWith('metadata');
   });

--- a/test/unit/ldp/operations/HeadOperationHandler.test.ts
+++ b/test/unit/ldp/operations/HeadOperationHandler.test.ts
@@ -3,10 +3,13 @@ import type { Authorization } from '../../../../src/authorization/Authorization'
 import { HeadOperationHandler } from '../../../../src/ldp/operations/HeadOperationHandler';
 import type { Operation } from '../../../../src/ldp/operations/Operation';
 import type { Representation } from '../../../../src/ldp/representation/Representation';
+import { BasicConditions } from '../../../../src/storage/BasicConditions';
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
 import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
 
 describe('A HeadOperationHandler', (): void => {
+  const conditions = new BasicConditions({});
+  const preferences = {};
   let store: ResourceStore;
   let handler: HeadOperationHandler;
   let data: Readable;
@@ -14,8 +17,8 @@ describe('A HeadOperationHandler', (): void => {
   beforeEach(async(): Promise<void> => {
     data = { destroy: jest.fn() } as any;
     store = {
-      getRepresentation: async(): Promise<Representation> =>
-        ({ binary: false, data, metadata: 'metadata' } as any),
+      getRepresentation: jest.fn(async(): Promise<Representation> =>
+        ({ binary: false, data, metadata: 'metadata' } as any)),
     } as any;
     handler = new HeadOperationHandler(store);
   });
@@ -27,17 +30,23 @@ describe('A HeadOperationHandler', (): void => {
   });
 
   it('returns the representation from the store with the correct response.', async(): Promise<void> => {
-    const result = await handler.handle({ target: { path: 'url' }} as Operation);
+    const result = await handler.handle({ target: { path: 'url' }, preferences, conditions } as Operation);
     expect(result.statusCode).toBe(200);
     expect(result.metadata).toBe('metadata');
     expect(result.data).toBeUndefined();
     expect(data.destroy).toHaveBeenCalledTimes(1);
+    expect(store.getRepresentation).toHaveBeenCalledTimes(1);
+    expect(store.getRepresentation).toHaveBeenLastCalledWith({ path: 'url' }, preferences, conditions);
   });
 
   it('adds authorization metadata in case the operation is an AuthorizedOperation.', async(): Promise<void> => {
     const authorization: Authorization = { addMetadata: jest.fn() };
-    const result = await handler.handle({ target: { path: 'url' }, authorization } as Operation);
+    const result = await handler.handle(
+      { target: { path: 'url' }, preferences, conditions, authorization } as Operation,
+    );
     expect(result.statusCode).toBe(200);
+    expect(store.getRepresentation).toHaveBeenCalledTimes(1);
+    expect(store.getRepresentation).toHaveBeenLastCalledWith({ path: 'url' }, preferences, conditions);
     expect(authorization.addMetadata).toHaveBeenCalledTimes(1);
     expect(authorization.addMetadata).toHaveBeenLastCalledWith('metadata');
   });

--- a/test/unit/ldp/operations/PatchOperationHandler.test.ts
+++ b/test/unit/ldp/operations/PatchOperationHandler.test.ts
@@ -1,11 +1,13 @@
 import type { Operation } from '../../../../src/ldp/operations/Operation';
 import { PatchOperationHandler } from '../../../../src/ldp/operations/PatchOperationHandler';
 import { RepresentationMetadata } from '../../../../src/ldp/representation/RepresentationMetadata';
+import { BasicConditions } from '../../../../src/storage/BasicConditions';
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
 import { BadRequestHttpError } from '../../../../src/util/errors/BadRequestHttpError';
 import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
 
 describe('A PatchOperationHandler', (): void => {
+  const conditions = new BasicConditions({});
   const store = {} as unknown as ResourceStore;
   const handler = new PatchOperationHandler(store);
   beforeEach(async(): Promise<void> => {
@@ -25,9 +27,9 @@ describe('A PatchOperationHandler', (): void => {
 
   it('deletes the resource from the store and returns the correct response.', async(): Promise<void> => {
     const metadata = new RepresentationMetadata('text/turtle');
-    const result = await handler.handle({ target: { path: 'url' }, body: { metadata }} as Operation);
+    const result = await handler.handle({ target: { path: 'url' }, body: { metadata }, conditions } as Operation);
     expect(store.modifyResource).toHaveBeenCalledTimes(1);
-    expect(store.modifyResource).toHaveBeenLastCalledWith({ path: 'url' }, { metadata });
+    expect(store.modifyResource).toHaveBeenLastCalledWith({ path: 'url' }, { metadata }, conditions);
     expect(result.statusCode).toBe(205);
     expect(result.metadata).toBeUndefined();
     expect(result.data).toBeUndefined();

--- a/test/unit/ldp/operations/PostOperationHandler.test.ts
+++ b/test/unit/ldp/operations/PostOperationHandler.test.ts
@@ -2,16 +2,23 @@ import type { Operation } from '../../../../src/ldp/operations/Operation';
 import { PostOperationHandler } from '../../../../src/ldp/operations/PostOperationHandler';
 import { RepresentationMetadata } from '../../../../src/ldp/representation/RepresentationMetadata';
 import type { ResourceIdentifier } from '../../../../src/ldp/representation/ResourceIdentifier';
+import { BasicConditions } from '../../../../src/storage/BasicConditions';
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
 import { BadRequestHttpError } from '../../../../src/util/errors/BadRequestHttpError';
 import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
 import { SOLID_HTTP } from '../../../../src/util/Vocabularies';
 
 describe('A PostOperationHandler', (): void => {
-  const store = {
-    addResource: async(): Promise<ResourceIdentifier> => ({ path: 'newPath' } as ResourceIdentifier),
-  } as unknown as ResourceStore;
-  const handler = new PostOperationHandler(store);
+  const conditions = new BasicConditions({});
+  let store: ResourceStore;
+  let handler: PostOperationHandler;
+
+  beforeEach(async(): Promise<void> => {
+    store = {
+      addResource: jest.fn(async(): Promise<ResourceIdentifier> => ({ path: 'newPath' } as ResourceIdentifier)),
+    } as unknown as ResourceStore;
+    handler = new PostOperationHandler(store);
+  });
 
   it('only supports POST operations.', async(): Promise<void> => {
     await expect(handler.canHandle({ method: 'POST', body: { }} as Operation))
@@ -28,10 +35,14 @@ describe('A PostOperationHandler', (): void => {
 
   it('adds the given representation to the store and returns the correct response.', async(): Promise<void> => {
     const metadata = new RepresentationMetadata('text/turtle');
-    const result = await handler.handle({ method: 'POST', body: { metadata }} as Operation);
+    const result = await handler.handle(
+      { method: 'POST', target: { path: 'url' }, body: { metadata }, conditions } as Operation,
+    );
     expect(result.statusCode).toBe(201);
     expect(result.metadata).toBeInstanceOf(RepresentationMetadata);
     expect(result.metadata?.get(SOLID_HTTP.location)?.value).toBe('newPath');
     expect(result.data).toBeUndefined();
+    expect(store.addResource).toHaveBeenCalledTimes(1);
+    expect(store.addResource).toHaveBeenLastCalledWith({ path: 'url' }, { metadata }, conditions);
   });
 });

--- a/test/unit/ldp/operations/PutOperationHandler.test.ts
+++ b/test/unit/ldp/operations/PutOperationHandler.test.ts
@@ -1,11 +1,13 @@
 import type { Operation } from '../../../../src/ldp/operations/Operation';
 import { PutOperationHandler } from '../../../../src/ldp/operations/PutOperationHandler';
 import { RepresentationMetadata } from '../../../../src/ldp/representation/RepresentationMetadata';
+import { BasicConditions } from '../../../../src/storage/BasicConditions';
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
 import { BadRequestHttpError } from '../../../../src/util/errors/BadRequestHttpError';
 import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
 
 describe('A PutOperationHandler', (): void => {
+  const conditions = new BasicConditions({});
   const store = {} as unknown as ResourceStore;
   const handler = new PutOperationHandler(store);
   beforeEach(async(): Promise<void> => {
@@ -26,9 +28,9 @@ describe('A PutOperationHandler', (): void => {
 
   it('sets the representation in the store and returns the correct response.', async(): Promise<void> => {
     const metadata = new RepresentationMetadata('text/turtle');
-    const result = await handler.handle({ target: { path: 'url' }, body: { metadata }} as Operation);
+    const result = await handler.handle({ target: { path: 'url' }, body: { metadata }, conditions } as Operation);
     expect(store.setRepresentation).toHaveBeenCalledTimes(1);
-    expect(store.setRepresentation).toHaveBeenLastCalledWith({ path: 'url' }, { metadata });
+    expect(store.setRepresentation).toHaveBeenLastCalledWith({ path: 'url' }, { metadata }, conditions);
     expect(result.statusCode).toBe(205);
     expect(result.metadata).toBeUndefined();
     expect(result.data).toBeUndefined();

--- a/test/unit/storage/BasicConditions.test.ts
+++ b/test/unit/storage/BasicConditions.test.ts
@@ -1,0 +1,78 @@
+import { RepresentationMetadata } from '../../../src/ldp/representation/RepresentationMetadata';
+import { BasicConditions } from '../../../src/storage/BasicConditions';
+import { getETag } from '../../../src/storage/Conditions';
+import { DC } from '../../../src/util/Vocabularies';
+
+describe('A BasicConditions', (): void => {
+  const now = new Date(2020, 10, 20);
+  const tomorrow = new Date(2020, 10, 21);
+  const yesterday = new Date(2020, 10, 19);
+  const eTags = [ '123456', 'abcdefg' ];
+
+  it('copies the input parameters.', async(): Promise<void> => {
+    const options = { matchesETag: eTags, notMatchesETag: eTags, modifiedSince: now, unmodifiedSince: now };
+    expect(new BasicConditions(options)).toMatchObject(options);
+  });
+
+  it('always returns false if notMatchesETag contains *.', async(): Promise<void> => {
+    const conditions = new BasicConditions({ notMatchesETag: [ '*' ]});
+    expect(conditions.matches()).toBe(false);
+  });
+
+  it('requires matchesETag to contain the provided ETag.', async(): Promise<void> => {
+    const conditions = new BasicConditions({ matchesETag: [ '1234' ]});
+    expect(conditions.matches('abcd')).toBe(false);
+    expect(conditions.matches('1234')).toBe(true);
+  });
+
+  it('supports all ETags if matchesETag contains *.', async(): Promise<void> => {
+    const conditions = new BasicConditions({ matchesETag: [ '*' ]});
+    expect(conditions.matches('abcd')).toBe(true);
+    expect(conditions.matches('1234')).toBe(true);
+  });
+
+  it('requires notMatchesETag to not contain the provided ETag.', async(): Promise<void> => {
+    const conditions = new BasicConditions({ notMatchesETag: [ '1234' ]});
+    expect(conditions.matches('1234')).toBe(false);
+    expect(conditions.matches('abcd')).toBe(true);
+  });
+
+  it('requires lastModified to be after modifiedSince.', async(): Promise<void> => {
+    const conditions = new BasicConditions({ modifiedSince: now });
+    expect(conditions.matches(undefined, yesterday)).toBe(false);
+    expect(conditions.matches(undefined, tomorrow)).toBe(true);
+  });
+
+  it('requires lastModified to be before unmodifiedSince.', async(): Promise<void> => {
+    const conditions = new BasicConditions({ unmodifiedSince: now });
+    expect(conditions.matches(undefined, tomorrow)).toBe(false);
+    expect(conditions.matches(undefined, yesterday)).toBe(true);
+  });
+
+  it('can match based on the last modified date in the metadata.', async(): Promise<void> => {
+    const metadata = new RepresentationMetadata({ [DC.modified]: now.toISOString() });
+    const conditions = new BasicConditions({
+      modifiedSince: yesterday,
+      unmodifiedSince: tomorrow,
+      matchesETag: [ getETag(metadata)! ],
+      notMatchesETag: [ '123456' ],
+    });
+    expect(conditions.matchesMetadata(metadata)).toBe(true);
+  });
+
+  it('matches if no date is found in the metadata.', async(): Promise<void> => {
+    const metadata = new RepresentationMetadata();
+    const conditions = new BasicConditions({
+      modifiedSince: yesterday,
+      unmodifiedSince: tomorrow,
+      matchesETag: [ getETag(metadata)! ],
+      notMatchesETag: [ '123456' ],
+    });
+    expect(conditions.matchesMetadata(metadata)).toBe(true);
+  });
+
+  it('checks if matchesETag contains * for resources that do not exist.', async(): Promise<void> => {
+    expect(new BasicConditions({ matchesETag: [ '*' ]}).matchesMetadata()).toBe(false);
+    expect(new BasicConditions({}).matchesMetadata()).toBe(true);
+  });
+});

--- a/test/unit/storage/Conditions.test.ts
+++ b/test/unit/storage/Conditions.test.ts
@@ -1,0 +1,17 @@
+import { RepresentationMetadata } from '../../../src/ldp/representation/RepresentationMetadata';
+import { getETag } from '../../../src/storage/Conditions';
+import { DC } from '../../../src/util/Vocabularies';
+
+describe('Conditions', (): void => {
+  describe('#getETag', (): void => {
+    it('creates an ETag based on the date last modified.', async(): Promise<void> => {
+      const now = new Date();
+      const metadata = new RepresentationMetadata({ [DC.modified]: now.toISOString() });
+      expect(getETag(metadata)).toBe(`"${now.getTime()}"`);
+    });
+
+    it('returns undefined if no date was found.', async(): Promise<void> => {
+      expect(getETag(new RepresentationMetadata())).toBeUndefined();
+    });
+  });
+});

--- a/test/unit/storage/PatchingStore.test.ts
+++ b/test/unit/storage/PatchingStore.test.ts
@@ -2,6 +2,7 @@ import type { Patch } from '../../../src/ldp/http/Patch';
 import type { PatchHandler } from '../../../src/storage/patch/PatchHandler';
 import { PatchingStore } from '../../../src/storage/PatchingStore';
 import type { ResourceStore } from '../../../src/storage/ResourceStore';
+import { NotImplementedHttpError } from '../../../src/util/errors/NotImplementedHttpError';
 
 describe('A PatchingStore', (): void => {
   let store: PatchingStore;
@@ -26,15 +27,25 @@ describe('A PatchingStore', (): void => {
     expect(source.modifyResource).toHaveBeenLastCalledWith({ path: 'modifyPath' }, {}, undefined);
   });
 
-  it('calls its patcher if modifyResource failed.', async(): Promise<void> => {
+  it('calls its patcher if modifyResource is not implemented.', async(): Promise<void> => {
     source.modifyResource = jest.fn(async(): Promise<any> => {
-      throw new Error('dummy');
+      throw new NotImplementedHttpError();
     });
     await expect(store.modifyResource({ path: 'modifyPath' }, {} as Patch)).resolves.toBe('patcher');
     expect(source.modifyResource).toHaveBeenCalledTimes(1);
     expect(source.modifyResource).toHaveBeenLastCalledWith({ path: 'modifyPath' }, {}, undefined);
-    await expect((source.modifyResource as jest.Mock).mock.results[0].value).rejects.toThrow('dummy');
+    await expect((source.modifyResource as jest.Mock).mock.results[0].value).rejects.toThrow(NotImplementedHttpError);
     expect(handleSafeFn).toHaveBeenCalledTimes(1);
     expect(handleSafeFn).toHaveBeenLastCalledWith({ source, identifier: { path: 'modifyPath' }, patch: {}});
+  });
+
+  it('rethrows source modifyResource errors.', async(): Promise<void> => {
+    source.modifyResource = jest.fn(async(): Promise<any> => {
+      throw new Error('dummy');
+    });
+    await expect(store.modifyResource({ path: 'modifyPath' }, {} as Patch)).rejects.toThrow('dummy');
+    expect(source.modifyResource).toHaveBeenCalledTimes(1);
+    expect(source.modifyResource).toHaveBeenLastCalledWith({ path: 'modifyPath' }, {}, undefined);
+    expect(handleSafeFn).toHaveBeenCalledTimes(0);
   });
 });

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -21,6 +21,8 @@ jest.mock('fs');
 
 const rootFilePath = 'uploads';
 const now = new Date();
+// All relevant functions do not care about the milliseconds or remove them
+now.setMilliseconds(0);
 
 describe('A FileDataAccessor', (): void => {
   const base = 'http://test.com/';
@@ -103,7 +105,8 @@ describe('A FileDataAccessor', (): void => {
       expect(metadata.get(POSIX.size)).toEqualRdfTerm(toLiteral('data'.length, XSD.terms.integer));
       expect(metadata.get(DC.modified)).toEqualRdfTerm(toLiteral(now.toISOString(), XSD.terms.dateTime));
       expect(metadata.get(POSIX.mtime)).toEqualRdfTerm(toLiteral(Math.floor(now.getTime() / 1000), XSD.terms.integer));
-      expect(metadata.quads(null, null, null, SOLID_META.terms.ResponseMetadata)).toHaveLength(3);
+      // `dc:modified` is in the default graph
+      expect(metadata.quads(null, null, null, SOLID_META.terms.ResponseMetadata)).toHaveLength(2);
     });
 
     it('does not generate size metadata for a container.', async(): Promise<void> => {
@@ -123,7 +126,8 @@ describe('A FileDataAccessor', (): void => {
       expect(metadata.get(POSIX.size)).toBeUndefined();
       expect(metadata.get(DC.modified)).toEqualRdfTerm(toLiteral(now.toISOString(), XSD.terms.dateTime));
       expect(metadata.get(POSIX.mtime)).toEqualRdfTerm(toLiteral(Math.floor(now.getTime() / 1000), XSD.terms.integer));
-      expect(metadata.quads(null, null, null, SOLID_META.terms.ResponseMetadata)).toHaveLength(2);
+      // `dc:modified` is in the default graph
+      expect(metadata.quads(null, null, null, SOLID_META.terms.ResponseMetadata)).toHaveLength(1);
     });
 
     it('generates metadata for container child resources.', async(): Promise<void> => {
@@ -139,8 +143,9 @@ describe('A FileDataAccessor', (): void => {
         expect(child.get(DC.modified)).toEqualRdfTerm(toLiteral(now.toISOString(), XSD.terms.dateTime));
         expect(child.get(POSIX.mtime)).toEqualRdfTerm(toLiteral(Math.floor(now.getTime() / 1000),
           XSD.terms.integer));
+        // `dc:modified` is in the default graph
         expect(child.quads(null, null, null, SOLID_META.terms.ResponseMetadata))
-          .toHaveLength(isContainerPath(child.identifier.value) ? 2 : 3);
+          .toHaveLength(isContainerPath(child.identifier.value) ? 1 : 2);
       }
     });
 

--- a/test/unit/util/ResourceUtil.test.ts
+++ b/test/unit/util/ResourceUtil.test.ts
@@ -1,7 +1,10 @@
+import 'jest-rdf';
+import type { Literal } from 'n3';
 import { BasicRepresentation } from '../../../src/ldp/representation/BasicRepresentation';
 import type { Representation } from '../../../src/ldp/representation/Representation';
-import * as resourceUtils from '../../../src/util/ResourceUtil';
-import 'jest-rdf';
+import { RepresentationMetadata } from '../../../src/ldp/representation/RepresentationMetadata';
+import { cloneRepresentation, updateModifiedDate } from '../../../src/util/ResourceUtil';
+import { DC, XSD } from '../../../src/util/Vocabularies';
 
 describe('ResourceUtil', (): void => {
   let representation: Representation;
@@ -10,16 +13,33 @@ describe('ResourceUtil', (): void => {
     representation = new BasicRepresentation('data', 'metadata');
   });
 
-  describe('cloneRepresentation', (): void => {
+  describe('#updateModifiedDate', (): void => {
+    it('adds the given date without milliseconds as last modified date.', async(): Promise<void> => {
+      const date = new Date();
+      date.setMilliseconds(500);
+      const metadata = new RepresentationMetadata();
+      updateModifiedDate(metadata, date);
+      const lastModified = metadata.get(DC.terms.modified);
+      expect(lastModified?.termType).toBe('Literal');
+      const lastModifiedDate = new Date(lastModified!.value);
+      expect(date.getTime() - lastModifiedDate.getTime()).toBe(500);
+
+      date.setMilliseconds(0);
+      expect(lastModified?.value).toBe(date.toISOString());
+      expect((lastModified as Literal).datatype).toEqualRdfTerm(XSD.terms.dateTime);
+    });
+  });
+
+  describe('#cloneRepresentation', (): void => {
     it('returns a clone of the passed representation.', async(): Promise<void> => {
-      const res = await resourceUtils.cloneRepresentation(representation);
+      const res = await cloneRepresentation(representation);
       expect(res.binary).toBe(representation.binary);
       expect(res.metadata.identifier).toBe(representation.metadata.identifier);
       expect(res.metadata.contentType).toBe(representation.metadata.contentType);
     });
 
     it('ensures that original representation does not update when the clone is updated.', async(): Promise<void> => {
-      const res = await resourceUtils.cloneRepresentation(representation);
+      const res = await cloneRepresentation(representation);
       res.metadata.contentType = 'typetype';
       expect(representation.metadata.contentType).not.toBe(res.metadata.contentType);
     });

--- a/test/unit/util/errors/HttpError.test.ts
+++ b/test/unit/util/errors/HttpError.test.ts
@@ -7,6 +7,7 @@ import { InternalServerError } from '../../../../src/util/errors/InternalServerE
 import { MethodNotAllowedHttpError } from '../../../../src/util/errors/MethodNotAllowedHttpError';
 import { NotFoundHttpError } from '../../../../src/util/errors/NotFoundHttpError';
 import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
+import { PreconditionFailedHttpError } from '../../../../src/util/errors/PreconditionFailedHttpError';
 import { UnauthorizedHttpError } from '../../../../src/util/errors/UnauthorizedHttpError';
 import { UnsupportedMediaTypeHttpError } from '../../../../src/util/errors/UnsupportedMediaTypeHttpError';
 
@@ -25,7 +26,7 @@ describe('HttpError', (): void => {
     [ 'NotFoundHttpError', 404, NotFoundHttpError ],
     [ 'MethodNotAllowedHttpError', 405, MethodNotAllowedHttpError ],
     [ 'ConflictHttpError', 409, ConflictHttpError ],
-    [ 'MethodNotAllowedHttpError', 405, MethodNotAllowedHttpError ],
+    [ 'PreconditionFailedHttpError', 412, PreconditionFailedHttpError ],
     [ 'UnsupportedMediaTypeHttpError', 415, UnsupportedMediaTypeHttpError ],
     [ 'InternalServerError', 500, InternalServerError ],
     [ 'NotImplementedHttpError', 501, NotImplementedHttpError ],

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -4,6 +4,7 @@ import type { SystemError } from '../../src/util/errors/SystemError';
 
 const portNames = [
   // Integration
+  'Conditions',
   'DynamicPods',
   'Identity',
   'LpdHandlerWithAuth',


### PR DESCRIPTION
Closes #17, closes #575, closes #576.

Merging into non-main branch for now due to potential breaking changes (so will have to remember to manually close those issues eventually).

Adds an ETag and Last-Modified header when doing a GET/HEAD request on a resource. Not sure if we also have to expose these headers through CORS now, @RubenVerborgh ?

Adds support for the following request headers:
 * If-Match
 * If-None-Match
 * If-Modified-Since
 * If-Unmodified-Since


Only adds support for the 412 error when trying to edit resources (POST/PATCH/PUT/DELETE), no support yet for the 304 Not Modified response on GET/HEAD requests (meaning we don't actually do anything yet with the `If-Modified-Since` header). Main reason for this is that we have no support yet for redirect responses, see #162.

The verification of the conditions of a PATCH happen in the `DataAccessorBasedStore` even though it throws a 501 after that. Reason is that this class contains all of the conditions checks. If we move this to the `PatchingStore` an extra `getMetadata` call would be required there. If we move this to the `PatchHandler`s, we would have to change their handle interface since they currently don't take conditions, and all future patch handlers would also have to do those checks (although we could potentially make a base class for this).

Main breaking changes in this PR:
 * `BasicRequestParser` now also needs a `ConditionsParser` parameter.
 * `PatchingStore` behaviour changed (only calling the patch handler if the source error was a 501 instead of all errors).