### PR TITLE
Build and push official docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,50 @@ jobs:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true
 
+  docker:
+    needs:
+      - lint
+      - test-unit
+      - test-integration
+      - test-integration-windows
+      - validate-components
+    # Only run on tags starting with v prefix for now -- extra push need for triggering CI again
+    # if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            solidproject/community-server
+          tags: |
+            type=raw,value=2.0.1
+            type=raw,value=2.0
+            type=raw,value=2
+            type=raw,value=latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+          github-token: ${{ secrets.github_token }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+        
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
       - test-integration-windows
       - validate-components
     # Only run on tags starting with v prefix for now -- extra push need for triggering CI again
-    # if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -159,10 +159,6 @@ jobs:
           images: |
             solidproject/community-server
           tags: |
-            type=raw,value=2.0.1
-            type=raw,value=2.0
-            type=raw,value=2
-            type=raw,value=latest
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+<a name="v2.0.2"></a>
+## [v2.0.2](https://github.com/solid/community-server/compare/v2.0.1...v2.0.2) - 2022-01-20
+
+### Added
+* [feat: Offical Docker image build](https://github.com/solid/community-server/commit/48bb9c2cca43e683d66f6a3eff921b59787bfb9d)
+
 <a name="v2.0.1"></a>
 ## [v2.0.1](https://github.com/solid/community-server/compare/v2.0.0...v2.0.1) - 2021-11-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-<a name="v2.0.2"></a>
-## [v2.0.2](https://github.com/solid/community-server/compare/v2.0.1...v2.0.2) - 2022-01-20
-
-### Added
-* [feat: Offical Docker image build](https://github.com/solid/community-server/commit/48bb9c2cca43e683d66f6a3eff921b59787bfb9d)
-
 <a name="v2.0.1"></a>
 ## [v2.0.1](https://github.com/solid/community-server/compare/v2.0.0...v2.0.1) - 2021-11-02
 

--- a/README.md
+++ b/README.md
@@ -69,20 +69,19 @@ npm start -- # add parameters if needed
 ```
 
 ### 📦 Running via Docker
-Docker allows you to run the server without having Node.js installed:
+Docker allows you to run the server without having Node.js installed. Images are built on each tagged version and hosted on [Docker Hub](https://hub.docker.com/r/solidproject/community-server). 
+
 ```shell
+# Clone the repo to get access to the configs
 git clone https://github.com/solid/community-server.git
 cd community-server
-# Build the Docker image
-docker build --rm -f Dockerfile -t css:latest .
 # Run the image, serving your `~/Solid` directory on `http://localhost:3000`
-docker run --rm -v ~/Solid:/data -p 3000:3000 -it css:latest
+docker run --rm -v ~/Solid:/data -p 3000:3000 -it solidproject/community-server:latest
 # Or use one of the built-in configurations
-docker run --rm -p 3000:3000 -it css:latest -c config/default.json
+docker run --rm -p 3000:3000 -it solidproject/community-server -c config/default.json
 # Or use your own configuration mapped to the right directory
-docker run --rm -v ~/solid-config:/config -p 3000:3000 -it css:latest -c /config/my-config.json
+docker run --rm -v ~/solid-config:/config -p 3000:3000 -it solidproject/community-server -c /config/my-config.json
 ```
-
 
 ## 🔧 Configuring the server
 The Community Solid Server is designed to be flexible


### PR DESCRIPTION
#### 📁 Related issues

* #1111 
* #1053 
* #728 

#### ✍️ Description

This PR adds a docker job to the ci.yml workflow. 

It should only trigger if the following jobs have been executed:
```yaml
needs:
      - lint
      - test-unit
      - test-integration
      - test-integration-windows
      - validate-components
```
and if the `ref` starts with `refs/tags/v`. 

For now, this should enable building and pushing of tagged versions following semver style.

**Example:**

Github tag: `v1.2.3`  
Docker tags:
 * 1
 * 1.2
 * 1.2.3
 * latest (overwrites previous latest tag)

_The necessary secrets should have been added by @RubenVerborgh._

**This temporarily adds some manual versions to immediatly build and push the current image**

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [ ] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.

<!-- Try to check these to the best of your abilities before opening the PR -->
