### PR TITLE
patch: fix broken link to developer-notes.md from docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ the [📐 architectural diagram](https://rubenverborgh.github.io/solid-server-a
 can help you find your way.
 
 If you want to help out with server development,
-have a look at the [📓 developer notes](guides/developer-notes.md) and
+have a look at the [📓 developer notes](https://github.com/solid/community-server/blob/main/guides/developer-notes.md) and
 [🛠️ good first issues](https://github.com/solid/community-server/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 


### PR DESCRIPTION
#### 📁 Related issues

https://github.com/solid/community-server/issues/1098

#### ✍️ Description

Fixes a broken link to developer notes on this page: https://solid.github.io/community-server/docs/#%F0%9F%91%A9%F0%9F%8F%BD%F0%9F%92%BB-developing-server-code

Uses a full URL so that this link works from the hosted docs. 
