### PR TITLE
fix: handle ENOTDIR in FileDataAccessor.getStats to prevent 500 on duplicate slug POST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.acl
+/.data
 /.eslintcache
 /componentsjs-error-state.json
 /coverage

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,5 +2,5 @@ import opinionated from 'opinionated-eslint-config';
 
 export default opinionated().append({
   // Don't want to lint test assets
-  ignores: [ 'test/assets/*', 'componentsjs-error-state.json' ],
+  ignores: [ 'test/assets/*', 'componentsjs-error-state.json', '.data/**' ],
 });

--- a/src/storage/accessors/FileDataAccessor.ts
+++ b/src/storage/accessors/FileDataAccessor.ts
@@ -148,7 +148,7 @@ export class FileDataAccessor implements DataAccessor {
     try {
       return await stat(path);
     } catch (error: unknown) {
-      if (isSystemError(error) && error.code === 'ENOENT') {
+      if (isSystemError(error) && (error.code === 'ENOENT' || error.code === 'ENOTDIR')) {
         throw new NotFoundHttpError('', { cause: error });
       }
       throw error;

--- a/test/integration/FileBackend.test.ts
+++ b/test/integration/FileBackend.test.ts
@@ -150,6 +150,34 @@ describe('A server with a file backend storage', (): void => {
   );
 
   it(
+    'returns 201 (not 500) when POSTing with the same Slug twice to a file-backend container.',
+    async(): Promise<void> => {
+      const slug = 'duplicate-slug-test.json';
+      const postOptions = {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          slug,
+        },
+        body: '{}',
+      };
+
+      // First POST with the slug — should create the resource.
+      const res1 = await fetch(baseUrl, postOptions);
+      expect(res1.status).toBe(201);
+      const location1 = res1.headers.get('location');
+      expect(location1).toBe(`${baseUrl}${slug}`);
+
+      // Second POST with the same slug — must NOT return 500.
+      // The server should fall back to a UUID-based name instead.
+      const res2 = await fetch(baseUrl, postOptions);
+      expect(res2.status).toBe(201);
+      const location2 = res2.headers.get('location');
+      expect(location2).not.toBe(location1);
+    },
+  );
+
+  it(
     'supports content types for which no extension mapping can be found (and falls back to using .unknown).',
     async(): Promise<void> => {
       const url = `${baseUrl}test`;

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -99,6 +99,15 @@ describe('A FileDataAccessor', (): void => {
       await expect(accessor.getMetadata({ path: base })).rejects.toThrow('error');
     });
 
+    it('throws a 404 if stat returns ENOTDIR (container path over an existing file).', async(): Promise<void> => {
+      cache.data = { resource: 'data' };
+      const enotdir = Object.assign(new Error('ENOTDIR: not a directory, stat'), { code: 'ENOTDIR', syscall: 'stat' });
+      jest.requireMock('fs-extra').stat = (): never => {
+        throw enotdir;
+      };
+      await expect(accessor.getMetadata({ path: `${base}resource/` })).rejects.toThrow(NotFoundHttpError);
+    });
+
     it('throws a 404 if the trailing slash does not match its type.', async(): Promise<void> => {
       cache.data = { resource: 'data' };
       await expect(accessor.getMetadata({ path: `${base}resource/` })).rejects.toThrow(NotFoundHttpError);


### PR DESCRIPTION
#### 📁 Related issues

https://github.com/CommunitySolidServer/CommunitySolidServer/issues/2021

#### ✍️ Description

Patch fix (I don't have permissions to add the label)

Posting a file to a container twice with the same `Slug` header causes a `500 InternalServerError` on file-system-backed deployments (e.g. `solidcommunity.net`). The second POST succeeds on in-memory servers but crashes on disk-based ones.

**Root cause:** `DataAccessorBasedStore.createSafeUri` checks whether a resource already exists at the slug path by calling `hasResource` with both `test.json` and its container equivalent `test.json/`. On Linux/macOS, `stat('test.json/')` on a regular file returns the POSIX error `ENOTDIR` instead of `ENOENT`. `FileDataAccessor.getStats` only caught `ENOENT` and converted it to `NotFoundHttpError`; `ENOTDIR` escaped as a raw OS error, which `ParsingHttpHandler` then wrapped into a 500.

**Call trace (before fix):**

1. `POST /container/` with `Slug: test.json` (file already exists on disk)
2. `DataAccessorBasedStore.addResource` → `createSafeUri`
3. `createSafeUri` builds candidate path `test.json`, then checks `hasResource({ path: 'test.json/' })` first (the container-equivalent check)
4. `hasResource` calls `FileDataAccessor.getMetadata({ path: 'test.json/' })`
5. `getMetadata` maps the URL to a filesystem path `…/test.json/` and calls `getStats`
6. `getStats` calls `stat('…/test.json/')` — Linux sees the trailing slash, tries to treat `test.json` as a directory, and throws `ENOTDIR`
7. `getStats` only handles `ENOENT`; `ENOTDIR` is re-thrown as a raw OS error
8. `hasResource` only catches `NotFoundHttpError`; raw `ENOTDIR` propagates out — the `||` short-circuits and the second check (`test.json` without slash) is never reached
9. `ParsingHttpHandler.handleError` sees a non-`HttpError` and returns a 500

**Fix:** Also catch `ENOTDIR` in `getStats` and convert it to `NotFoundHttpError`. `ENOTDIR` on a trailing-slash path means "no container exists here" — semantically identical to not-found. With the fix:

- `hasResource({ path: 'test.json/' })` catches `NotFoundHttpError` → returns `false`
- `false ||` continues to `hasResource({ path: 'test.json' })` → file exists → returns `true`
- Condition is met → UUID fallback name is generated → `201`

**Result after fix:**
- First POST `Slug: test.json` → `201` at `.../test.json`
- Second POST same slug → `201` at `.../cb0ccbd8-f25a-...` (UUID fallback)

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.