### PR TITLE
docs: Add routing config for sparql endpoint and storage

### DIFF
--- a/config/sparql-file-storage.json
+++ b/config/sparql-file-storage.json
@@ -1,0 +1,87 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld",
+  "import": [
+    "files-scs:config/app/main/default.json",
+    "files-scs:config/app/init/default.json",
+    "files-scs:config/app/setup/required.json",
+    "files-scs:config/http/handler/default.json",
+    "files-scs:config/http/middleware/websockets.json",
+    "files-scs:config/http/server-factory/websockets.json",
+    "files-scs:config/http/static/default.json",
+    "files-scs:config/identity/access/public.json",
+    "files-scs:config/identity/email/default.json",
+    "files-scs:config/identity/handler/default.json",
+    "files-scs:config/identity/ownership/token.json",
+    "files-scs:config/identity/pod/static.json",
+    "files-scs:config/identity/registration/enabled.json",
+    "files-scs:config/ldp/authentication/dpop-bearer.json",
+    "files-scs:config/ldp/authorization/webacl.json",
+    "files-scs:config/ldp/handler/default.json",
+    "files-scs:config/ldp/metadata-parser/default.json",
+    "files-scs:config/ldp/metadata-writer/default.json",
+    "files-scs:config/ldp/modes/default.json",
+
+    "files-scs:config/storage/key-value/resource-store.json",
+    "files-scs:config/storage/middleware/default.json",
+    "files-scs:config/util/auxiliary/acl.json",
+    "files-scs:config/util/identifiers/suffix.json",
+    "files-scs:config/util/index/default.json",
+    "files-scs:config/util/logging/winston.json",
+    "files-scs:config/util/representation-conversion/default.json",
+    "files-scs:config/util/resource-locker/memory.json",
+    "files-scs:config/util/variables/default.json",
+
+    "files-scs:config/storage/backend/data-accessors/file.json",
+    "files-scs:config/storage/backend/data-accessors/sparql-endpoint.json"
+  ],
+  "@graph": [
+    {
+      "comment": "This store will be used to route internal storage to the file system and all other data to the SPARQL endpoint."
+    },
+
+    {
+      "@id": "urn:solid-server:default:ResourceStore_Backend",
+      "@type": "RoutingResourceStore",
+      "rule": { "@id": "urn:solid-server:default:RouterRule" }
+    },
+
+    {
+      "comment": "Configure routing to send internal data to file system and all other data to sparql store.",
+      "@id": "urn:solid-server:default:RouterRule",
+      "@type": "RegexRouterRule",
+      "base": { "@id": "urn:solid-server:default:variable:baseUrl" },
+      "storeMap": [
+        {
+          "comment": "Internal storage data",
+          "RegexRouterRule:_storeMap_key": "^/\\.internal/",
+          "RegexRouterRule:_storeMap_value": { "@id": "urn:solid-server:default:FileResourceStore" }
+        },
+        {
+          "comment": "Send everything else to the SPARQL store.",
+          "RegexRouterRule:_storeMap_key": "^/(?!\\.internal/).*",
+          "RegexRouterRule:_storeMap_value": { "@id": "urn:solid-server:default:SparqlResourceStore" }
+        }
+      ]
+    },
+
+    {
+      "@id": "urn:solid-server:default:FileResourceStore",
+      "@type": "DataAccessorBasedStore",
+      "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" },
+      "auxiliaryStrategy": { "@id": "urn:solid-server:default:AuxiliaryStrategy" },
+      "accessor": { "@id": "urn:solid-server:default:FileDataAccessor" }
+    },
+    {
+      "@id": "urn:solid-server:default:SparqlResourceStore",
+      "@type": "RepresentationConvertingStore",
+      "options_inConverter": { "@id": "urn:solid-server:default:RepresentationConverter" },
+      "options_inType": "internal/quads",
+      "source": {
+        "@type": "DataAccessorBasedStore",
+        "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" },
+        "auxiliaryStrategy": { "@id": "urn:solid-server:default:AuxiliaryStrategy" },
+        "accessor": { "@id": "urn:solid-server:default:SparqlDataAccessor" }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This config uses a sparql endpoint but uses routing to put all internal storage on the file system.

Reason is that the default sparql config puts internal storage in memory. This due to internal storage using JSON which can't be converted into quads. Perhaps we should have a converter for that at some point, but for now this is a solution that allows for permanent account storage.

Origin of this is someone asking how to do this in the gitter causing me to make this [gist](https://gist.github.com/joachimvh/da75e1239fb026db0b3375ded505b21f). Since I heard from 1-2 people that they also found this gist and used it, it might not be a bad idea to just have this example in our list of configs.