### PR TITLE
Split AccountStorage and ForgotPasswordStorage (expiring now)

### DIFF
--- a/config/identity/handler/account-store/default.json
+++ b/config/identity/handler/account-store/default.json
@@ -8,7 +8,21 @@
       "saltRounds": 10,
       "storage": {
         "@id": "urn:solid-server:default:AccountStorage"
+      },
+      "forgotPasswordStorage": {
+        "@id": "urn:solid-server:default:ExpiringForgotPasswordStorage"
       }
+    },
+    {
+      "comment": "Stores expiring data. This class has a `finalize` function that needs to be called after stopping the server.",
+      "@id": "urn:solid-server:default:ExpiringForgotPasswordStorage",
+      "@type": "WrappedExpiringStorage",
+      "source": { "@id": "urn:solid-server:default:ForgotPasswordStorage" }
+    },
+    {
+      "comment": "Makes sure the expiring storage cleanup timer is stopped when the application needs to stop.",
+      "@id": "urn:solid-server:default:Finalizer",
+      "ParallelFinalizer:_finalizers": [ { "@id": "urn:solid-server:default:ExpiringForgotPasswordStorage" } ]
     }
   ]
 }

--- a/config/storage/key-value/memory.json
+++ b/config/storage/key-value/memory.json
@@ -33,6 +33,11 @@
       "comment": "Storage used by setup components.",
       "@id": "urn:solid-server:default:SetupStorage",
       "@type": "MemoryMapStorage"
+    },
+    {
+      "comment": "Storage used for ForgotPassword records",
+      "@id": "urn:solid-server:default:ForgotPasswordStorage",
+      "@type":"MemoryMapStorage"
     }
   ]
 }

--- a/config/storage/key-value/resource-store.json
+++ b/config/storage/key-value/resource-store.json
@@ -48,6 +48,14 @@
       "container": "/.internal/accounts/"
     },
     {
+      "comment": "Storage used for ForgotPassword records",
+      "@id": "urn:solid-server:default:ForgotPasswordStorage",
+      "@type":"JsonResourceStorage",
+      "source": { "@id": "urn:solid-server:default:ResourceStore" },
+      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
+      "container": "/.internal/forgot-password/"
+    },
+    {
       "comment": "Storage used by setup components.",
       "@id": "urn:solid-server:default:SetupStorage",
       "@type": "JsonResourceStorage",

--- a/test/unit/identity/interaction/email-password/storage/BaseAccountStore.test.ts
+++ b/test/unit/identity/interaction/email-password/storage/BaseAccountStore.test.ts
@@ -3,10 +3,12 @@ import type {
   EmailPasswordData,
 } from '../../../../../../src/identity/interaction/email-password/storage/BaseAccountStore';
 import { BaseAccountStore } from '../../../../../../src/identity/interaction/email-password/storage/BaseAccountStore';
+import type { ExpiringStorage } from '../../../../../../src/storage/keyvalue/ExpiringStorage';
 import type { KeyValueStorage } from '../../../../../../src/storage/keyvalue/KeyValueStorage';
 
 describe('A BaseAccountStore', (): void => {
   let storage: KeyValueStorage<string, EmailPasswordData>;
+  let forgotPasswordStorage: ExpiringStorage<string, EmailPasswordData>;
   const saltRounds = 11;
   let store: BaseAccountStore;
   const email = 'test@test.com';
@@ -22,7 +24,13 @@ describe('A BaseAccountStore', (): void => {
       delete: jest.fn((id: string): any => map.delete(id)),
     } as any;
 
-    store = new BaseAccountStore(storage, saltRounds);
+    forgotPasswordStorage = {
+      get: jest.fn((id: string): any => map.get(id)),
+      set: jest.fn((id: string, value: any): any => map.set(id, value)),
+      delete: jest.fn((id: string): any => map.delete(id)),
+    } as any;
+
+    store = new BaseAccountStore(storage, forgotPasswordStorage, saltRounds);
   });
 
   it('can create accounts.', async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

<!-- 
Reference any relevant issues here. Closing keywords only have an effect when targeting the main branch. If there are no related issues, you must first create an issue through https://github.com/solid/community-server/issues/new/choose
-->

#744 

#### ✍️ Description

<!-- Describe the relevant changes in this PR. Also add notes that might be relevant for code reviewers. -->

This PR will split the AccountStorage being used, into an AccountStorage (which still has the KeyValueStorage type) and a new ForgotPasswordStorage (of type ExpiringStorage).

The purpose of this change is to allow for ForgotPassword entries to be purged from the storage (be it in-memory or file based) when users don't click the link sent in the email. A default expiration of 15 minutes is added.



### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [x] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.

<!-- Try to check these to the best of your abilities before opening the PR -->
