### PR TITLE
fix: Return correct allow headers for description resources

### DIFF
--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -140,25 +140,22 @@ export class DataAccessorBasedStore implements ResourceStore {
           }
         }
         data = metadata.quads();
-
-        if (isMetadata) {
-          metadata = new RepresentationMetadata(this.metadataStrategy.getAuxiliaryIdentifier(identifier));
-        }
       }
+
+      if (isMetadata) {
+        metadata = new RepresentationMetadata(this.metadataStrategy.getAuxiliaryIdentifier(identifier));
+        addResourceMetadata(metadata, false);
+        metadata.add(RDF.terms.type, SOLID_META.terms.DescriptionResource);
+      }
+
       metadata.addQuad(DC.terms.namespace, PREFERRED_PREFIX_TERM, 'dc', SOLID_META.terms.ResponseMetadata);
       metadata.addQuad(LDP.terms.namespace, PREFERRED_PREFIX_TERM, 'ldp', SOLID_META.terms.ResponseMetadata);
       metadata.addQuad(POSIX.terms.namespace, PREFERRED_PREFIX_TERM, 'posix', SOLID_META.terms.ResponseMetadata);
       metadata.addQuad(XSD.terms.namespace, PREFERRED_PREFIX_TERM, 'xsd', SOLID_META.terms.ResponseMetadata);
     }
 
-    if (isContainer) {
+    if (isContainer || isMetadata) {
       representation = new BasicRepresentation(data, metadata, INTERNAL_QUADS);
-    } else if (isMetadata) {
-      representation = new BasicRepresentation(
-        metadata.quads(),
-        this.metadataStrategy.getAuxiliaryIdentifier(identifier),
-        INTERNAL_QUADS,
-      );
     } else {
       representation = new BasicRepresentation(await this.accessor.getData(identifier), metadata);
     }

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -313,6 +313,8 @@ export const SOLID_META = createVocabulary(
   'urn:npm:solid:community-server:meta:',
   // This identifier is used as graph for all metadata that is generated on the fly and should not be stored
   'ResponseMetadata',
+  // Used to identify description resources, which are a specific kind of resource
+  'DescriptionResource',
   // This is used to identify templates that can be used for the representation of a resource
   'template',
   // This is used to store Content-Type Parameters

--- a/test/integration/LdpHandlerWithoutAuth.test.ts
+++ b/test/integration/LdpHandlerWithoutAuth.test.ts
@@ -2,7 +2,7 @@ import { createReadStream } from 'node:fs';
 import fetch from 'cross-fetch';
 import type { Quad } from 'n3';
 import { DataFactory, Parser, Store } from 'n3';
-import { joinFilePath, joinUrl, PIM, RDF } from '../../src/';
+import { joinFilePath, joinUrl, PIM, RDF, splitCommaSeparated } from '../../src/';
 import type { App } from '../../src/';
 import { LDP } from '../../src/util/Vocabularies';
 import {
@@ -699,6 +699,9 @@ describe.each(stores)('An LDP handler allowing all requests %s', (name, { storeC
   it('can read metadata.', async(): Promise<void> => {
     const response = await fetch(baseUrl + metaSuffix);
     expect(response.status).toBe(200);
+    const allows = splitCommaSeparated(response.headers.get('allow') ?? '');
+    expect(allows.sort()).toEqual([ 'GET', 'HEAD', 'OPTIONS', 'PATCH' ]);
+    expect(response.headers.get('accept-patch')).toBe('text/n3, application/sparql-update');
     await expectQuads(response, [ quad(namedNode(baseUrl), namedNode(RDF.type), namedNode(PIM.Storage)) ]);
   });
 

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -196,6 +196,10 @@ describe('A DataAccessorBasedStore', (): void => {
         quad(namedNode(resourceID.path), CONTENT_TYPE_TERM, literal('text/plain')),
       );
       expect(result.metadata.contentType).toBe(INTERNAL_QUADS);
+      expect(result.metadata.getAll(RDF.terms.type)).toEqualRdfTermArray([
+        LDP.terms.Resource,
+        SOLID_META.terms.DescriptionResource,
+      ]);
     });
 
     it('will return the generated representation for container metadata resources.', async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/2096

#### ✍️ Description

Adds an extra type to description resource metadata so they can be identified by other components.

Some context: The class that handles these headers, the [AllowAcceptHeaderWriter](https://github.com/CommunitySolidServer/CommunitySolidServer/blob/v7.1.7/src/http/output/metadata/AllowAcceptHeaderWriter.ts), has to determine which headers are returned based on the metadata of the resource being returned, this due to its location in the architecture. By adding this new type it can correctly deduce the headers for description resources.
