### PR TITLE
fix: Explain why logging in will not work

### DIFF
--- a/src/identity/IdentityProviderHttpHandler.ts
+++ b/src/identity/IdentityProviderHttpHandler.ts
@@ -227,10 +227,9 @@ export class IdentityProviderHttpHandler extends HttpHandler {
 
     if (result.type === 'complete') {
       if (!oidcInteraction) {
-        // Once https://github.com/solid/community-server/pull/898 is merged
-        // we want to assign an error code here to have a more thorough explanation
         throw new BadRequestHttpError(
-          'This action can only be executed as part of an authentication flow. It should not be used directly.',
+          'This action can only be performed as part of an OIDC authentication flow.',
+          { errorCode: 'E0002' },
         );
       }
       // Create a redirect URL with the OIDC library

--- a/templates/error/descriptions/E0002.md.hbs
+++ b/templates/error/descriptions/E0002.md.hbs
@@ -1,0 +1,6 @@
+# Please log in through an app
+Logging in to a Solid Pod needs to happen via a Solid app.
+<br>
+It is not possible to use the login page directly.
+If you are developing an app,
+you can use a library such as [`solid-client-authn-js`](https://github.com/inrupt/solid-client-authn-js) to initiate an OIDC authentication flow.

--- a/test/unit/identity/IdentityProviderHttpHandler.test.ts
+++ b/test/unit/identity/IdentityProviderHttpHandler.test.ts
@@ -160,9 +160,10 @@ describe('An IdentityProviderHttpHandler', (): void => {
     expect(routes.complete.handler.handleSafe).toHaveBeenLastCalledWith({ operation });
     expect(interactionCompleter.handleSafe).toHaveBeenCalledTimes(0);
 
-    const error = new BadRequestHttpError(
-      'This action can only be executed as part of an authentication flow. It should not be used directly.',
-    );
+    const error = expect.objectContaining({
+      message: 'This action can only be performed as part of an OIDC authentication flow.',
+      errorCode: 'E0002',
+    });
     expect(errorHandler.handleSafe).toHaveBeenCalledTimes(1);
     expect(errorHandler.handleSafe).toHaveBeenLastCalledWith({ error, preferences: { type: { 'text/html': 1 }}});
     expect(responseWriter.handleSafe).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Closes #880 

Now that the IDP handles content-negotiation for errors the login error can have a more detailed explanation.