### PR TITLE
chore: Run conformance tests on upcoming version

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   conformance:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - 'main'
+          - 'versions/2.0.0'
     timeout-minutes: 10
     steps:
       - name: Use Node.js 16.x
@@ -17,6 +23,8 @@ jobs:
           node-version: 16.x
       - name: Check out the project
         uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.branch }}
       - name: Install dependencies and run build scripts
         run: npm ci
       - name: Start the server in the background

--- a/test/deploy/conformance.env
+++ b/test/deploy/conformance.env
@@ -1,5 +1,5 @@
-SOLID_IDENTITY_PROVIDER=http://localhost:3000/idp
-USER_REGISTRATION_ENDPOINT=http://localhost:3000/idp/register
+SOLID_IDENTITY_PROVIDER=http://localhost:3000/idp/
+USER_REGISTRATION_ENDPOINT=http://localhost:3000/idp/register/
 USERS_ALICE_WEBID=http://localhost:3000/alice/profile/card#me
 USERS_ALICE_USERNAME=alice@alice.mail
 USERS_ALICE_PASSWORD=pass1234


### PR DESCRIPTION
This also runs the conformance test on the `version/2.0.0` branch. We probably want to know the status there before we release it.

It also updates the env file in preparation of 2.0.0.

"Problems" with this PR:
 - It's a bit more annoying to test if the change does not break anything since the `test/conformance` branch no longer gets tested (since the branches are now set in the matrix). So I tested this by adding that branch to the matrix, and then force pushing a commit where it was removed again after testing.
 - `version/2.0.0` is hardcoded in the matrix. I don't know of any solution where we could run this on all branches matching `version/*`, but would be happy if there was a solution possible there. Otherwise we will have to update this every time we do a release.
 - Conformance tests on 2.0.0 are not going to run at all after this PR since that branch still has the incorrect env file. So will have to merge `main` into `version/2.0.0` after this to make it work.

CI is going to fail on this PR since we don't pass all conformance tests.