### PR TITLE
feat: Generate `:next` and `:edge` docker tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,15 +139,15 @@ jobs:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true
 
-  docker:
+  docker-main-branch:
     needs:
       - lint
       - test-unit
       - test-integration
       - test-integration-windows
       - validate-components
-    # Only run on tags starting with v prefix for now -- extra push need for triggering CI again
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Only run on tag push events starting with v prefix for now OR main branch push events
+    if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -158,10 +158,53 @@ jobs:
         with:
           images: |
             solidproject/community-server
+          # edge will always be executed (without latest tag), semver only on tag push events (with latest tag)
           tags: |
+            type=edge
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+          github-token: ${{ secrets.github_token }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  docker-versions-branch:
+    needs:
+      - lint
+      - test-unit
+      - test-integration
+      - test-integration-windows
+      - validate-components
+    # Only run on push events on a versions/* branch (ASSUMPTION: THERE SHOULD ONLY BE ONE THERE!)
+    if: startsWith(github.ref, 'refs/heads/versions/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with: 
+          ref: ${{ github.ref }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            solidproject/community-server
+          # Just one label: next (no latest here) for the last pushed commit on this branch
+          tags: |
+            type=raw,value=next
           github-token: ${{ secrets.github_token }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
#### 📁 Related issues

<!-- 
Reference any relevant issues here. Closing keywords only have an effect when targeting the main branch. If there are no related issues, you must first create an issue through https://github.com/solid/community-server/issues/new/choose
-->
#1140 

#### ✍️ Description

<!-- Describe the relevant changes in this PR. Also add notes that might be relevant for code reviewers. -->
This PR will add 2 new docker tags to the [official docker image](https://hub.docker.com/r/solidproject/community-server/tags) by updating the CI.

---

**branch:** `main`  
**docker tag:** `:edge`

This tag would be generated on each commit push on the `main` branch. The idea is that you can have a docker image of the latest developments. I suggest `:edge` in favor of the earlier proposed `:dev` tagname, because it better self-explains what it is. It is on the edge of the main repository. If you need that for development, you'll pick it.  
If we were to use the `:dev` tag, you first have to at least find out what that really means.

---

**branch:** `versions/*`  
**docker tag:** `:next`

This tag would be generated on each commit push on the `versions/*` branch. There should only be one version there that is being prepared. This tag will guarantee an image with the latest upcoming version features.

---


### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [ ] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.

<!-- Try to check these to the best of your abilities before opening the PR -->
