### PR TITLE
Make json-ld context prefix generation deterministic

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/solid/community-server#readme",
   "scripts": {
     "build": "npm run build:ts && npm run build:components",
-    "build:components": "componentsjs-generator -s src -c dist/components -i .componentsignore --typeScopedContexts",
+    "build:components": "componentsjs-generator -s src -c dist/components -r scs -i .componentsignore --typeScopedContexts",
     "build:ts": "tsc",
     "docker": "npm run docker:setup && npm run docker:start",
     "docker:clean": "./test/docker/docker-clean.sh",


### PR DESCRIPTION
Currently all instance configurations in `config/` uses `scs`, `files-scs` prefixes in compact-iris. The prefix seems expected to get defined in json-ld context that gets generated on `build:components`.

But it is unclear why prefix is getting generated to magical `scs` on build. after verifying with `components-generator`, it seems using a function https://github.com/LinkedSoftwareDependencies/Components-Generator.js/blob/5b7a93b42f773d9cd83a7f62a5de7d03a59bfe66/lib/serialize/ContextConstructor.ts#L23 to heuristically generate fallback prefix from package-name.

It's good to be deterministic and not to depend on heuristics-sans-contract, as other code assuming this prefix. Also newbies can understand from where those assumptions came from.