### PR TITLE
Update index.html: add link to login page

### DIFF
--- a/templates/root/index.html
+++ b/templates/root/index.html
@@ -23,7 +23,8 @@
     <h2 id="users">Getting started as a <em>user</em></h2>
     <p>
       <strong><a href="/idp/register/">Sign up</a> for an account</strong>
-      to get started with your own Pod and WebID.
+      to get started with your own Pod and WebID. After that, you can <a href="/idp/login/">Log In</a> 
+      with your new account.
     </p>
     <p>
       The <em>default</em> configuration stores data only in memory,


### PR DESCRIPTION
The login page is not linked inside the welcoming index page. Adding a link here makes it easier for newcomers to find the login page URL.