### PR TITLE
fix: Add webid claim to webid scope

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## v3.0.0
 ### New features
-...
+- The Identity Provider now uses the `webid` scope as required for Solid-OIDC.
 
 ### Configuration changes
 You might need to make changes to your v2 configuration if you use a custom config.
@@ -13,6 +13,8 @@ The following changes pertain to the imports in the default configs:
 The following changes are relevant for v2 custom configs that replaced certain features.
 - Conversion has been simplified so most converters are part of the conversion chain:
   - `/util/representation-conversion/default.json`
+- The IDP settings have changed to support the latest Solid-OIDC draft.
+  - `/identity/handler/provider-factory/identity.json`
 
 ### Interface changes
 These changes are relevant if you wrote custom modules for the server that depend on existing interfaces.

--- a/config/identity/handler/provider-factory/identity.json
+++ b/config/identity/handler/provider-factory/identity.json
@@ -3,9 +3,9 @@
   "@graph": [
     {
       "comment": [
-        "Sets all the relevant oidc parameters.",
-        "webid claim is in openid scope until an official scope has been decided: https://github.com/solid/authentication-panel/issues/86"
-        ],
+        "Sets all the relevant Solid-OIDC parameters.",
+        "dPoP is draft-01 since that is the latest version v6 of the OIDC library supports."
+      ],
       "@id": "urn:solid-server:default:IdentityProviderFactory",
       "@type": "IdentityProviderFactory",
       "args_adapterFactory": { "@id": "urn:solid-server:default:IdpAdapterFactory" },
@@ -16,14 +16,12 @@
       "args_responseWriter": { "@id": "urn:solid-server:default:ResponseWriter" },
       "config": {
         "claims": {
-          "openid": [ "webid", "client_id" ]
+          "openid": [ "client_id" ],
+          "webid": [ "webid" ]
         },
         "cookies": {
           "long": { "signed": true, "maxAge": 86400000 },
           "short": { "signed": true }
-        },
-        "discovery": {
-          "solid_oidc_supported": "https://solidproject.org/TR/solid-oidc"
         },
         "features": {
           "claimsParameter": { "enabled": true },
@@ -36,8 +34,8 @@
         "formats": {
           "AccessToken": "jwt"
         },
-        "scopes": [ "openid", "profile", "offline_access" ],
-        "subjectTypes": [ "public", "pairwise" ],
+        "scopes": [ "openid", "profile", "offline_access", "webid" ],
+        "subjectTypes": [ "public" ],
         "ttl": {
           "AccessToken": 3600,
           "AuthorizationCode": 600,

--- a/test/integration/Identity.test.ts
+++ b/test/integration/Identity.test.ts
@@ -373,8 +373,8 @@ describe('A Solid server with IDP', (): void => {
       const jsonBody = await res.json();
 
       expect(res.status).toBe(200);
-      // https://solid.github.io/authentication-panel/solid-oidc/#discovery
-      expect(jsonBody.solid_oidc_supported).toEqual('https://solidproject.org/TR/solid-oidc');
+      // https://solid.github.io/solid-oidc/#discovery
+      expect(jsonBody.scopes_supported).toContain('webid');
     });
 
     it('should return correct error output.', async(): Promise<void> => {


### PR DESCRIPTION
Closes #1038.

I don't think this breaks anything for older versions but there might be a case I'm not aware of.