### PR TITLE
fix: Update conformance script to target full URI

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -35,5 +35,7 @@ jobs:
           docker run -i --rm
           -v "$(pwd)"/reports/css:/reports
           --env-file=./test/deploy/conformance.env
-          --network="host" solidconformancetestbeta/conformance-test-harness
-          --output=/reports --target=css
+          --network="host"
+          solidconformancetestbeta/conformance-test-harness
+          --output=/reports
+          --target=https://github.com/solid/conformance-test-harness/css


### PR DESCRIPTION
Was required due to update to the conformance test suite.

Test is going to fail since we don't return a 201 yet when creating a new resource.