### PR TITLE
fix: Return 409 when there is a slash semantics issue

### DIFF
--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -193,7 +193,7 @@ export class DataAccessorBasedStore implements ResourceStore {
     // requests for the latter URI with a 301 redirect to the former."
     // https://solid.github.io/specification/protocol#uri-slash-semantics
     if (oldMetadata && oldMetadata.identifier.value !== identifier.path) {
-      throw new ForbiddenHttpError(`${identifier.path} conflicts with existing path ${oldMetadata.identifier.value}`);
+      throw new ConflictHttpError(`${identifier.path} conflicts with existing path ${oldMetadata.identifier.value}`);
     }
 
     const isContainer = this.isNewContainer(representation.metadata, identifier.path);

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -358,7 +358,7 @@ describe('A DataAccessorBasedStore', (): void => {
       representation.metadata.identifier = DataFactory.namedNode(`${resourceID.path}/`);
       const prom = store.setRepresentation(resourceID, representation);
       await expect(prom).rejects.toThrow(`${resourceID.path} conflicts with existing path ${resourceID.path}/`);
-      await expect(prom).rejects.toThrow(ForbiddenHttpError);
+      await expect(prom).rejects.toThrow(ConflictHttpError);
     });
 
     it('throws a 412 if the conditions are not matched.', async(): Promise<void> => {


### PR DESCRIPTION
After this the 2.0.0 branch will completely pass the conformance test harness (tested [here](https://github.com/solid/community-server/runs/3902969058)).

But (and this is an important but), this is actually a revert of a revert. Originally we returned 409 in this case, but at some point it was mentioned that this should be a 403: https://github.com/solid/community-server/pull/475#issuecomment-756066384
Which resulted in a discussion and eventually a spec issue that is still open: https://github.com/solid/specification/issues/219

So perhaps it's the test harness that has to change. But seeing as this will probably not be decided in a day and I do want our server to pass the test harness until this is decided, it's probably easiest to just return 409 for now.