### PR TITLE
fix: Let Representations always have a body

### DIFF
--- a/src/authorization/permissions/SparqlPatchModesExtractor.ts
+++ b/src/authorization/permissions/SparqlPatchModesExtractor.ts
@@ -11,9 +11,6 @@ export class SparqlPatchModesExtractor extends ModesExtractor {
     if (method !== 'PATCH') {
       throw new NotImplementedHttpError(`Cannot determine permissions of ${method}, only PATCH.`);
     }
-    if (!body) {
-      throw new NotImplementedHttpError('Cannot determine permissions of PATCH operations without a body.');
-    }
     if (!this.isSparql(body)) {
       throw new NotImplementedHttpError('Cannot determine permissions of non-SPARQL patches.');
     }

--- a/src/http/Operation.ts
+++ b/src/http/Operation.ts
@@ -29,7 +29,7 @@ export interface Operation {
    */
   permissionSet?: PermissionSet;
   /**
-   * Optional representation of the body.
+   * Representation of the body and metadata headers.
    */
-  body?: Representation;
+  body: Representation;
 }

--- a/src/http/input/body/BodyParser.ts
+++ b/src/http/input/body/BodyParser.ts
@@ -19,4 +19,4 @@ export interface BodyParserArgs {
  * Parses the body of an incoming {@link HttpRequest} and converts it to a {@link Representation}.
  */
 export abstract class BodyParser extends
-  AsyncHandler<BodyParserArgs, Representation | undefined> {}
+  AsyncHandler<BodyParserArgs, Representation> {}

--- a/src/http/input/body/RawBodyParser.ts
+++ b/src/http/input/body/RawBodyParser.ts
@@ -13,7 +13,7 @@ export class RawBodyParser extends BodyParser {
 
   // Note that the only reason this is a union is in case the body is empty.
   // If this check gets moved away from the BodyParsers this union could be removed
-  public async handle({ request, metadata }: BodyParserArgs): Promise<Representation | undefined> {
+  public async handle({ request, metadata }: BodyParserArgs): Promise<Representation> {
     const {
       'content-type': contentType,
       'content-length': contentLength,
@@ -26,7 +26,7 @@ export class RawBodyParser extends BodyParser {
     // some still provide a Content-Length of 0 (but without Content-Type).
     if ((!contentLength || (/^0+$/u.test(contentLength) && !contentType)) && !transferEncoding) {
       this.logger.debug('HTTP request does not have a body, or its empty body is missing a Content-Type header');
-      return;
+      return new BasicRepresentation([], metadata);
     }
 
     // While RFC7231 allows treating a body without content type as an octet stream,

--- a/src/http/input/body/SparqlUpdateBodyParser.ts
+++ b/src/http/input/body/SparqlUpdateBodyParser.ts
@@ -38,6 +38,7 @@ export class SparqlUpdateBodyParser extends BodyParser {
       binary: true,
       data: guardedStreamFrom(sparql),
       metadata,
+      isEmpty: false,
     };
   }
 }

--- a/src/http/ldp/PatchOperationHandler.ts
+++ b/src/http/ldp/PatchOperationHandler.ts
@@ -32,9 +32,9 @@ export class PatchOperationHandler extends OperationHandler {
     // Solid, §2.1: "A Solid server MUST reject PUT, POST and PATCH requests
     // without the Content-Type header with a status code of 400."
     // https://solid.github.io/specification/protocol#http-server
-    if (!operation.body?.metadata.contentType) {
-      this.logger.warn('No Content-Type header specified on PATCH request');
-      throw new BadRequestHttpError('No Content-Type header specified on PATCH request');
+    if (!operation.body.metadata.contentType) {
+      this.logger.warn('PATCH requests require the Content-Type header to be set');
+      throw new BadRequestHttpError('PATCH requests require the Content-Type header to be set');
     }
     await this.store.modifyResource(operation.target, operation.body as Patch, operation.conditions);
     return new ResetResponseDescription();

--- a/src/http/ldp/PostOperationHandler.ts
+++ b/src/http/ldp/PostOperationHandler.ts
@@ -31,9 +31,9 @@ export class PostOperationHandler extends OperationHandler {
     // Solid, §2.1: "A Solid server MUST reject PUT, POST and PATCH requests
     // without the Content-Type header with a status code of 400."
     // https://solid.github.io/specification/protocol#http-server
-    if (!operation.body?.metadata.contentType) {
-      this.logger.warn('No Content-Type header specified on POST request');
-      throw new BadRequestHttpError('No Content-Type header specified on POST request');
+    if (!operation.body.metadata.contentType) {
+      this.logger.warn('POST requests require the Content-Type header to be set');
+      throw new BadRequestHttpError('POST requests require the Content-Type header to be set');
     }
     const identifier = await this.store.addResource(operation.target, operation.body, operation.conditions);
     return new CreatedResponseDescription(identifier);

--- a/src/http/ldp/PutOperationHandler.ts
+++ b/src/http/ldp/PutOperationHandler.ts
@@ -31,9 +31,9 @@ export class PutOperationHandler extends OperationHandler {
     // Solid, §2.1: "A Solid server MUST reject PUT, POST and PATCH requests
     // without the Content-Type header with a status code of 400."
     // https://solid.github.io/specification/protocol#http-server
-    if (!operation.body?.metadata.contentType) {
-      this.logger.warn('No Content-Type header specified on PUT request');
-      throw new BadRequestHttpError('No Content-Type header specified on PUT request');
+    if (!operation.body.metadata.contentType) {
+      this.logger.warn('PUT requests require the Content-Type header to be set');
+      throw new BadRequestHttpError('PUT requests require the Content-Type header to be set');
     }
     await this.store.setRepresentation(operation.target, operation.body, operation.conditions);
     return new ResetResponseDescription();

--- a/src/http/representation/BasicRepresentation.ts
+++ b/src/http/representation/BasicRepresentation.ts
@@ -25,6 +25,11 @@ export class BasicRepresentation implements Representation {
   public readonly binary: boolean;
 
   /**
+   * An empty Representation
+   */
+  public constructor();
+
+  /**
    * @param data - The representation data
    * @param metadata - The representation metadata
    * @param binary - Whether the representation is a binary or object stream
@@ -86,13 +91,15 @@ export class BasicRepresentation implements Representation {
   );
 
   public constructor(
-    data: Readable | any[] | string,
-    metadata: RepresentationMetadata | MetadataRecord | MetadataIdentifier | string,
+    data?: Readable | any[] | string,
+    metadata?: RepresentationMetadata | MetadataRecord | MetadataIdentifier | string,
     metadataRest?: MetadataRecord | string | boolean,
     binary?: boolean,
   ) {
     if (typeof data === 'string' || Array.isArray(data)) {
       data = guardedStreamFrom(data);
+    } else if (!data) {
+      data = guardedStreamFrom([]);
     }
     this.data = guardStream(data);
 
@@ -109,5 +116,12 @@ export class BasicRepresentation implements Representation {
       binary = metadata.contentType !== INTERNAL_QUADS;
     }
     this.binary = binary;
+  }
+
+  /**
+   * Data should only be interpreted if there is a content type.
+   */
+  public get isEmpty(): boolean {
+    return !this.metadata.contentType;
   }
 }

--- a/src/http/representation/Representation.ts
+++ b/src/http/representation/Representation.ts
@@ -19,4 +19,10 @@ export interface Representation {
    * (as opposed to complex objects).
    */
   binary: boolean;
+  /**
+   * Whether the data stream is empty.
+   * This being true does not imply that the data stream has a length of more than 0,
+   * only that it is a possibility and should be read to be sure.
+   */
+  isEmpty: boolean;
 }

--- a/src/identity/IdentityProviderHttpHandler.ts
+++ b/src/identity/IdentityProviderHttpHandler.ts
@@ -3,7 +3,6 @@ import type { ErrorHandler } from '../http/output/error/ErrorHandler';
 import { RedirectResponseDescription } from '../http/output/response/RedirectResponseDescription';
 import { ResponseDescription } from '../http/output/response/ResponseDescription';
 import { BasicRepresentation } from '../http/representation/BasicRepresentation';
-import type { Representation } from '../http/representation/Representation';
 import { getLoggerFor } from '../logging/LogUtil';
 import type { HttpRequest } from '../server/HttpRequest';
 import type { OperationHttpHandlerInput } from '../server/OperationHttpHandler';
@@ -124,10 +123,10 @@ export class IdentityProviderHttpHandler extends OperationHttpHandler {
     }
 
     // Cloning input data so it can be sent back in case of errors
-    let clone: Representation | undefined;
+    let clone = operation.body;
 
     // IDP handlers expect JSON data
-    if (operation.body) {
+    if (!operation.body.isEmpty) {
       const args = {
         representation: operation.body,
         preferences: { type: { [APPLICATION_JSON]: 1 }},
@@ -187,7 +186,7 @@ export class IdentityProviderHttpHandler extends OperationHttpHandler {
       const details = await readJsonStream(response.data!);
 
       // Add the input data to the JSON response;
-      if (operation.body) {
+      if (!operation.body.isEmpty) {
         details.prefilled = await readJsonStream(operation.body.data);
 
         // Don't send passwords back

--- a/src/identity/interaction/SessionHttpHandler.ts
+++ b/src/identity/interaction/SessionHttpHandler.ts
@@ -12,7 +12,7 @@ export class SessionHttpHandler extends InteractionHandler {
       throw new NotImplementedHttpError('Only interactions with a valid session are supported.');
     }
 
-    const { remember } = await readJsonStream(operation.body!.data);
+    const { remember } = await readJsonStream(operation.body.data);
     return {
       type: 'complete',
       details: { webId: oidcInteraction.session.accountId, shouldRemember: Boolean(remember) },

--- a/src/identity/interaction/email-password/handler/ForgotPasswordHandler.ts
+++ b/src/identity/interaction/email-password/handler/ForgotPasswordHandler.ts
@@ -39,7 +39,7 @@ export class ForgotPasswordHandler extends InteractionHandler {
 
   public async handle({ operation }: InteractionHandlerInput): Promise<InteractionResponseResult<{ email: string }>> {
     // Validate incoming data
-    const { email } = await readJsonStream(operation.body!.data);
+    const { email } = await readJsonStream(operation.body.data);
     assert(typeof email === 'string' && email.length > 0, 'Email required');
 
     await this.resetPassword(email);

--- a/src/identity/interaction/email-password/handler/LoginHandler.ts
+++ b/src/identity/interaction/email-password/handler/LoginHandler.ts
@@ -43,7 +43,7 @@ export class LoginHandler extends InteractionHandler {
    */
   private async parseInput(operation: Operation): Promise<{ email: string; password: string; remember: boolean }> {
     const prefilled: Record<string, string> = {};
-    const { email, password, remember } = await readJsonStream(operation.body!.data);
+    const { email, password, remember } = await readJsonStream(operation.body.data);
     assert(typeof email === 'string' && email.length > 0, 'Email required');
     prefilled.email = email;
     assert(typeof password === 'string' && password.length > 0, 'Password required');

--- a/src/identity/interaction/email-password/handler/RegistrationHandler.ts
+++ b/src/identity/interaction/email-password/handler/RegistrationHandler.ts
@@ -19,7 +19,7 @@ export class RegistrationHandler extends InteractionHandler {
 
   public async handle({ operation }: InteractionHandlerInput):
   Promise<InteractionResponseResult<RegistrationResponse>> {
-    const data = await readJsonStream(operation.body!.data);
+    const data = await readJsonStream(operation.body.data);
     const validated = this.registrationManager.validateInput(data, false);
     const details = await this.registrationManager.register(validated, false);
     return { type: 'response', details };

--- a/src/identity/interaction/email-password/handler/ResetPasswordHandler.ts
+++ b/src/identity/interaction/email-password/handler/ResetPasswordHandler.ts
@@ -24,7 +24,7 @@ export class ResetPasswordHandler extends InteractionHandler {
     // Extract record ID from request URL
     const recordId = /\/([^/]+)$/u.exec(operation.target.path)?.[1];
     // Validate input data
-    const { password, confirmPassword } = await readJsonStream(operation.body!.data);
+    const { password, confirmPassword } = await readJsonStream(operation.body.data);
     assert(
       typeof recordId === 'string' && recordId.length > 0,
       'Invalid request. Open the link from your email again',

--- a/src/init/setup/SetupHttpHandler.ts
+++ b/src/init/setup/SetupHttpHandler.ts
@@ -159,7 +159,7 @@ export class SetupHttpHandler extends OperationHttpHandler {
 
     // Registration manager expects JSON data
     let json: SetupInput = {};
-    if (operation.body) {
+    if (!operation.body.isEmpty) {
       const args = {
         representation: operation.body,
         preferences: { type: { [APPLICATION_JSON]: 1 }},

--- a/test/integration/GuardedStream.test.ts
+++ b/test/integration/GuardedStream.test.ts
@@ -37,7 +37,7 @@ class DummyConverter extends TypedRepresentationConverter {
     const data = guardedStreamFrom([ 'dummy' ]);
     const metadata = new RepresentationMetadata(representation.metadata, 'x/x');
 
-    return { binary: true, data, metadata };
+    return { binary: true, data, metadata, isEmpty: false };
   }
 }
 

--- a/test/integration/RequestParser.test.ts
+++ b/test/integration/RequestParser.test.ts
@@ -55,7 +55,7 @@ describe('A BasicRequestParser with simple input parsers', (): void => {
     });
     expect(result.body?.metadata.contentType).toEqual('text/turtle');
 
-    await expect(arrayifyStream(result.body!.data)).resolves.toEqual(
+    await expect(arrayifyStream(result.body.data)).resolves.toEqual(
       [ '<http://test.com/s> <http://test.com/p> <http://test.com/o>.' ],
     );
   });

--- a/test/unit/authorization/permissions/SparqlPatchModesExtractor.test.ts
+++ b/test/unit/authorization/permissions/SparqlPatchModesExtractor.test.ts
@@ -19,10 +19,6 @@ describe('A SparqlPatchModesExtractor', (): void => {
     await expect(result).rejects.toThrow(NotImplementedHttpError);
     await expect(result).rejects.toThrow('Cannot determine permissions of GET, only PATCH.');
 
-    result = extractor.canHandle({ ...operation, body: undefined });
-    await expect(result).rejects.toThrow(NotImplementedHttpError);
-    await expect(result).rejects.toThrow('Cannot determine permissions of PATCH operations without a body.');
-
     result = extractor.canHandle({ ...operation, body: {} as SparqlUpdatePatch });
     await expect(result).rejects.toThrow(NotImplementedHttpError);
     await expect(result).rejects.toThrow('Cannot determine permissions of non-SPARQL patches.');

--- a/test/unit/http/ldp/DeleteOperationHandler.test.ts
+++ b/test/unit/http/ldp/DeleteOperationHandler.test.ts
@@ -1,5 +1,6 @@
 import { DeleteOperationHandler } from '../../../../src/http/ldp/DeleteOperationHandler';
 import type { Operation } from '../../../../src/http/Operation';
+import { BasicRepresentation } from '../../../../src/http/representation/BasicRepresentation';
 import { BasicConditions } from '../../../../src/storage/BasicConditions';
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
 import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
@@ -7,10 +8,11 @@ import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplemen
 describe('A DeleteOperationHandler', (): void => {
   let operation: Operation;
   const conditions = new BasicConditions({});
+  const body = new BasicRepresentation();
   const store = {} as unknown as ResourceStore;
   const handler = new DeleteOperationHandler(store);
   beforeEach(async(): Promise<void> => {
-    operation = { method: 'DELETE', target: { path: 'http://test.com/foo' }, preferences: {}, conditions };
+    operation = { method: 'DELETE', target: { path: 'http://test.com/foo' }, preferences: {}, conditions, body };
     store.deleteResource = jest.fn(async(): Promise<any> => undefined);
   });
 

--- a/test/unit/http/ldp/GetOperationHandler.test.ts
+++ b/test/unit/http/ldp/GetOperationHandler.test.ts
@@ -1,5 +1,6 @@
 import { GetOperationHandler } from '../../../../src/http/ldp/GetOperationHandler';
 import type { Operation } from '../../../../src/http/Operation';
+import { BasicRepresentation } from '../../../../src/http/representation/BasicRepresentation';
 import type { Representation } from '../../../../src/http/representation/Representation';
 import { BasicConditions } from '../../../../src/storage/BasicConditions';
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
@@ -9,11 +10,12 @@ describe('A GetOperationHandler', (): void => {
   let operation: Operation;
   const conditions = new BasicConditions({});
   const preferences = {};
+  const body = new BasicRepresentation();
   let store: ResourceStore;
   let handler: GetOperationHandler;
 
   beforeEach(async(): Promise<void> => {
-    operation = { method: 'GET', target: { path: 'http://test.com/foo' }, preferences, conditions };
+    operation = { method: 'GET', target: { path: 'http://test.com/foo' }, preferences, conditions, body };
     store = {
       getRepresentation: jest.fn(async(): Promise<Representation> =>
         ({ binary: false, data: 'data', metadata: 'metadata' } as any)),

--- a/test/unit/http/ldp/HeadOperationHandler.test.ts
+++ b/test/unit/http/ldp/HeadOperationHandler.test.ts
@@ -1,6 +1,7 @@
 import type { Readable } from 'stream';
 import { HeadOperationHandler } from '../../../../src/http/ldp/HeadOperationHandler';
 import type { Operation } from '../../../../src/http/Operation';
+import { BasicRepresentation } from '../../../../src/http/representation/BasicRepresentation';
 import type { Representation } from '../../../../src/http/representation/Representation';
 import { BasicConditions } from '../../../../src/storage/BasicConditions';
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
@@ -10,12 +11,13 @@ describe('A HeadOperationHandler', (): void => {
   let operation: Operation;
   const conditions = new BasicConditions({});
   const preferences = {};
+  const body = new BasicRepresentation();
   let store: ResourceStore;
   let handler: HeadOperationHandler;
   let data: Readable;
 
   beforeEach(async(): Promise<void> => {
-    operation = { method: 'HEAD', target: { path: 'http://test.com/foo' }, preferences, conditions };
+    operation = { method: 'HEAD', target: { path: 'http://test.com/foo' }, preferences, conditions, body };
     data = { destroy: jest.fn() } as any;
     store = {
       getRepresentation: jest.fn(async(): Promise<Representation> =>

--- a/test/unit/http/ldp/PatchOperationHandler.test.ts
+++ b/test/unit/http/ldp/PatchOperationHandler.test.ts
@@ -25,10 +25,8 @@ describe('A PatchOperationHandler', (): void => {
     await expect(handler.canHandle({ operation })).rejects.toThrow(NotImplementedHttpError);
   });
 
-  it('errors if there is no body or content-type.', async(): Promise<void> => {
-    operation.body!.metadata.contentType = undefined;
-    await expect(handler.handle({ operation })).rejects.toThrow(BadRequestHttpError);
-    delete operation.body;
+  it('errors if there is no content-type.', async(): Promise<void> => {
+    operation.body.metadata.contentType = undefined;
     await expect(handler.handle({ operation })).rejects.toThrow(BadRequestHttpError);
   });
 

--- a/test/unit/http/ldp/PostOperationHandler.test.ts
+++ b/test/unit/http/ldp/PostOperationHandler.test.ts
@@ -32,10 +32,8 @@ describe('A PostOperationHandler', (): void => {
     await expect(handler.canHandle({ operation })).rejects.toThrow(NotImplementedHttpError);
   });
 
-  it('errors if there is no body or content-type.', async(): Promise<void> => {
-    operation.body!.metadata.contentType = undefined;
-    await expect(handler.handle({ operation })).rejects.toThrow(BadRequestHttpError);
-    delete operation.body;
+  it('errors if there is no content-type.', async(): Promise<void> => {
+    operation.body.metadata.contentType = undefined;
     await expect(handler.handle({ operation })).rejects.toThrow(BadRequestHttpError);
   });
 

--- a/test/unit/http/ldp/PutOperationHandler.test.ts
+++ b/test/unit/http/ldp/PutOperationHandler.test.ts
@@ -26,10 +26,8 @@ describe('A PutOperationHandler', (): void => {
     await expect(handler.canHandle({ operation })).rejects.toThrow(NotImplementedHttpError);
   });
 
-  it('errors if there is no body or content-type.', async(): Promise<void> => {
-    operation.body!.metadata.contentType = undefined;
-    await expect(handler.handle({ operation })).rejects.toThrow(BadRequestHttpError);
-    delete operation.body;
+  it('errors if there is no content-type.', async(): Promise<void> => {
+    operation.body.metadata.contentType = undefined;
     await expect(handler.handle({ operation })).rejects.toThrow(BadRequestHttpError);
   });
 

--- a/test/unit/http/ldp/metadata/WebAclMetadataCollector.test.ts
+++ b/test/unit/http/ldp/metadata/WebAclMetadataCollector.test.ts
@@ -3,6 +3,7 @@ import { CredentialGroup } from '../../../../../src/authentication/Credentials';
 import type { AclPermission } from '../../../../../src/authorization/permissions/AclPermission';
 import { WebAclMetadataCollector } from '../../../../../src/http/ldp/metadata/WebAclMetadataCollector';
 import type { Operation } from '../../../../../src/http/Operation';
+import { BasicRepresentation } from '../../../../../src/http/representation/BasicRepresentation';
 import { RepresentationMetadata } from '../../../../../src/http/representation/RepresentationMetadata';
 import { ACL, AUTH } from '../../../../../src/util/Vocabularies';
 
@@ -16,6 +17,7 @@ describe('A WebAclMetadataCollector', (): void => {
       method: 'GET',
       target: { path: 'http://test.com/foo' },
       preferences: {},
+      body: new BasicRepresentation(),
     };
 
     metadata = new RepresentationMetadata();

--- a/test/unit/identity/IdentityProviderHttpHandler.test.ts
+++ b/test/unit/identity/IdentityProviderHttpHandler.test.ts
@@ -38,7 +38,12 @@ describe('An IdentityProviderHttpHandler', (): void => {
   let handler: IdentityProviderHttpHandler;
 
   beforeEach(async(): Promise<void> => {
-    operation = { method: 'GET', target: { path: 'http://test.com/idp' }, preferences: { type: { 'text/html': 1 }}};
+    operation = {
+      method: 'GET',
+      target: { path: 'http://test.com/idp' },
+      preferences: { type: { 'text/html': 1 }},
+      body: new BasicRepresentation(),
+    };
 
     provider = {
       callback: jest.fn(),

--- a/test/unit/init/setup/SetupHttpHandler.test.ts
+++ b/test/unit/init/setup/SetupHttpHandler.test.ts
@@ -43,6 +43,7 @@ describe('A SetupHttpHandler', (): void => {
       method: 'GET',
       target: { path: 'http://test.com/setup' },
       preferences: { type: { 'text/html': 1 }},
+      body: new BasicRepresentation(),
     };
 
     errorHandler = { handleSafe: jest.fn(({ error }: ErrorHandlerArgs): ResponseDescription => ({

--- a/test/unit/server/AuthorizingHttpHandler.test.ts
+++ b/test/unit/server/AuthorizingHttpHandler.test.ts
@@ -5,6 +5,7 @@ import type { PermissionReader } from '../../../src/authorization/PermissionRead
 import type { ModesExtractor } from '../../../src/authorization/permissions/ModesExtractor';
 import { AccessMode } from '../../../src/authorization/permissions/Permissions';
 import type { Operation } from '../../../src/http/Operation';
+import { BasicRepresentation } from '../../../src/http/representation/BasicRepresentation';
 import { AuthorizingHttpHandler } from '../../../src/server/AuthorizingHttpHandler';
 import type { HttpRequest } from '../../../src/server/HttpRequest';
 import type { HttpResponse } from '../../../src/server/HttpResponse';
@@ -30,6 +31,7 @@ describe('An AuthorizingHttpHandler', (): void => {
       target: { path: 'http://test.com/foo' },
       method: 'GET',
       preferences: {},
+      body: new BasicRepresentation(),
     };
 
     credentialsExtractor = {

--- a/test/unit/server/ParsingHttpHandler.test.ts
+++ b/test/unit/server/ParsingHttpHandler.test.ts
@@ -5,6 +5,7 @@ import type { ErrorHandler } from '../../../src/http/output/error/ErrorHandler';
 import { OkResponseDescription } from '../../../src/http/output/response/OkResponseDescription';
 import { ResponseDescription } from '../../../src/http/output/response/ResponseDescription';
 import type { ResponseWriter } from '../../../src/http/output/ResponseWriter';
+import { BasicRepresentation } from '../../../src/http/representation/BasicRepresentation';
 import { RepresentationMetadata } from '../../../src/http/representation/RepresentationMetadata';
 import type { HttpRequest } from '../../../src/server/HttpRequest';
 import type { HttpResponse } from '../../../src/server/HttpResponse';
@@ -15,7 +16,8 @@ describe('A ParsingHttpHandler', (): void => {
   const request: HttpRequest = {} as any;
   const response: HttpResponse = {} as any;
   const preferences = { type: { 'text/html': 1 }};
-  const operation: Operation = { method: 'GET', target: { path: 'http://test.com/foo' }, preferences };
+  const body = new BasicRepresentation();
+  const operation: Operation = { method: 'GET', target: { path: 'http://test.com/foo' }, preferences, body };
   const errorResponse = new ResponseDescription(400);
   let requestParser: jest.Mocked<RequestParser>;
   let metadataCollector: jest.Mocked<OperationMetadataCollector>;

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -164,6 +164,7 @@ describe('A DataAccessorBasedStore', (): void => {
       metadata: new RepresentationMetadata(
         { [CONTENT_TYPE]: 'text/plain', [RDF.type]: DataFactory.namedNode(LDP.Resource) },
       ),
+      isEmpty: false,
     };
   });
 

--- a/test/unit/storage/accessors/SparqlDataAccessor.test.ts
+++ b/test/unit/storage/accessors/SparqlDataAccessor.test.ts
@@ -4,6 +4,7 @@ import arrayifyStream from 'arrayify-stream';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { DataFactory } from 'n3';
 import type { Quad } from 'rdf-js';
+import { BasicRepresentation } from '../../../../src/http/representation/BasicRepresentation';
 import { RepresentationMetadata } from '../../../../src/http/representation/RepresentationMetadata';
 import { SparqlDataAccessor } from '../../../../src/storage/accessors/SparqlDataAccessor';
 import { INTERNAL_QUADS } from '../../../../src/util/ContentTypes';
@@ -69,11 +70,13 @@ describe('A SparqlDataAccessor', (): void => {
   });
 
   it('can only handle quad data.', async(): Promise<void> => {
-    await expect(accessor.canHandle({ binary: true, data, metadata })).rejects.toThrow(UnsupportedMediaTypeHttpError);
-    metadata.contentType = 'newInternalType';
-    await expect(accessor.canHandle({ binary: false, data, metadata })).rejects.toThrow(UnsupportedMediaTypeHttpError);
+    let representation = new BasicRepresentation(data, metadata, true);
+    await expect(accessor.canHandle(representation)).rejects.toThrow(UnsupportedMediaTypeHttpError);
+    representation = new BasicRepresentation(data, 'newInternalType', false);
+    await expect(accessor.canHandle(representation)).rejects.toThrow(UnsupportedMediaTypeHttpError);
+    representation = new BasicRepresentation(data, INTERNAL_QUADS, false);
     metadata.contentType = INTERNAL_QUADS;
-    await expect(accessor.canHandle({ binary: false, data, metadata })).resolves.toBeUndefined();
+    await expect(accessor.canHandle(representation)).resolves.toBeUndefined();
   });
 
   it('returns the corresponding quads when data is requested.', async(): Promise<void> => {

--- a/test/unit/storage/patch/SparqlUpdatePatcher.test.ts
+++ b/test/unit/storage/patch/SparqlUpdatePatcher.test.ts
@@ -19,6 +19,7 @@ function getPatch(query: string): SparqlUpdatePatch {
     data: guardedStreamFrom(prefixedQuery),
     metadata: new RepresentationMetadata(),
     binary: true,
+    isEmpty: false,
   };
 }
 

--- a/test/unit/storage/routing/ConvertingRouterRule.test.ts
+++ b/test/unit/storage/routing/ConvertingRouterRule.test.ts
@@ -26,7 +26,7 @@ describe('A ConvertingRouterRule', (): void => {
     rule = new ConvertingRouterRule({ store: store1, supportChecker: checker1 }, defaultStore);
 
     metadata = new RepresentationMetadata();
-    representation = { binary: true, data: 'data!' as any, metadata };
+    representation = { binary: true, data: 'data!' as any, metadata, isEmpty: false };
   });
 
   it('returns the corresponding store if it supports the input.', async(): Promise<void> => {


### PR DESCRIPTION
Closes #982 and indirectly closes #969 (since we now accept empty/missing bodies).

`Operation.body` is no longer optional. `Representation` has a new `isEmpty` parameter, which in practice is a shortcut for checking if there is a content-type.

I looked into having the `data` field of a Representation be optional, but the problem is that classes then no longer can be sure they get a data stream from functions that return a Representation. It would also potentially cause confusion between an empty data stream and an undefined one.