### PR TITLE
Build and push official docker image following github tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,8 @@ jobs:
       - test-unit
       - test-integration
       - validate-components
-    # Only run on tags for now
-    if: ${{ github.ref_type == 'tag' }}
+    # Only run on tags starting with v prefix for now
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,8 @@ jobs:
       - test-unit
       - test-integration
       - validate-components
+    # Only run on tags for now
+    if: ${{ github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
       - test-unit
       - test-integration
       - validate-components
-    # Only run on tags starting with v prefix for now
+    # Only run on tags starting with v prefix for now -- extra push need for triggering CI again
     # if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,11 @@ jobs:
           parallel-finished: true
 
   docker:
+    needs:
+      - lint
+      - test-unit
+      - test-integration
+      - validate-components
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -148,10 +153,8 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          # list of Docker images to use as base name for tags
           images: |
-            name/app
-          # generate Docker tags based on the following events/attributes
+            solidproject/community-server
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,40 @@ jobs:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true
 
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            name/app
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+          github-token: ${{ secrets.github_token }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+        
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
       - lint
       - test-unit
       - test-integration
+      - test-integration-windows
       - validate-components
     # Only run on tags starting with v prefix for now -- extra push need for triggering CI again
     # if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       - test-integration
       - validate-components
     # Only run on tags starting with v prefix for now
-    if: startsWith(github.ref, 'refs/tags/v')
+    # if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -158,6 +158,10 @@ jobs:
           images: |
             solidproject/community-server
           tags: |
+            type=raw,value=2.0.1
+            type=raw,value=2.0
+            type=raw,value=2
+            type=raw,value=latest
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
#### 📁 Related issues

* #1111 
* #1053 
* #728 

#### ✍️ Description

This PR adds a docker job to the ci.yml workflow. 

It should only trigger if the following jobs have been executed:
```yaml
needs:
      # docs (edited: docs should not be here)
      - lint
      - test-unit
      - test-integration
      - validate-components
```
and if the `ref_type` is `'tag'`. 

For now, this should enable building and pushing of tagged versions following semver style.

**Example:**

Github tag: `v1.2.3`  
Docker tags:
 * 1
 * 1.2
 * 1.2.3
 * latest (overwrites previous latest tag)

_The necessary secrets should have been added by @RubenVerborgh._

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [ ] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.

<!-- Try to check these to the best of your abilities before opening the PR -->
