### PR TITLE
Rename resourceStore to aclStore

### DIFF
--- a/config/ldp/authorization/authorizers/acl.json
+++ b/config/ldp/authorization/authorizers/acl.json
@@ -12,7 +12,7 @@
       "aclStrategy": {
         "@id": "urn:solid-server:default:AclStrategy"
       },
-      "resourceStore": {
+      "aclStore": {
         "@id": "urn:solid-server:default:ResourceStore"
       },
       "identifierStrategy": {

--- a/src/authorization/WebAclAuthorizer.ts
+++ b/src/authorization/WebAclAuthorizer.ts
@@ -37,15 +37,15 @@ export class WebAclAuthorizer extends Authorizer {
   protected readonly logger = getLoggerFor(this);
 
   private readonly aclStrategy: AuxiliaryIdentifierStrategy;
-  private readonly resourceStore: ResourceStore;
+  private readonly aclStore: ResourceStore;
   private readonly identifierStrategy: IdentifierStrategy;
   private readonly accessChecker: AccessChecker;
 
-  public constructor(aclStrategy: AuxiliaryIdentifierStrategy, resourceStore: ResourceStore,
+  public constructor(aclStrategy: AuxiliaryIdentifierStrategy, aclStore: ResourceStore,
     identifierStrategy: IdentifierStrategy, accessChecker: AccessChecker) {
     super();
     this.aclStrategy = aclStrategy;
-    this.resourceStore = resourceStore;
+    this.aclStore = aclStore;
     this.identifierStrategy = identifierStrategy;
     this.accessChecker = accessChecker;
   }
@@ -172,7 +172,7 @@ export class WebAclAuthorizer extends Authorizer {
     try {
       const acl = this.aclStrategy.getAuxiliaryIdentifier(id);
       this.logger.debug(`Trying to read the ACL document ${acl.path}`);
-      const data = await this.resourceStore.getRepresentation(acl, { type: { [INTERNAL_QUADS]: 1 }});
+      const data = await this.aclStore.getRepresentation(acl, { type: { [INTERNAL_QUADS]: 1 }});
       this.logger.info(`Reading ACL statements from ${acl.path}`);
 
       return await this.filterData(data, recurse ? ACL.default : ACL.accessTo, id.path);


### PR DESCRIPTION
Changing the name of the parameter to indicate that this store only has to contain the ACL resources.

(This might become relevant later if it turns out we also need to access resource state to make ACL decisions, as in https://github.com/solid/web-access-control-spec/issues/97)